### PR TITLE
fix(util): preview failed to show chunkInfo in Vim8

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -279,7 +279,7 @@ function! coc#util#preview_info(info, ...) abort
   setl filetype=markdown
   setl conceallevel=2
   setl nofoldenable
-  let lines = split(a:info, "\n")
+  let lines = a:info
   call append(0, lines)
   exe "normal! z" . len(lines) . "\<cr>"
   exe "normal! gg"


### PR DESCRIPTION
我发现在此处传给 preview_info 函数的参数已经是一个列表了

[coc-git/src/manager.ts](https://github.com/neoclide/coc-git/blob/4b1105459a8691845fa746d29fad2b089f3cc529/src/manager.ts#L247):
```vim
this.nvim.call('coc#util#preview_info', [lines], true)
```

```vim
  setl nofoldenable
  let lines = split(a:info, "\n")
  call append(0, lines)
  exe "normal! z" . len(lines) . "\<cr>"
```
这里却又将其当作字符串