### PR TITLE
fix typescript.jsx languageModeId

### DIFF
--- a/src/extensions/tsserver/features/bufferSyncSupport.ts
+++ b/src/extensions/tsserver/features/bufferSyncSupport.ts
@@ -20,6 +20,8 @@ function mode2ScriptKind(
       return 'TS'
     case languageModeIds.typescripttsx:
       return 'TSX'
+    case languageModeIds.typescriptjsx:
+      return 'TSX'
     case languageModeIds.typescriptreact:
       return 'TSX'
     case languageModeIds.javascript:

--- a/src/extensions/tsserver/features/fileConfigurationManager.ts
+++ b/src/extensions/tsserver/features/fileConfigurationManager.ts
@@ -78,7 +78,8 @@ export default class FileConfigurationManager {
   }
 
   public isTypeScriptDocument(languageId: string): boolean {
-    return languageId === languageIds.typescript || languageId === languageIds.typescriptreact || languageId === languageIds.typescripttsx
+    return languageId === languageIds.typescript || languageId === languageIds.typescriptreact || 
+      languageId === languageIds.typescripttsx || languageId === languageIds.typescriptjsx
   }
 
   public enableJavascript(): boolean {

--- a/src/extensions/tsserver/utils/languageDescription.ts
+++ b/src/extensions/tsserver/utils/languageDescription.ts
@@ -18,7 +18,8 @@ export const standardLanguageDescriptions: LanguageDescription[] = [
     id: 'typescript',
     diagnosticSource: 'ts',
     diagnosticOwner: 'typescript',
-    modeIds: [languageModeIds.typescript, languageModeIds.typescriptreact, languageModeIds.typescripttsx],
+    modeIds: [languageModeIds.typescript, languageModeIds.typescriptreact, 
+      languageModeIds.typescripttsx, languageModeIds.typescriptjsx],
     configFile: 'tsconfig.json'
   },
   {

--- a/src/extensions/tsserver/utils/languageModeIds.ts
+++ b/src/extensions/tsserver/utils/languageModeIds.ts
@@ -6,6 +6,7 @@
 export const typescript = 'typescript'
 export const typescriptreact = 'typescriptreact'
 export const typescripttsx = 'typescript.tsx'
+export const typescriptjsx = 'typescript.jsx'
 export const javascript = 'javascript'
 export const javascriptreact = 'javascript.jsx'
 export const jsxTags = 'jsx-tags'


### PR DESCRIPTION
In [b3604](https://github.com/neoclide/coc.nvim/commit/b3604e00d133e29777591349d352ae22b2c0015c#diff-375d26229ede96ca813dae07d7bdcf8a) prior to adding the typescriptreact type, it referenced 'typescript.jsx' not 'typescript.tsx'. I'm unsure of whether you intended for this, but it broke functionality for me.

If you'd prefer me to go through and rename all the variables to typescriptjsx or even add a new variable all together in all the necessary areas, I can do that for you, just let me know.