### PR TITLE
Fixed duplicate coc-list-sources tag

### DIFF
--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -33,9 +33,9 @@ List 						|coc-list|
     Commands 					 |coc-list-commands|
     Links 					 |coc-list-links|
     Output 					 |coc-list-output|
-    Sources 					 |coc-list-sources|
+    Sources 					 |coc-list-completion-sources|
     Lists 					 |coc-list-lists|
-Statueline support      			|coc-status|
+Statusline support      			|coc-status|
   Manual                			|coc-status-manual|
   Airline 					|coc-status-airline|
   Lightline  					|coc-stauts-lightline|
@@ -1302,7 +1302,7 @@ output 							 *coc-list-output*
 
 ------------------------------------------------------------------------------
 
-sources 						 *coc-list-sources*
+sources 						 *coc-list-completion-sources*
 
 	Available completion sources.
 


### PR DESCRIPTION
Renamed second coc-list-sources tag to coc-list-completion-sources

I am not sure about the naming, maybe **coc-list-completions** would be better.

This this fixes the: Vim(helptags):E154: Duplicate tag "coc-list-sources" in file /home/jpoppe/.cache/dein/.cache/init.vim/.dein/doc/coc.txt error.

Also fixed a typo.