### PR TITLE
Use package.json as source of truth for installed extensions

### DIFF
--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -161,16 +161,13 @@ export class Extensions {
   private async checkExtensions(): Promise<void> {
     let { globalExtensions, watchExtensions } = workspace.env
     if (globalExtensions && globalExtensions.length) {
-      let names = globalExtensions.filter(name => !this.isDisabled(name))
-      let folder = path.join(this.root, 'node_modules')
-      let files = await util.promisify(fs.readdir)(folder)
-      names = names.filter(s => files.indexOf(s) == -1)
+      let extensions = globalExtensions.filter(name => !this.isDisabled(name))
       let json = this.loadJson()
       if (json && json.dependencies) {
-        let vals = Object.values(json.dependencies) as string[]
-        names = names.filter(s => vals.findIndex(val => val.indexOf(s) !== -1) == -1)
+        let installedExtensions = Object.keys(json.dependencies)
+        extensions = extensions.filter(extension => (installedExtensions.indexOf(extension) === -1))
       }
-      this.installExtensions(names).logError()
+      this.installExtensions(extensions).logError()
     }
     // watch for changes
     if (watchExtensions && watchExtensions.length) {


### PR DESCRIPTION
On a fresh install of coc, the `extensions` directory is initialised with `package.json` and no `node_modules` folder. This causes the current code to silently fail when checking for currently installed extensions as it can't read the non existent `node_modules` folder.

I have changed the current behaviour to use `package.json` as the source of truth for installed extensions rather than `node_modules`. I think this is safer and faster as we don't need to loop the entire `node_modules` directory.

This also fixes #945 where global extensions will not be installed unless other extensions are already installed, i.e.`node_modules` exists.