### PR TITLE
s/sh/bash/ in the 'nodejs' command

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -77,7 +77,7 @@ Below are the reasons that led coc.nvim to build its own engine:
   Install [nodejs](https://nodejs.org/en/download/):
 
   ```sh
-  curl -sL install-node.now.sh/lts | sh
+  curl -sL install-node.now.sh/lts | bash
   # Optional install yarn if you want install extension by CocInstall command
   curl --compressed -o- -L https://yarnpkg.com/install.sh | bash
   ```


### PR DESCRIPTION
There is an error from `sh` (i.e. `dash`) on Ubuntu 16.04 about `set -o pipefail` being unsupported