### PR TITLE
expand tilde in languageserver args #650

### DIFF
--- a/src/language-client/index.ts
+++ b/src/language-client/index.ts
@@ -420,7 +420,7 @@ export class LanguageClient extends BaseLanguageClient {
         command.command = command.command.replace(/^~/, os.homedir())
       }
 
-      for (var i = 0, len = command_args_ro.length; i < len; i++) {
+      for (let i = 0, len = command_args_ro.length; i < len; i++) {
           args[i] = command_args_ro[i].replace(/^~/, os.homedir())
       }
 

--- a/src/language-client/index.ts
+++ b/src/language-client/index.ts
@@ -410,13 +410,20 @@ export class LanguageClient extends BaseLanguageClient {
       }
     } else if (Executable.is(json) && json.command) {
       let command: Executable = json as Executable
-      let args = command.args || []
+      let command_args_ro = command.args || []
+      let args = []
+
       let options = Object.assign({}, command.options)
       options.env = options.env ? Object.assign(options.env, process.env) : process.env
       options.cwd = options.cwd || serverWorkingDir
       if (command.command.startsWith('~')) {
         command.command = command.command.replace(/^~/, os.homedir())
       }
+
+      for (var i = 0, len = command_args_ro.length; i < len; i++) {
+          args[i] = command_args_ro[i].replace(/^~/, os.homedir())
+      }
+
       let serverProcess = cp.spawn(command.command, args, options)
       if (!serverProcess || !serverProcess.pid) {
         throw new Error(`Launching server using command ${command.command} failed.`)


### PR DESCRIPTION
Continuation of #650 

Also expand ~ for language server language-server args:

for example:
```json
"languageserver": {
        "phppsalmls": {
            "command": "php",
            "args": ["~/dev/php/composer/vendor/vimeo/psalm/psalm-language-server"],
            "filetypes": ["php"]
        }
}
```