### PR TITLE
Fix too many args to rpc_installed

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -554,7 +554,7 @@ function! s:coc_installed(status, ...)
   endif
 endfunction
 
-function! s:rpc_installed(status)
+function! s:rpc_installed(status, ...)
   if a:status == 0
     redraw!
     echohl MoreMsg | echom 'vim-node-rpc installed, starting rpc server.' | echohl None


### PR DESCRIPTION
Was seeing this trying to use yarn to install vim-node-rpc.

```
TERMINAL  yarn global add vim-node-rpc                                                                                                                                                                                                                                                           ☰    1  /4 ㏑
Error detected while processing function <SNR>88_OnExit:
line    6:
E118: Too many arguments for function: <SNR>88_rpc_installed
```