### PR TITLE
Change example goto type mapping to gt

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -209,7 +209,7 @@ nmap <silent> ]c <Plug>(coc-diagnostic-next)
 
 " Remap keys for gotos
 nmap <silent> gd <Plug>(coc-definition)
-nmap <silent> gy <Plug>(coc-type-definition)
+nmap <silent> gt <Plug>(coc-type-definition)
 nmap <silent> gi <Plug>(coc-implementation)
 nmap <silent> gr <Plug>(coc-references)
 


### PR DESCRIPTION
Currently the example `vimrc` maps goto type to `gy`, but `gt` seams like a more intuitive mapping.

Thoughts?