### PR TITLE
chore(util): add --ignore-scripts on update command

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -676,11 +676,11 @@ function! coc#util#update_extensions(...) abort
   if !useTerminal
     let cwd = getcwd()
     exe 'lcd '.dir
-    exe '!'.yarncmd.' upgrade --latest --ignore-engines'
+    exe '!'.yarncmd.' upgrade --latest --ignore-engines --ignore-scripts'
     exe 'lcd '.cwd
   else
     call coc#util#open_terminal({
-          \ 'cmd': yarncmd.' upgrade --latest --ignore-engines',
+          \ 'cmd': yarncmd.' upgrade --latest --ignore-engines --ignore-scripts',
           \ 'autoclose': 1,
           \ 'cwd': dir,
           \})


### PR DESCRIPTION
extension update should also ignore-scripts for VSCode-Only build scripts 