### PR TITLE
Fix comparing in getCurrentFunctionSymbol

### DIFF
--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -38,8 +38,8 @@ interface SymbolInfo {
   kind: string
   level?: number
   containerName?: string
-  selectionRange: Range
-  range?: Range
+  range: Range
+  selectionRange?: Range
 }
 
 interface CommandItem {
@@ -237,8 +237,8 @@ export default class Handler {
     let filetype = document.filetype
     let functionName = ''
     for (let sym of symbols.reverse()) {
-      if (sym.selectionRange
-        && positionInRange(position, sym.selectionRange) == 0
+      if (sym.range
+        && positionInRange(position, sym.range) == 0
         && !sym.text.endsWith(') callback')) {
         functionName = sym.text
         let kind = sym.kind.toLowerCase()
@@ -355,7 +355,7 @@ export default class Handler {
           text: name,
           level,
           kind: getSymbolKind(kind),
-          selectionRange: location.range,
+          range: location.range,
           containerName
         }
         res.push(o)


### PR DESCRIPTION
I've tried the newest release of coc for golang and typescript. The function `getCurrentFunctionSymbol` works well in typescript but is broken in golang. After a while for digging, I found the DocumentSymbols response from typescript server is different from golang.

Specifically, the `range` and `selectionRange` property of `DocumentSymbol` response has a different meaning. Here's the definitions from [LSP specification](https://microsoft.github.io/language-server-protocol/specification#textDocument_documentSymbol):

```
/**
* The range enclosing this symbol not including leading/trailing whitespace but everything else
 * like comments. This information is typically used to determine if the clients cursor is
 * inside the symbol to reveal in the symbol in the UI.
 */
range: Range;

/**
 * The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
 * Must be contained by the `range`.
 */
selectionRange: Range;
```

It says we should use `range` property to determine if the cursor is inside the symbol. While `selectionRange` is only the range of the symbol name string, not include the body.

So why the `selectionRange` also works for typescript? 

I thought that maybe another bug in `coc-tsserver`. I found the `range` and `selectionRange` property of DocumentSymbol response are exactly the same from `coc-tsserver`. But they are different in the response from gopls server. 
Anyway, We need to use `range` instead of `selectionRange` as the LSP specification told.
