### PR TITLE
Fixed EOL for cygwin

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -576,6 +576,7 @@ function! coc#util#vim_info()
         \ 'completeOpt': &completeopt,
         \ 'pumevent': exists('##MenuPopupChanged') || exists('##CompleteChanged'),
         \ 'isVim': has('nvim') ? v:false : v:true,
+        \ 'isCygwin': has('win32unix') ? v:true : v:false,
         \ 'isMacvim': has('gui_macvim') ? v:true : v:false,
         \ 'colorscheme': get(g:, 'colors_name', ''),
         \ 'workspaceFolders': get(g:, 'WorkspaceFolders', v:null),
@@ -861,4 +862,8 @@ endfunction
 function! coc#util#set_buf_var(bufnr, name, val) abort
   if !bufloaded(a:bufnr) | return | endif
   call setbufvar(a:bufnr, a:name, a:val)
+endfunction
+
+function! coc#util#get_fileformat()
+  return &fileformat
 endfunction

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -5,7 +5,7 @@ import { URI } from 'vscode-uri'
 import { BufferOption, ChangeInfo, Env } from '../types'
 import { diffLines, getChange } from '../util/diff'
 import { isGitIgnored } from '../util/fs'
-import { getUri, wait } from '../util/index'
+import { getUri, wait, platform } from '../util/index'
 import { byteIndex, byteLength, byteSlice } from '../util/string'
 import { Chars } from './chars'
 import { group } from '../util/array'
@@ -280,6 +280,12 @@ export default class Document {
     let orig = this.lines.join('\n') + (this.eol ? '\n' : '')
     let textDocument = TextDocument.create(this.uri, this.filetype, 1, orig)
     let content = TextDocument.applyEdits(textDocument, edits as TextEdit[])
+    if (this.env.isCygwin && platform.isWindows) {
+      let fileformat = await this.nvim.call('coc#util#get_fileformat', [])
+      if (fileformat == 'unix') {
+        content = content.replace(/\r\n/g, '\n');
+      }
+    }
     // could be equal sometimes
     if (orig === content) {
       this.createDocument()

--- a/src/types.ts
+++ b/src/types.ts
@@ -237,6 +237,7 @@ export interface Env {
   readonly pumevent: boolean
   readonly cmdheight: number
   readonly filetypeMap: { [index: string]: string }
+  readonly isCygwin: boolean
   readonly isVim: boolean
   readonly isMacvim: boolean
   readonly version: string


### PR DESCRIPTION
When running under cygwin, if your files are using unix line ending, because of the node process being a Window process, there will be windows line endings added when modifying code via coc.nvim (for example when adding a new import via `:CocFix`). 

This PR aims to fix this. It checks if the vim is running under cygwin and if the node process is running under windows and if the fileformat is unix, then it will replace the end lines with linux end lines. 