### PR TITLE
fix(diagnostic): correct ALE end column

### DIFF
--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -524,7 +524,7 @@ export class DiagnosticManager implements Disposable {
               lnum: range.start.line + 1,
               col: range.start.character + 1,
               end_lnum: range.end.line + 1,
-              end_col: range.end.character + 1,
+              end_col: range.end.character,
               type: getSeverityType(o.severity)
             }
           })


### PR DESCRIPTION
An off-by-one error relating to the `end_col` field passed to ALE was causing an extra character to be highlighted.

Latest build, using ALE:
<img width="131" alt="image" src="https://user-images.githubusercontent.com/5321575/58953395-52f86280-8764-11e9-9169-404debb53189.png">

Latest build, using coc native highlighting (ignore color differences and note the underline range):
<img width="118" alt="image" src="https://user-images.githubusercontent.com/5321575/58953349-2fcdb300-8764-11e9-8b9d-314410f9a740.png">

This pull request, using ALE:
<img width="127" alt="image" src="https://user-images.githubusercontent.com/5321575/58953296-014fd800-8764-11e9-97a3-ae0ec2479a2f.png">



