### PR TITLE
Corrects spelling of "initailize" to "initialize"

### DIFF
--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -59,13 +59,13 @@ function! s:Init(sync)
   let func = a:sync ? 'CocInitSync' : 'CocInitAsync'
   if a:sync
     echohl MoreMsg
-    echom '[coc.nvim] Lazyload takes more time for initailize, consider disable lazyload'
+    echom '[coc.nvim] Lazyload takes more time for initialize, consider disable lazyload'
     echohl None
   endif
   try
     execute 'call '.func.'()'
   catch /^Vim\%((\a\+)\)\=:E117/
-    call coc#util#on_error('Initailize failed, try :UpdateRemotePlugins and restart')
+    call coc#util#on_error('Initialize failed, try :UpdateRemotePlugins and restart')
   endtry
 endfunction
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ const logger = require('./util/logger')('index')
 
 @Plugin({dev: false})
 export default class CompletePlugin {
-  private initailized = false
+  private initialized = false
   private emitter: EventEmitter
   private handler: Handler
 
@@ -50,13 +50,13 @@ export default class CompletePlugin {
       await nvim.command(`let g:coc_node_channel_id=${channelId}`)
       await nvim.command('silent doautocmd User CocNvimInit')
       services.init(nvim)
-      this.initailized = true
-      logger.info('Coc service Initailized')
+      this.initialized = true
+      logger.info('Coc service Initialized')
       let filetype = await nvim.eval('&filetype') as string
       services.start(filetype)
     } catch (err) {
       logger.error(err.stack)
-      return echoErr(nvim, `Initailize failed, ${err.message}`)
+      return echoErr(nvim, `Initialize failed, ${err.message}`)
     }
   }
 
@@ -139,7 +139,7 @@ export default class CompletePlugin {
 
   @Function('CocAction', {sync: true})
   public async cocAction (args: any): Promise<any> {
-    if (!this.initailized) return
+    if (!this.initialized) return
     let {handler} = this
     try {
       switch (args[0] as string) {

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -292,7 +292,7 @@ export default class Document {
 
   /**
    * Current word for replacement, used by completion
-   * For increment completion, the document is initailized document
+   * For increment completion, the document is initialized document
    *
    * @public
    * @param {Position} position

--- a/src/model/fileSystemWatcher.ts
+++ b/src/model/fileSystemWatcher.ts
@@ -33,7 +33,7 @@ export default class FileSystemWatcher implements Disposable {
         return this.listen(client)
       }
     }).catch(error => {
-      logger.error('watchman initailize failed')
+      logger.error('watchman initialize failed')
       logger.error(error.stack)
     })
   }


### PR DESCRIPTION
This PR simply corrects the spelling of `initailize` to `initialize`.