### PR TITLE
feat(plugin): current function symbol

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -647,6 +647,11 @@
       "description": "Auto close preview window on cursor move.",
       "default": true
     },
+    "coc.preferences.currentFunctionSymbolAutoUpdate": {
+      "type": "boolean",
+      "description": "Automatically update the value of b:coc_current_function on CursorHold event",
+      "default": false
+    },
     "coc.preferences.formatOnSaveFiletypes": {
       "type": "array",
       "default": [],

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   },
   "dependencies": {
     "@chemzqm/neovim": "4.4.1",
+    "binary-search": "1.3.5",
     "debounce": "^1.2.0",
     "fast-diff": "^1.2.0",
     "fb-watchman": "^2.0.0",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -392,6 +392,8 @@ export default class Plugin extends EventEmitter {
           return await extensions.toggleExtension(args[1])
         case 'uninstallExtension':
           return await extensions.uninstallExtension(args.slice(1))
+        case 'getCurrentFunctionSymbol':
+          return await handler.getCurrentFunctionSymbol()
         default:
           workspace.showMessage(`unknown action ${args[0]}`, 'error')
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -687,6 +687,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+binary-search@1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/binary-search/-/binary-search-1.3.5.tgz#479ad009589e0273cf54e5d74ab1546c489078ce"
+  integrity sha512-RHFP0AdU6KAB0CCZsRMU2CJTk2EpL8GLURT+4gilpjr1f/7M91FgUMnXuQLmf3OKLet34gjuNFwO7e4agdX5pw==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"


### PR DESCRIPTION
tl;dr
====
* New plugin action: `getCurrentFunctionSymbol`
* New preference: `coc.preferences.currentFunctionSymbolAutoUpdate`
* New depedency on `binary-search`.

---

A new handler method had been added (`getCurrentFunctionSymbol`) that
returns the name of the enclosing
Class/Method/Function/Interface/Enum/Constructor relative to the current
cursor position.
It will also set the `b:coc_current_function` buffer variable.

If the user choses to, by setting the
`coc.preferences.currentFunctionSymbolAutoUpdate` to `true` (default:
false), a hook is setup on the `CursorHold` event that will call
`getCurrentFunctionSymbol` and subsequently update the value of
`b:coc_current_function`.
This is useful in the context of an enhanced status line for instance.

Fixes https://github.com/neoclide/coc.nvim/issues/512

Inspired by @liuchengxu 's work on https://github.com/liuchengxu/vista.vim .