### PR TITLE
trim coc#status()

### DIFF
--- a/autoload/coc.vim
+++ b/autoload/coc.vim
@@ -107,7 +107,7 @@ function! coc#status()
   if get(info, 'warning', 0)
     call add(msgs, s:warning_sign . info['warning'])
   endif
-  return join(msgs, ' ') . ' ' . get(g:, 'coc_status', '')
+  return trim(join(msgs, ' ') . ' ' . get(g:, 'coc_status', ''))
 endfunction
 
 function! coc#config(section, value)


### PR DESCRIPTION
return empty string instead of a space when there is no diagnostic info.