### PR TITLE
Allow ranges in `CocCommand`

### DIFF
--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -221,7 +221,7 @@ command! -nargs=0 CocRebuild      :call coc#util#rebuild()
 command! -nargs=+ -complete=custom,s:InstallOptions CocInstall   :call coc#util#install_extension([<f-args>])
 command! -nargs=+ -complete=custom,s:ExtensionList  CocUninstall :call coc#rpc#notify('CocAction', ['uninstallExtension', <f-args>])
 command! -nargs=* -complete=custom,coc#list#options CocList      :call coc#rpc#notify('openList',  [<f-args>])
-command! -nargs=* -complete=custom,s:CommandList    CocCommand   :call coc#rpc#notify('runCommand', [<f-args>])
+command! -nargs=* -complete=custom,s:CommandList -range CocCommand :call coc#rpc#notify('runCommand', [<f-args>])
 
 call s:Enable()
 


### PR DESCRIPTION
This is would allow commands like `git.browserOpen` to open blocks of
code in github.