### PR TITLE
WIP: Diagnostics on CursorHold config option

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -405,6 +405,11 @@
       "description": "Use NeoVim virtual text to display diagnostics",
       "default": false
     },
+    "coc.preferences.diagnostic.onCursorHold": {
+      "type": "boolean",
+      "description": "Wait until the cursor stays in a place to draw diagnostics",
+      "default": false
+    },
     "coc.preferences.diagnostic.enableMessage": {
       "type": "boolean",
       "description": "Set to false to disable echo message on CursorMove",

--- a/src/__tests__/modules/diagnosticBuffer.test.ts
+++ b/src/__tests__/modules/diagnosticBuffer.test.ts
@@ -8,6 +8,7 @@ import { DiagnosticItems } from '../../types'
 let nvim: Neovim
 const config: DiagnosticConfig = {
   virtualText: false,
+  onCursorHold: false,
   displayByAle: false,
   srcId: 1000,
   level: DiagnosticSeverity.Hint,


### PR DESCRIPTION
This is a WIP solution to @kristijanhusak's https://github.com/neoclide/coc.nvim/issues/360#issuecomment-455845385. The problem is while in insert mode diagnostics are almost never updated.  I suspect this is because diagnostics are not yet ready.
A timer could be added, but how long should it wait? If were using a timer, why put it on the normal path?
Does anyone have a solution?