### PR TITLE
fix(diagnostics): echo max length

### DIFF
--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -534,10 +534,16 @@ export class Workspace implements IWorkspace {
       let last = lines[cmdHeight - 1]
       lines[cmdHeight - 1] = `${last} ...`
     }
-    let columns = await nvim.getOption('columns')
+
+    // If an echoed line exceeds `columns - 9` for vim or `columns - 12` for nvim
+    // The "Press ENTER or type command to continue" prompt will trigger.
+    // This may be a bug in vim/nvim
+    // These numbers were found empirically.
+    let maxLength = await nvim.getOption('columns').then((c: number) => c - (this.isVim ? 9 : 12))
+
     lines = lines.map(line => {
       line = line.replace(/\n/g, ' ')
-      if (truncate) line = line.slice(0, (columns as number) - 1)
+      if (truncate) line = line.slice(0, maxLength)
       return line
     })
     nvim.callTimer('coc#util#echo_lines', [lines], true)


### PR DESCRIPTION
On neovim the maximum length of an echo'd line seems to be `columns -
12` (where columns is the vim option), passed that length it will trigger the "Press ENTER or type a
command" prompt.

On vim this value seems to be `columns - 8`.

This fixes https://github.com/neoclide/coc.nvim/issues/435 .