### PR TITLE
Added support for cygwin

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -551,6 +551,15 @@ function! coc#util#run_terminal(opts, cb)
   call coc#util#open_terminal(opts)
 endfunction
 
+function! coc#util#getpid()
+  if !has('win32unix')
+    return getpid()
+  endif
+
+  let cmd = 'cat /proc/' . getpid() . '/winpid'
+  return substitute(system(cmd), '\v\n', '', 'gi')
+endfunction
+
 function! coc#util#vim_info()
   return {
         \ 'mode': mode(),
@@ -559,7 +568,7 @@ function! coc#util#vim_info()
         \ 'watchExtensions': get(g:, 'coc_watch_extensions', []),
         \ 'globalExtensions': get(g:, 'coc_global_extensions', []),
         \ 'config': get(g:, 'coc_user_config', {}),
-        \ 'pid': getpid(),
+        \ 'pid': coc#util#getpid(),
         \ 'columns': &columns,
         \ 'lines': &lines,
         \ 'cmdheight': &cmdheight,
@@ -568,6 +577,7 @@ function! coc#util#vim_info()
         \ 'completeOpt': &completeopt,
         \ 'pumevent': exists('##MenuPopupChanged') || exists('##CompleteChanged'),
         \ 'isVim': has('nvim') ? v:false : v:true,
+        \ 'isCygwin': has('win32unix') ? v:true : v:false,
         \ 'isMacvim': has('gui_macvim') ? v:true : v:false,
         \ 'colorscheme': get(g:, 'colors_name', ''),
         \ 'workspaceFolders': get(g:, 'WorkspaceFolders', v:null),

--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -577,7 +577,6 @@ function! coc#util#vim_info()
         \ 'completeOpt': &completeopt,
         \ 'pumevent': exists('##MenuPopupChanged') || exists('##CompleteChanged'),
         \ 'isVim': has('nvim') ? v:false : v:true,
-        \ 'isCygwin': has('win32unix') ? v:true : v:false,
         \ 'isMacvim': has('gui_macvim') ? v:true : v:false,
         \ 'colorscheme': get(g:, 'colors_name', ''),
         \ 'workspaceFolders': get(g:, 'WorkspaceFolders', v:null),

--- a/src/types.ts
+++ b/src/types.ts
@@ -237,6 +237,7 @@ export interface Env {
   readonly pumevent: boolean
   readonly cmdheight: number
   readonly filetypeMap: { [index: string]: string }
+  readonly isCygwin: boolean
   readonly isVim: boolean
   readonly isMacvim: boolean
   readonly version: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -237,7 +237,6 @@ export interface Env {
   readonly pumevent: boolean
   readonly cmdheight: number
   readonly filetypeMap: { [index: string]: string }
-  readonly isCygwin: boolean
   readonly isVim: boolean
   readonly isMacvim: boolean
   readonly version: string


### PR DESCRIPTION
Right now, in cygwin, the vim process will return via the `getpid()` command the cygwin pid. When trying to check that process from the node process (which is not a posix process) that will fail and after 15 minutes the coc.nvim is closed. 

Via this pull request, I am trying to get the winpid, instead of the cygwin pid. 

However, I was wondering what is the purpose of having the `workspace.ts::checkProcess` logic? The process launched via `job_start` in vim is a child process of vim. So, anyway, as soon as the vim process does not exists anymore, the node process will be killed automatically by the OS. This is valid for Linux, Mac and cygwin. I don't know for windows. But if this is not valid for windows, can we modify the function to be called only for Windows?

There is really no use for the timer here:

https://github.com/neoclide/coc.nvim/blob/3ce5cabf4c83f40fa7557d65d0e718519cc36422/src/workspace.ts#L1597