### PR TITLE
Fix command names in docs (typo and capitalisation)

### DIFF
--- a/doc/coc.cnx
+++ b/doc/coc.cnx
@@ -906,7 +906,7 @@ CocActionAsync({action}, [...{args}, [{callback}]])
 		访问 https://www.npmjs.com/search?q=keywords%3Acoc.nvim
 		获取所有 coc 插件。
 
-:CocUninstall {name} 				*:CocUnInstall*
+:CocUninstall {name} 				*:CocUninstall*
 
 		卸载指定 coc 插件，支持使用 <tab> 进行补全。
 
@@ -917,7 +917,7 @@ CocActionAsync({action}, [...{args}, [{callback}]])
 		升级前请尽可能确保 coc 为最新版本，否则升级可能失败，
 		因为插件可能使用了新版 API 导致不兼容。
 
-:CocUpdateSync 					*:CocUpdatSynce*
+:CocUpdateSync 					*:CocUpdateSync*
 
 		同步方式升级所有插件。
 

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -1374,7 +1374,7 @@ COMMANDS 					*coc-commands*
 		Check out https://www.npmjs.com/search?q=keywords%3Acoc.nvim 
 		for available extensions.
 
-:CocUninstall {name} 				*:CocUnInstall*
+:CocUninstall {name} 				*:CocUninstall*
 
 		Uninstall an extension, use <tab> to complete the extension 
 		name.
@@ -1383,7 +1383,7 @@ COMMANDS 					*coc-commands*
 
 		Update all coc extensions to the latest version.
 
-:CocUpdateSync 					*:CocUpdatSynce*
+:CocUpdateSync 					*:CocUpdateSync*
 
 		Block version of update coc extensions.
 

--- a/history.md
+++ b/history.md
@@ -449,7 +449,7 @@
 - **Break change** snippet support reworked: support nest snippets, independent
   session in each buffer and lots of fixes.
 - **Break change** diagnostic list now sort by severity first.
-- Add commands: `:CocUnInstall` and `:CocOpenLog`
+- Add commands: `:CocUninstall` and `:CocOpenLog`
 - Add cterm color for highlights.
 - Add line highlight support for diagnostic.
 - Add `coc.preferences.fixInsertedWord` to make complete item replace current word.


### PR DESCRIPTION
CocUpdateSync, obvious typo fix.
CocUninstall, fix capitalisation to match code.