### PR TITLE
fix regex for getting node version

### DIFF
--- a/autoload/health/coc.vim
+++ b/autoload/health/coc.vim
@@ -21,7 +21,7 @@ function! s:checkEnvironment() abort
     echohl Error | echon output | echohl None
     return
   endif
-  let ms = matchlist(output, 'v\(\d\+\).\d\+.\d\+')
+  let ms = matchlist(output, 'v\(\d\+\).\(\d\+\).\(\d\+\)')
   if empty(ms) || str2nr(ms[1]) < 8 || (str2nr(ms[1]) == 8 && str2nr(ms[2]) < 10)
     let valid = 0
     call health#report_error('Node.js version '.output.' < 8.10.0, please upgrade node.js')


### PR DESCRIPTION
Hi, I got this error, but `8.12.0` must be greater than `8.10.0`.
<img width="315" alt="スクリーンショット 2019-05-18 17 33 56" src="https://user-images.githubusercontent.com/20733354/57966996-40c0ab00-7994-11e9-9825-cab815369b2a.png">

This regex works correctly.
<img width="482" alt="スクリーンショット 2019-05-18 17 41 34" src="https://user-images.githubusercontent.com/20733354/57967006-6352c400-7994-11e9-9bef-e62ed7afc80c.png">
<img width="420" alt="スクリーンショット 2019-05-18 17 41 27" src="https://user-images.githubusercontent.com/20733354/57967007-651c8780-7994-11e9-84d0-b413f7f4eebe.png">
