### PR TITLE
Ensure call dictwatcheradd only in neovim

### DIFF
--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -186,7 +186,9 @@ endfunction
 
 function! s:OnInit()
   call s:Enable()
-  call dictwatcheradd(g:, 'coc_enabled', function('s:StatChange'))
+  if !s:is_vim
+    call dictwatcheradd(g:, 'coc_enabled', function('s:StatChange'))
+  endif
   let extensions = get(g:, 'coc_local_extensions', [])
   call coc#rpc#notify('registExtensions', extensions)
 endfunction


### PR DESCRIPTION
I use `CocNvimInit` in my config. When I'm using coc in vim, this error will definitely occur:

```vim
Error detected while processing function <SNR>75_OnInit:                                                                                                
line    3:                                                                                                                                              
E117: Unknown function: dictwatcheradd                                                                                                                  
Press ENTER or type command to continue                                                                                                                 
```

Additionally, since this function is neovim specific, it's more robust to add this check IMO. 