### PR TITLE
add float highlight

### DIFF
--- a/doc/coc.cnx
+++ b/doc/coc.cnx
@@ -923,6 +923,30 @@ CocHintSign 					*CocHintSign*
 
   提醒标记符使用的高亮。
 
+CocErrorFloat 					*CocErrorFloat*
+
+  默认: `hi default link CocErrorFloat CocErrorSign`
+
+  错误浮窗符使用的高亮。
+
+CocWarningFloat 					*CocWarningFloat*
+
+  默认: `hi default link CocWarningFloat CocWarningSign`
+
+  警告浮窗符使用的高亮。
+
+CocInfoFloat 					*CocInfoFloat*
+
+  默认: `hi default link CocInfoFloat CocInfoSign`
+
+  信息浮窗符使用的高亮。
+
+CocHintFloat 					*CocHintFloat*
+
+  默认: `hi default link CocHintFloat CocHintSign`
+
+  提醒浮窗符使用的高亮。
+
 CocErrorHighlight 				*CocErrorHighlight*
 
   默认： `hi default link CocErrorHighlight   CocUnderline`

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -951,6 +951,30 @@ CocHintSign 					*CocHintSign*
 
   The highlight used for hint signs.
 
+CocErrorFloat 					*CocErrorFloat*
+
+  Default: `hi default link CocErrorFloat CocErrorSign`
+
+  The highlight used for error float window.
+
+CocWarningFloat 					*CocWarningFloat*
+
+  Default: `hi default link CocWarningFloat CocWarningSign`
+
+  The highlight used for warning float window.
+
+CocInfoFloat 					*CocInfoFloat*
+
+  Default: `hi default link CocInfoFloat CocInfoSign`
+
+  The highlight used for information float window.
+
+CocHintFloat 					*CocHintFloat*
+
+  Default: `hi default link CocHintFloat CocHintSign`
+
+  The highlight used for hint float window.
+
 CocErrorHighlight 				*CocErrorHighlight*
 
   Default: `hi default link CocErrorHighlight   CocUnderline`

--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -175,6 +175,10 @@ hi default CocInfoSign     ctermfg=Yellow  guifg=#fab005
 hi default CocHintSign     ctermfg=Blue    guifg=#15aabf
 hi default CocSelectedText ctermfg=Red     guifg=#fb4934
 hi default CocCodeLens     ctermfg=Gray    guifg=#999999
+hi default link CocErrorFloat   CocErrorSign
+hi default link CocWarningFloat CocWarningSign
+hi default link CocInfoFloat    CocInfoSign
+hi default link CocHintFloat    CocHintSign
 hi default link CocErrorHighlight   CocUnderline
 hi default link CocWarningHighlight CocUnderline
 hi default link CocInfoHighlight    CocUnderline

--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -379,16 +379,16 @@ export class DiagnosticManager {
       lines.push(...str.split('\n'))
     })
     if (useFloat) {
-      let hlGroup = 'CocErrorSign'
+      let hlGroup = 'CocErrorFloat'
       switch (diagnostics[0].severity) {
         case DiagnosticSeverity.Hint:
-          hlGroup = 'CocHintSign'
+          hlGroup = 'CocHintFloat'
           break
         case DiagnosticSeverity.Warning:
-          hlGroup = 'CocWarningSign'
+          hlGroup = 'CocWarningFloat'
           break
         case DiagnosticSeverity.Information:
-          hlGroup = 'CocInfoSign'
+          hlGroup = 'CocInfoFloat'
           break
       }
       let mode = await this.nvim.call('mode')


### PR DESCRIPTION
My sign colunm background same as line number column. now the diagnostic float window background is same as the normal background. so it will be useful for float window has it's own highlight group different from sign column.