### PR TITLE
install.sh: Also check for yarn binary

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -58,7 +58,7 @@ install_yarn() {
     info "Nodejs not found, installing latest LTS"
     fetch install-node.now.sh/lts | sh
   fi
-  if ! command_exists yarnpkg; then
+  if ! command_exists yarn && ! command_exists yarnpkg; then
     info "Yarn not found, installing yarn."
     fetch https://yarnpkg.com/install.sh | sh
   fi


### PR DESCRIPTION
Yarn installs two binaries `yarn` & `yarnpkg`, currently the check only checks for `yarnpkg` only. I added the check for `yarn` two.

This will also match the node check which also check for two binaries `node` & `nodejs`