### PR TITLE
Fix clear highlight for the symbol under cursor

### DIFF
--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -168,6 +168,12 @@ export default class Handler {
     events.on('BufUnload', async bufnr => {
       this.clearHighlight(bufnr)
     }, null, this.disposables)
+    events.on('BufWinEnter', async bufnr => {
+      this.clearHighlight(bufnr)
+    }, null, this.disposables)
+    events.on('BufWinLeave', async bufnr => {
+      this.clearHighlight(bufnr)
+    }, null, this.disposables)
     events.on('InsertEnter', async bufnr => {
       this.clearHighlight(bufnr)
     }, null, this.disposables)


### PR DESCRIPTION
First, congratulations for this awesome plugin! I love it!

This is a fix to a small problem with symbol highlighting. When moving the cursor or switching buffer, highlights are not cleared properly. See the following example (vim 8.1):
![out](https://user-images.githubusercontent.com/8300317/56496300-20b6dc80-64f9-11e9-834f-e830849acefb.gif)

As you can see, after generating a highlight in the Python file at line 12, when switching to the other buffer and moving the cursor the highlighting at line 12 is still present and will not go away.

Fixed by adding event handlers to clear highlights on BufWinEnter,
and BufWinLeave (similar to how it is [implemented in vim-lsp](https://github.com/prabirshrestha/vim-lsp/pull/363/files#diff-d894fdd20596308dd9b1c8ac8a9197c8R160)).