### PR TITLE
fix(language-client): mismatch createMessageTransports type

### DIFF
--- a/src/language-client/client.ts
+++ b/src/language-client/client.ts
@@ -3782,7 +3782,7 @@ export abstract class BaseLanguageClient {
 
   protected abstract createMessageTransports(
     encoding: string
-  ): Thenable<MessageTransports>
+  ): Promise<MessageTransports | null>
 
   private createConnection(): Thenable<IConnection> {
     let errorHandler = (error: Error, message: Message, count: number) => {


### PR DESCRIPTION
I've updated the type of BaseLanguageClient.createMessageTransports to match the type of LanguageClient.createMessageTransports. In my project, using typescript, I was getting compile errors because the types didn't match.