### PR TITLE
Expose CodeAction functionality

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -12,7 +12,7 @@ import listManager from './list/manager'
 import services from './services'
 import snippetManager from './snippets/manager'
 import sources from './sources'
-import { Autocmd, OutputChannel, PatternType } from './types'
+import { Autocmd, CodeAction, OutputChannel, PatternType } from './types'
 import clean from './util/clean'
 import workspace from './workspace'
 import debounce = require('debounce')
@@ -88,6 +88,17 @@ export default class Plugin extends EventEmitter {
     })
     this.addMethod('updateConfig', (section: string, val: any) => {
       workspace.configurations.updateUserConfig({ [section]: val })
+    })
+    this.addMethod('getCurrentCodeActions', async (mode?: string, only?: CodeActionKind[]) => {
+      let codeActions = await this.handler.getCurrentCodeActions(mode, only)
+      if (codeActions && codeActions.length > 0) {
+        return codeActions
+      }
+    })
+    this.addMethod('applyCodeAction', async (codeAction: CodeAction) => {
+      if (codeAction) {
+        await this.handler.applyCodeAction(codeAction)
+      }
     })
     this.addMethod('snippetNext', async () => {
       await snippetManager.nextPlaceholder()


### PR DESCRIPTION
**Details**
- Specifically exposes `getCurrentCodeActions` and `applyCodeAction`
- The intention is to allow vim scripts, plugins or coc extensions to hook into this part of the plugin

```vim
let s:code_actions = coc#rpc#request('getCurrentCodeActions', [])

call coc#rpc#request('applyCodeAction', [s:code_actions[0]])
```

**Discussion**
- Happy to be pointed to where a better extension point might be to expose this functionality
- I didn't discover an obvious place to write tests which exercise which functions are exposed (ie. test the plugin interface). Happy to add something with some direction.
- I'm motivated towards these changes as it allows my popupmenu to [select and execute code actions](https://github.com/kizza/actionmenu.nvim/pull/1), and suspect others might be interested in being able to do similar things

(Thanks so much for `coc` it. is .awesome.)