### PR TITLE
Clear diagnostic info when restarting

### DIFF
--- a/autoload/coc/rpc.vim
+++ b/autoload/coc/rpc.vim
@@ -156,6 +156,7 @@ endfunction
 
 function! coc#rpc#restart()
   call coc#util#clear_signs()
+  call coc#util#clear_diagnostic_info()
   if has('nvim')
     let [code] = jobwait([s:channel_id], 100)
     " running

--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -440,14 +440,7 @@ function! coc#util#clear_diagnostic_info()
 endfunction
 
 function! coc#util#clear_signs()
-  let buflist = []
-  for i in range(tabpagenr('$'))
-    for n in tabpagebuflist(i + 1)
-      if index(buflist, n) == -1
-        call add(buflist, n)
-      endif
-    endfor
-  endfor
+  let buflist = filter(range(1, bufnr('$')), 'buflisted(v:val)')
   for b in buflist
     let signIds = []
     let lines = split(execute('sign place buffer='.b), "\n")

--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -435,6 +435,10 @@ function! coc#util#clear()
   silent! call clearmatches()
 endfunction
 
+function! coc#util#clear_diagnostic_info()
+  let b:coc_diagnostic_info = {}
+endfunction
+
 function! coc#util#clear_signs()
   let buflist = []
   for i in range(tabpagenr('$'))


### PR DESCRIPTION
After restarting, the diagnostic info is not cleared, so that airline (and maybe other status lines) still shows the original error and warning number. However, the errors and warnings may be gone because of the new configuration of the language server. In these cases, the error and warning number in the status line will not be cleared until new errors or warnings appear.