### PR TITLE
fix(schema): add float as a valid value for hoverTarget

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -438,7 +438,7 @@
     "coc.preferences.hoverTarget": {
       "type": "string",
       "description": "Target to show hover information, default is floating window when possible.",
-      "enum": ["preview", "echo"]
+      "enum": ["preview", "echo", "float"]
     },
     "coc.preferences.colorSupport": {
       "type": "boolean",


### PR DESCRIPTION
A fix for an issue referenced in a [comment](https://github.com/neoclide/coc.nvim/issues/496#issuecomment-470785424) in #496.