### PR TITLE
style: Clean up input text formatting

### DIFF
--- a/src/__tests__/modules/workspace.test.ts
+++ b/src/__tests__/modules/workspace.test.ts
@@ -740,7 +740,7 @@ describe('workspace utility', () => {
   })
 
   it('should request input', async () => {
-    let p = workspace.requestInput('name')
+    let p = workspace.requestInput('Name')
     await helper.wait(30)
     await nvim.input('bar<enter>')
     let res = await p
@@ -748,7 +748,7 @@ describe('workspace utility', () => {
   })
 
   it('should return null when input empty', async () => {
-    let p = workspace.requestInput('name')
+    let p = workspace.requestInput('Name')
     await helper.wait(30)
     await nvim.input('<enter>')
     let res = await p

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -457,7 +457,7 @@ export default class Handler {
     }
     if (!newName) {
       let curname = await nvim.eval('expand("<cword>")')
-      newName = await workspace.callAsync<string>('input', ['new name:', curname])
+      newName = await workspace.callAsync<string>('input', ['New name: ', curname])
       nvim.command('normal! :<C-u>', true)
       if (!newName) {
         workspace.showMessage('Empty name, canceled', 'warning')

--- a/src/list/source/folders.ts
+++ b/src/list/source/folders.ts
@@ -16,7 +16,7 @@ export default class FoldList extends BasicList {
     super(nvim)
 
     this.addAction('edit', async item => {
-      let newPath = await nvim.call('input', ['Folder:', item.label, 'file'])
+      let newPath = await nvim.call('input', ['Folder: ', item.label, 'file'])
       let stat = await statAsync(newPath)
       if (!stat || !stat.isDirectory()) {
         await nvim.command(`echoerr "invalid path: ${newPath}"`)

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1044,7 +1044,7 @@ export class Workspace implements IWorkspace {
    */
   public async requestInput(title: string, defaultValue?: string): Promise<string> {
     let { nvim } = this
-    let res = await this.callAsync<string>('input', [title + ':', defaultValue || ''])
+    let res = await this.callAsync<string>('input', [title + ': ', defaultValue || ''])
     nvim.command('normal! :<C-u>', true)
     if (!res) {
       this.showMessage('Empty word, canceled', 'warning')
@@ -1479,7 +1479,7 @@ augroup end`
       return
     }
     let oldPath = URI.parse(doc.uri).fsPath
-    let newPath = await nvim.call('input', ['new path:', oldPath, 'file'])
+    let newPath = await nvim.call('input', ['New path: ', oldPath, 'file'])
     newPath = newPath ? newPath.trim() : null
     if (newPath == oldPath || !newPath) return
     let lines = await doc.buffer.lines


### PR DESCRIPTION
Vim prompts generally are formatted with a leading capital letter and space. For example, the prompt when pressing `%` in netrw to create a new file:

<img width="200" alt="image" src="https://user-images.githubusercontent.com/5321575/62421906-9d6c6180-b677-11e9-9cee-a9f7eeb804b1.png">

coc.nvim uses a lowercase first letter and no trailing space:

<img width="156" alt="image" src="https://user-images.githubusercontent.com/5321575/62421901-92193600-b677-11e9-8491-d43445262942.png">

This change updates the text formatting to be more similar:

<img width="147" alt="image" src="https://user-images.githubusercontent.com/5321575/62421966-a7db2b00-b678-11e9-8391-7fb93085cb27.png">

