### PR TITLE
install.cmd: use -NoProfile for powershell

### DIFF
--- a/install.cmd
+++ b/install.cmd
@@ -1,4 +1,4 @@
-@PowerShell -ExecutionPolicy Bypass -Command Invoke-Expression $('$args=@(^&{$args} %*);'+[String]::Join(';',(Get-Content '%~f0') -notmatch '^^@PowerShell.*EOF$')) & goto :EOF
+@PowerShell -ExecutionPolicy Bypass -NoProfile -Command Invoke-Expression $('$args=@(^&{$args} %*);'+[String]::Join(';',(Get-Content '%~f0') -notmatch '^^@PowerShell.*EOF$')) & goto :EOF
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 


### PR DESCRIPTION
If pwsh is loaded with user profile, and the user enables PSCX, Expand-Archive signature will be different.