### PR TITLE
fix file path completion

### DIFF
--- a/src/source/file.ts
+++ b/src/source/file.ts
@@ -22,7 +22,7 @@ export default class File extends Source {
     if (opt.triggerCharacter == '/') {
       let synName = await this.nvim.call('coc#util#get_syntax_name', [linenr, colnr - 1]) as string
       synName = synName.toLowerCase()
-      if (['string', 'comment'].indexOf(synName) == -1) {
+      if (synName && ['string', 'comment'].indexOf(synName) == -1) {
         return false
       }
     }


### PR DESCRIPTION
What I want: when entered `/` file trigger, items will popup for completion.

This maybe a **quick-but-dirty** fix, I just found that if `synName` is empty, `shouldComplete` will return false to disable completion. So I just add this check fix.

BTW, what's the effects of `synName string|comment` check?