### PR TITLE
Ensure cursor position is counted by UTF16

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -98,11 +98,16 @@ function! coc#util#yarn_cmd()
   return ''
 endfunction
 
+function! s:count_utf16_code_units(str) abort
+    let l:rs = split(a:str, '\zs')
+    let l:len = len(l:rs)
+    return l:len + len(filter(l:rs, 'char2nr(v:val)>=0x10000'))
+endfunction
+
 " get cursor position
 function! coc#util#cursor()
-  let pos = getcurpos()
-  let content = pos[2] == 1 ? '' : getline('.')[0: pos[2] - 2]
-  return [pos[1] - 1, strchars(content)]
+  let pos = s:count_utf16_code_units(getline('.')[:col('.')-1])
+  return [line('.') - 1, pos - 1]
 endfunction
 
 function! coc#util#close_win(id)


### PR DESCRIPTION
This is a requirement of the [language server spec](https://github.com/Microsoft/language-server-protocol/blob/gh-pages/specification.md#text-documents).
Inspired by prabirshrestha/vim-lsp#284