### PR TITLE
Fix the "Using configuration file" link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -114,7 +114,7 @@ Below are the reasons that led coc.nvim to build its own engine:
 
 - [Using list](https://github.com/neoclide/coc.nvim/wiki/Using-coc-list)
 
-- [Using configuration file](https://github.com/neoclide/coc.nvim/wiki/Using-configuration-file)
+- [Using configuration file](https://github.com/neoclide/coc.nvim/wiki/Using-the-configuration-file)
 
 - [Using workspaceFolders](https://github.com/neoclide/coc.nvim/wiki/Using-workspaceFolders)
 


### PR DESCRIPTION
The old link lead to a non existent wiki page