### PR TITLE
Don't call coc#util#echo_hover without a valid message

### DIFF
--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -877,7 +877,10 @@ export default class Handler {
       i++
     }
     if (target == 'echo') {
-      await this.nvim.call('coc#util#echo_hover', lines.join('\n').trim())
+      const msg = lines.join('\n').trim()
+      if (msg.length) {
+        await this.nvim.call('coc#util#echo_hover', msg)
+      }
     } else if (target == 'float') {
       diagnosticManager.hideFloat()
       await this.hoverFactory.create(docs)


### PR DESCRIPTION
If coc.preferences.hoverTarget is set to echo:
Avoid request error if the current position is not on a valid 'hover
object'