### PR TITLE
Config option to display multiple lines of a diagnostic in a single virtual text line

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -412,7 +412,7 @@
     },
     "coc.preferences.diagnostic.virtualTextLines": {
       "type":"number",
-      "description": "The number of lines from a diagnostic to display",
+      "description": "The number of non empty lines from a diagnostic to display",
       "default": 1
     },
     "coc.preferences.diagnostic.virtualTextLineSeparator": {

--- a/data/schema.json
+++ b/data/schema.json
@@ -410,6 +410,16 @@
       "description": "The prefix added virtual text diagnostics",
       "default": " "
     },
+    "coc.preferences.diagnostic.virtualTextLines": {
+      "type":"number",
+      "description": "The number of lines from a diagnostic to display",
+      "default": 1
+    },
+    "coc.preferences.diagnostic.virtualTextLineSeparator": {
+      "type":"string",
+      "description": "The text that will mark a line end from the diagnostic message",
+      "default": " \\ "
+    },
     "coc.preferences.diagnostic.enableMessage": {
       "type": "string",
       "default": "always",

--- a/data/schema.json
+++ b/data/schema.json
@@ -413,7 +413,7 @@
     "coc.preferences.diagnostic.virtualTextLines": {
       "type":"number",
       "description": "The number of non empty lines from a diagnostic to display",
-      "default": 1
+      "default": 3
     },
     "coc.preferences.diagnostic.virtualTextLineSeparator": {
       "type":"string",

--- a/src/__tests__/modules/diagnosticBuffer.test.ts
+++ b/src/__tests__/modules/diagnosticBuffer.test.ts
@@ -12,7 +12,7 @@ const config: DiagnosticConfig = {
   virtualTextSrcId: 0,
   virtualText: false,
   virtualTextPrefix: " ",
-  virtualTextLines: 1,
+  virtualTextLines: 3,
   virtualTextLineSeparator: " \\ ",
   displayByAle: false,
   srcId: 1000,

--- a/src/__tests__/modules/diagnosticBuffer.test.ts
+++ b/src/__tests__/modules/diagnosticBuffer.test.ts
@@ -12,6 +12,8 @@ const config: DiagnosticConfig = {
   virtualTextSrcId: 0,
   virtualText: false,
   virtualTextPrefix: " ",
+  virtualTextLines: 1,
+  virtualTextLineSeparator: " \\ ",
   displayByAle: false,
   srcId: 1000,
   level: DiagnosticSeverity.Hint,

--- a/src/diagnostic/buffer.ts
+++ b/src/diagnostic/buffer.ts
@@ -188,11 +188,11 @@ export class DiagnosticBuffer {
       let highlight = getNameFromSeverity(diagnostic.severity) + 'Sign'
       let msgLines = diagnostic.message.split(/\n/)
       let msg = msgLines[0]
-      for (let i = 1; i < Math.min(this.config.virtualTextLines, msgLines.length); i++) {
-        if (msgLines[i] != '') {
-          msg += this.config.virtualTextLineSeparator + msgLines[i].trim()
-        }
-      }
+      msgLines
+        .map((l: string) => l.trim())
+        .filter((l: string) => l !== '')
+        .slice(1, this.config.virtualTextLines)
+        .forEach((l: string) => msg += this.config.virtualTextLineSeparator + l)
       buffer.setVirtualText(srcId, line, [[prefix + msg, highlight]], {})
     }
   }

--- a/src/diagnostic/buffer.ts
+++ b/src/diagnostic/buffer.ts
@@ -186,7 +186,13 @@ export class DiagnosticBuffer {
       if (lines.has(line)) continue
       lines.add(line)
       let highlight = getNameFromSeverity(diagnostic.severity) + 'Sign'
-      let msg = diagnostic.message.split(/\n/)[0]
+      let msgLines = diagnostic.message.split(/\n/)
+      let msg = msgLines[0]
+      for (let i = 1; i < Math.min(this.config.virtualTextLines, msgLines.length); i++) {
+        if (msgLines[i] != '') {
+          msg += this.config.virtualTextLineSeparator + msgLines[i].trim()
+        }
+      }
       buffer.setVirtualText(srcId, line, [[prefix + msg, highlight]], {})
     }
   }

--- a/src/diagnostic/buffer.ts
+++ b/src/diagnostic/buffer.ts
@@ -186,13 +186,12 @@ export class DiagnosticBuffer {
       if (lines.has(line)) continue
       lines.add(line)
       let highlight = getNameFromSeverity(diagnostic.severity) + 'Sign'
-      let msgLines = diagnostic.message.split(/\n/)
-      let msg = msgLines[0]
-      msgLines
-        .map((l: string) => l.trim())
-        .filter((l: string) => l !== '')
-        .slice(1, this.config.virtualTextLines)
-        .forEach((l: string) => msg += this.config.virtualTextLineSeparator + l)
+      let msg =
+        diagnostic.message.split(/\n/)
+          .map((l: string) => l.trim())
+          .filter((l: string) => l.length > 0)
+          .slice(0, this.config.virtualTextLines)
+          .join(this.config.virtualTextLineSeparator)
       buffer.setVirtualText(srcId, line, [[prefix + msg, highlight]], {})
     }
   }

--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -372,7 +372,7 @@ export class DiagnosticManager {
       virtualText: config.get<boolean>('virtualText', false),
       virtualTextPrefix: config.get<string>('virtualTextPrefix', " "),
       virtualTextLineSeparator: config.get<string>('virtualTextLineSeparator', " \\ "),
-      virtualTextLines: config.get<number>('virtualTextLines', 1),
+      virtualTextLines: config.get<number>('virtualTextLines', 3),
       displayByAle: config.get<boolean>('displayByAle', false),
       srcId: config.get<number>('highlightOffset', 1000),
       level: severityLevel(config.get<string>('level', 'hint')),

--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -25,6 +25,8 @@ export interface DiagnosticConfig {
   refreshOnInsertMode: boolean
   virtualTextSrcId: number
   virtualTextPrefix: string
+  virtualTextLines: number
+  virtualTextLineSeparator: string
 }
 
 export class DiagnosticManager {
@@ -368,7 +370,9 @@ export class DiagnosticManager {
     this.config = {
       virtualTextSrcId: await workspace.createNameSpace('diagnostic-virtualText'),
       virtualText: config.get<boolean>('virtualText', false),
-      virtualTextPrefix: config.get('virtualTextPrefix', " "),
+      virtualTextPrefix: config.get<string>('virtualTextPrefix', " "),
+      virtualTextLineSeparator: config.get<string>('virtualTextLineSeparator', " \\ "),
+      virtualTextLines: config.get<number>('virtualTextLines', 1),
       displayByAle: config.get<boolean>('displayByAle', false),
       srcId: config.get<number>('highlightOffset', 1000),
       level: severityLevel(config.get<string>('level', 'hint')),


### PR DESCRIPTION
`coc.preferences.diagnostic.virtualTextLines`  allows the user to specify the number of non empty lines from each diagnostic message that should be shown in a single virtual text line.
`coc.preferences.diagnostic.virtualTextLineSeparator` allows the users to specify a custom `string` to go in between the conjoined lines.

This commit does not change any defaults, however I would advocate `virtualTextLines` defaulting to three instead of one. This would allow the standard `mismatched type\n {expected type}\n {found type}` diagnostics to be correctly displayed.