### PR TITLE
feat(float): map `q` to close floating or preview window

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -279,6 +279,7 @@ function! coc#util#preview_info(info, ...) abort
   setl filetype=markdown
   setl conceallevel=2
   setl nofoldenable
+  nnoremap <silent><nowait> q <C-w>c
   let lines = a:info
   call append(0, lines)
   exe "normal! z" . len(lines) . "\<cr>"

--- a/src/model/floatFactory.ts
+++ b/src/model/floatFactory.ts
@@ -203,6 +203,7 @@ export default class FloatFactory implements Disposable {
       window.setOption('relativenumber', false, true)
       window.setOption('winhl', `Normal:CocFloating,NormalNC:CocFloating`, true)
       nvim.command(`noa call win_gotoid(${window.id})`, true)
+      nvim.command(`nnoremap <silent><nowait> q <C-w>c`, true)
       floatBuffer.setLines()
       if (alignTop) nvim.command('normal! G', true)
       nvim.command('noa wincmd p', true)


### PR DESCRIPTION
用 `<C-w>p` 跳转到 preview/floating window 之后，感觉上直接按 `q` 键退出更方便。这个也不是很必须，只是感觉稍微方便一点