### PR TITLE
fix(util): Escape filename for jump

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -219,7 +219,7 @@ endfunction
 
 function! coc#util#jump(cmd, filepath, ...) abort
   let file = fnamemodify(a:filepath, ":~:.")
-  silent exe a:cmd.' '.file
+  silent exe a:cmd.' '.fnameescape(file)
   if &l:filetype ==# ''
     filetype detect
   endif


### PR DESCRIPTION
When using coc-java with the latest coc.nvim, I found that URL with `jdt://` failed to load when using "Go to definition".
It turned out the `jdt://` URL contained special characters like `%` and `?` which needs escaping when used with `:edit`.

I think this bug is important to fix especially for coc-java users. coc-java interacts with such URL by nature like the following.
`jdt://contents/com.google.guava--guava--guava--jar--16.0.1.jar/com.google.common.collect/ImmutableList.class?=DummyProject/ide-lib%5C/compile%5C/com.google.guava--guava--guava--jar--16.0.1.jar%3Ccom.google.common.collect(ImmutableList.class`
