### PR TITLE
Allow display of diagnostic info in Insert Mode

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -428,6 +428,11 @@
       "description": "Join lines messages to reduce lines of floating window.",
       "default": false
     },
+    "diagnostic.showInInsertMode": {
+      "type": "boolean",
+      "description": "Allow viewing of diagnostic messages in Insert Mode, default false.",
+      "default": false
+    },
     "diagnostic.refreshOnInsertMode": {
       "type": "boolean",
       "description": "Enable diagnostic refresh on insert mode, default false.",

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -260,9 +260,19 @@ Builtin configurations:~
 	Join lines messages to reduce lines of floating window.,  default:
 	`false`
 
+"diagnostic.showInInsertMode":~
+
+	Allow display of diagnostics in insert mode, default false.,  default:
+	`false`
+
 "diagnostic.refreshOnInsertMode":~
 
 	Enable diagnostic refresh on insert mode, default false.,  default:
+	`false`
+
+"diagnostic.showInInsertMode":~
+
+	Allow display of diagnostics in insert mode, default false.,  default:
 	`false`
 
 "diagnostic.refreshAfterSave":~

--- a/src/__tests__/modules/diagnosticBuffer.test.ts
+++ b/src/__tests__/modules/diagnosticBuffer.test.ts
@@ -13,6 +13,7 @@ const config: DiagnosticConfig = {
   maxWindowHeight: 8,
   enableMessage: 'always',
   messageTarget: 'echo',
+  showInInsertMode: false,
   refreshOnInsertMode: false,
   virtualTextSrcId: 0,
   virtualText: false,


### PR DESCRIPTION
Previously it was impossible to ever display diagnostic info when in
Insert Mode. There should at least be an option to do so.

Though, CursorHold behaviour will have to be set manually by the user
with:
`autocmd CursorHoldI * call CocActionAsync('diagnosticInfo')`

I couldn't see where to add this to the Chinese docs.