### PR TITLE
Add in link to scala section in the wiki

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -134,6 +134,7 @@ Below are the reasons that led coc.nvim to build its own engine:
     - [Bash](https://github.com/neoclide/coc.nvim/wiki/Language-servers#bash)
     - [Lua](https://github.com/neoclide/coc.nvim/wiki/Language-servers#lua)
     - [OCaml and ReasonML](https://github.com/neoclide/coc.nvim/wiki/Language-servers#ocaml-and-reasonml)
+    - [Scala](https://github.com/neoclide/coc.nvim/wiki/Language-servers#scala)
 
 - [Statusline integration](https://github.com/neoclide/coc.nvim/wiki/Statusline-integration)
 


### PR DESCRIPTION
Scalameta Metals has been doing some amazing work and coc is currently the example they use with vim.

I've gone ahead and added the information in the Wiki, and then am linking it here.