### PR TITLE
install.cmd: fix PSCX conflict on Expand-Archive

### DIFF
--- a/install.cmd
+++ b/install.cmd
@@ -29,7 +29,7 @@ if ($tag -eq "nightly") {
   Invoke-WebRequest $download -Out $zip
 
   Write-Host Extracting release files
-  Expand-Archive $zip -DestinationPath $dir -Force
+  Microsoft.Powershell.Compression\Expand-Archive $zip -DestinationPath $dir -Force
 
   Remove-Item $zip -Force
   Write-Host install completed.


### PR DESCRIPTION
Tested on Windows 10, Powershell 5, and PSCX module installed.

Solution from https://github.com/Pscx/Pscx/issues/23#issuecomment-313865570

README.md should mention the minimum Powershell version to run the install script.