### PR TITLE
Allow configuration of virtual text diagnostic prefix

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -400,6 +400,11 @@
       "description": "Use NeoVim virtual text to display diagnostics",
       "default": false
     },
+    "coc.preferences.diagnostic.virtualTextPrefix": {
+      "type":"string",
+      "description": "The prefix added virtual text diagnostics",
+      "default": " "
+    },
     "coc.preferences.diagnostic.enableMessage": {
       "type": "boolean",
       "description": "Set to false to disable echo message on CursorMove",

--- a/src/__tests__/modules/diagnosticBuffer.test.ts
+++ b/src/__tests__/modules/diagnosticBuffer.test.ts
@@ -10,6 +10,7 @@ let nvim: Neovim
 const config: DiagnosticConfig = {
   virtualTextSrcId: 0,
   virtualText: false,
+  virtualTextPrefix: " ",
   displayByAle: false,
   srcId: 1000,
   level: DiagnosticSeverity.Hint,

--- a/src/diagnostic/buffer.ts
+++ b/src/diagnostic/buffer.ts
@@ -179,6 +179,7 @@ export class DiagnosticBuffer {
     let buffer = this.nvim.createBuffer(bufnr)
     let lines: Set<number> = new Set()
     let srcId = this.config.virtualTextSrcId
+    let prefix = this.config.virtualTextPrefix
     buffer.clearNamespace(srcId)
     for (let diagnostic of diagnostics) {
       let { line } = diagnostic.range.start
@@ -186,7 +187,7 @@ export class DiagnosticBuffer {
       lines.add(line)
       let highlight = getNameFromSeverity(diagnostic.severity) + 'Sign'
       let msg = diagnostic.message.split(/\n/)[0]
-      buffer.setVirtualText(srcId, line, [[' ' + msg, highlight]], {})
+      buffer.setVirtualText(srcId, line, [[prefix + msg, highlight]], {})
     }
   }
 

--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -23,6 +23,7 @@ export interface DiagnosticConfig {
   hintSign: string
   level: number
   virtualTextSrcId: number
+  virtualTextPrefix: string
 }
 
 export class DiagnosticManager {
@@ -366,6 +367,7 @@ export class DiagnosticManager {
     this.config = {
       virtualTextSrcId: await workspace.createNameSpace('diagnostic-virtualText'),
       virtualText: config.get<boolean>('virtualText', false),
+      virtualTextPrefix: config.get('virtualTextPrefix', " "),
       displayByAle: config.get<boolean>('displayByAle', false),
       srcId: config.get<number>('highlightOffset', 1000),
       level: severityLevel(config.get<string>('level', 'hint')),


### PR DESCRIPTION
solves #360

Adds: `"coc.preferences.diagnostic.virtualTextPrefix": " ",`