### PR TITLE
fix error doc/coc.txt faq ALE configuration

### DIFF
--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -1696,7 +1696,7 @@ Q: 	I want to use ale for diagnostics.
 
 A: 	Yes, you can make coc send diagnostics to ale, just add >
 
-	"coc.preferences.diagnostic.displayByAle": false,
+	"coc.preferences.diagnostic.displayByAle": true,
 <
 	to your coc-settings.json
 


### PR DESCRIPTION
Hi !

There is a little error.

To make coc send diagnostics to alle we mast add : "coc.preferences.diagnostic.displayByAle": ***true***, and no false :-)

Thanks in advance