### PR TITLE
Fix markdown link parsing

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,6 +38,7 @@ Check out [doc/coc.txt](doc/coc.txt) for the vim interface.
 
 <details><summary>Completion experience</summary>
 <p>
+  
 You might be wondering why yet another completion engine since there is the already
 widely used [YouCompleteMe](https://github.com/Valloric/YouCompleteMe) and
 [deoplete.nvim](https://github.com/Shougo/deoplete.nvim).


### PR DESCRIPTION
For whatever  reason, the Github markdown parser seems to get confused when there's an HTML tag adjoining a markdown segment. The work around is a blank line between them. 

This fixes the link display in the paragraph about other completion engines.