### PR TITLE
fix(file): show hidden files completion

### DIFF
--- a/src/source/file.ts
+++ b/src/source/file.ts
@@ -109,7 +109,7 @@ export default class File extends Source {
     if (!root) return null
     let items = await this.getItemsFromRoot(pathstr, root)
     let trimExt = this.trimSameExts.indexOf(ext) != -1
-    let startcol = this.fixStartcol(opt, ['-', '@'])
+    let startcol = this.fixStartcol(opt, ['-', '@', '.'])
     let first = input[0]
     if (first && col == startcol) items = items.filter(o => o.word[0] === first)
     return {


### PR DESCRIPTION
I have the following config:
```
'coc.source.file.ignoreHidden': false,
'coc.source.file.triggerCharacters': ['/', '.']
```

And, here is the file tree:
```
├── foo
    └── .bar
```

Input `foo/.b` will not suggest `.bar`, the PR fixed it.