### PR TITLE
fix: diagnostic test config

### DIFF
--- a/src/__tests__/modules/diagnosticBuffer.test.ts
+++ b/src/__tests__/modules/diagnosticBuffer.test.ts
@@ -8,6 +8,7 @@ import { wait } from '../../util'
 let nvim: Neovim
 const config: DiagnosticConfig = {
   enableMessage: 'always',
+  messageTarget: 'float',
   refreshOnInsertMode: false,
   virtualTextSrcId: 0,
   virtualText: false,


### PR DESCRIPTION
`Property 'messageTarget' is missing in type '{ enableMessage: string; refreshOnInsertMode: false; virtualTextSrcId: number; virtualText: false; virtualTextPrefix: string; virtualTextLines: number; virtualTextLineSeparator: string; ... 9 more ...; hintSign: string; }' but required in type 'DiagnosticConfig'`