### PR TITLE
Add config to set diagnostic filetype (syntax highlight diagnostics)

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -550,16 +550,12 @@
       "description": "Maximum height of diagnostics floating window.",
       "default": 8
     },
-    "diagnostic.filetype": {
-      "type": "string",
-      "description": "The filetype given to diagnostic buffers. Use \"bufferType\" config to set diagnostics windows to parent code window's filetype.",
-      "default": "",
-      "enum": ["", "bufferType", "custom"]
-    },
     "diagnostic.filetypeMap": {
       "type":"object",
-      "description": "A map between buffer filetype and the filetype assigned to diagnostics. Use to override default \"diagnostic.filetype\"",
-      "default": {}
+      "description": "A map between buffer filetype and the filetype assigned to diagnostics. To syntax highlight diagnostics withs their parent buffer type use '\"default\": \"bufferType\"'",
+      "default": {
+        "default": ""
+      }
     },
     "signature.enable": {
       "type": "boolean",

--- a/data/schema.json
+++ b/data/schema.json
@@ -556,6 +556,11 @@
       "default": "",
       "enum": ["", "bufferType", "custom"]
     },
+    "diagnostic.filetypeMap": {
+      "type":"object",
+      "description": "A map between buffer filetype and the filetype assigned to diagnostics. Use to override default \"diagnostic.filetype\"",
+      "default": {}
+    },
     "signature.enable": {
       "type": "boolean",
       "description": "Enable signature help when trigger character typed, require restart service on change.",

--- a/data/schema.json
+++ b/data/schema.json
@@ -550,6 +550,12 @@
       "description": "Maximum height of diagnostics floating window.",
       "default": 8
     },
+    "diagnostic.filetype": {
+      "type": "string",
+      "description": "The filetype given to diagnostic buffers. Use \"bufferType\" config to set diagnostics windows to parent code window's filetype.",
+      "default": "",
+      "enum": ["", "bufferType", "custom"]
+    },
     "signature.enable": {
       "type": "boolean",
       "description": "Enable signature help when trigger character typed, require restart service on change.",

--- a/src/__tests__/modules/diagnosticBuffer.test.ts
+++ b/src/__tests__/modules/diagnosticBuffer.test.ts
@@ -28,7 +28,8 @@ const config: DiagnosticConfig = {
   warningSign: '>>',
   infoSign: '>>',
   refreshAfterSave: false,
-  hintSign: '>>'
+  hintSign: '>>',
+  filetype: ''
 }
 
 async function createDiagnosticBuffer(): Promise<DiagnosticBuffer> {

--- a/src/__tests__/modules/diagnosticBuffer.test.ts
+++ b/src/__tests__/modules/diagnosticBuffer.test.ts
@@ -29,8 +29,9 @@ const config: DiagnosticConfig = {
   infoSign: '>>',
   refreshAfterSave: false,
   hintSign: '>>',
-  filetype: '',
-  filetypeMap: {},
+  filetypeMap: {
+    'default': ''
+  },
 }
 
 async function createDiagnosticBuffer(): Promise<DiagnosticBuffer> {

--- a/src/__tests__/modules/diagnosticBuffer.test.ts
+++ b/src/__tests__/modules/diagnosticBuffer.test.ts
@@ -29,7 +29,8 @@ const config: DiagnosticConfig = {
   infoSign: '>>',
   refreshAfterSave: false,
   hintSign: '>>',
-  filetype: ''
+  filetype: '',
+  filetypeMap: {},
 }
 
 async function createDiagnosticBuffer(): Promise<DiagnosticBuffer> {

--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -36,7 +36,6 @@ export interface DiagnosticConfig {
   virtualTextPrefix: string
   virtualTextLines: number
   virtualTextLineSeparator: string
-  filetype: string
   filetypeMap: object
 }
 
@@ -416,11 +415,14 @@ export class DiagnosticManager implements Disposable {
     let lines: string[] = []
     let docs: Documentation[] = []
 
+
+
     const buf_ft = (await workspace.document).filetype
+    const default_ft = config.filetypeMap['default']
     const ft = config.filetypeMap.hasOwnProperty(buf_ft) ?
       config.filetypeMap[buf_ft] :
-      (config.filetype === "bufferType" ?
-        buf_ft : config.filetype)
+      (default_ft === 'bufferType' ?
+        buf_ft : (default_ft ? default_ft : ''))
 
     diagnostics.forEach(diagnostic => {
       let { source, code, severity, message } = diagnostic
@@ -524,7 +526,6 @@ export class DiagnosticManager implements Disposable {
       hintSign: getConfig<string>('hintSign', '>>'),
       refreshAfterSave: getConfig<boolean>('refreshAfterSave', false),
       refreshOnInsertMode: getConfig<boolean>('refreshOnInsertMode', false),
-      filetype: getConfig<string>('filetype', ''),
       filetypeMap: getConfig<object>('filetypeMap', {}),
     }
     this.enabled = getConfig<boolean>('enable', true)

--- a/src/model/floatFactory.ts
+++ b/src/model/floatFactory.ts
@@ -210,10 +210,6 @@ export default class FloatFactory implements Disposable {
       this.close()
       return
     }
-    let filetypes = docs.reduce((p, curr) => {
-      p.add(curr.filetype)
-      return p
-    }, new Set as Set<string>)
 
     if (this.tokenSource) {
       this.tokenSource.cancel()
@@ -249,9 +245,6 @@ export default class FloatFactory implements Disposable {
       } else {
         this.window.setConfig(config, true)
         nvim.command(`noa call win_gotoid(${this.window.id})`, true)
-      }
-      if (filetypes.size == 1) {
-        nvim.command(`set filetype=${filetypes.values().next().value}`)
       }
       this.floatBuffer.setLines()
       nvim.command(`normal! ${alignTop ? 'G' : 'gg'}0`, true)

--- a/src/model/floatFactory.ts
+++ b/src/model/floatFactory.ts
@@ -251,7 +251,7 @@ export default class FloatFactory implements Disposable {
         nvim.command(`noa call win_gotoid(${this.window.id})`, true)
       }
       if (filetypes.size == 1) {
-        nvim.command(`setfiletype ${filetypes.values().next().value}`)
+        nvim.command(`set filetype=${filetypes.values().next().value}`)
       }
       this.floatBuffer.setLines()
       nvim.command(`normal! ${alignTop ? 'G' : 'gg'}0`, true)

--- a/src/model/floatFactory.ts
+++ b/src/model/floatFactory.ts
@@ -178,11 +178,9 @@ export default class FloatFactory implements Disposable {
       let { nvim, alignTop } = this
       let reuse = false
       let filetypes = docs.reduce((p, curr) => {
-        if (p.indexOf(curr.filetype) == -1) {
-          p.push(curr.filetype)
-        }
+        p.add(curr.filetype)
         return p
-      }, [] as string[])
+      }, new Set as Set<string>)
       nvim.pauseNotification()
       let { popup, window } = this
       this.popup.move({
@@ -195,8 +193,8 @@ export default class FloatFactory implements Disposable {
       })
       this.floatBuffer.setLines()
       // nvim.call('win_execute', [window.id, `normal! G`], true)
-      if (filetypes.length == 1) {
-        this.popup.setFiletype(filetypes[0])
+      if (filetypes.size == 1) {
+        this.popup.setFiletype(filetypes.values().next().value)
       }
       let [res, err] = await nvim.resumeNotification()
       if (err) {
@@ -212,6 +210,11 @@ export default class FloatFactory implements Disposable {
       this.close()
       return
     }
+    let filetypes = docs.reduce((p, curr) => {
+      p.add(curr.filetype)
+      return p
+    }, new Set as Set<string>)
+
     if (this.tokenSource) {
       this.tokenSource.cancel()
     }
@@ -246,6 +249,9 @@ export default class FloatFactory implements Disposable {
       } else {
         this.window.setConfig(config, true)
         nvim.command(`noa call win_gotoid(${this.window.id})`, true)
+      }
+      if (filetypes.size == 1) {
+        nvim.command(`setfiletype ${filetypes.values().next().value}`)
       }
       this.floatBuffer.setLines()
       nvim.command(`normal! ${alignTop ? 'G' : 'gg'}0`, true)


### PR DESCRIPTION
This allow you to apply either the parent buffers filetype or an arbitrary file type to diagnostic floats.