### PR TITLE
Hide alert of changing 'completeopt' when it is not replaced.

### DIFF
--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -155,6 +155,7 @@ export class Workspace implements IWorkspace {
       if (doc) doc.setIskeyword(newValue)
     }, this.disposables)
     this.watchOption('completeopt', async (_, newValue) => {
+      if (this.env.completeOpt === newValue) return
       this.env.completeOpt = newValue
       if (!this._attached) return
       if (this.insertMode) {


### PR DESCRIPTION
## Problem
I use "coc.nvim" and "[deoplete.nvim](https://github.com/Shougo/deoplete.nvim)".
"deoplete.nvim" often changes "completeopt" to "noselect,menuone" and "coc.nvim" show the alert message as the same time.
Then, the message is displayed at the command line for a moment as below.
![May-18-2019 22-27-58](https://user-images.githubusercontent.com/20733354/57970438-44682800-79bc-11e9-9271-fc2a4a92b085.gif)

However, the value "noselect,menuone" is the same as that "coc.nvim" uses. So, the message is unnecessary.

## Proposal
Skip to show the message if new value equals old one.