### PR TITLE
fix: fix coc_status not change while installing extensions

### DIFF
--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -217,6 +217,8 @@ export class Extensions {
     await Promise.all(list.map(def => {
       return this.manager.install(npm, def).then(name => {
         if (name) this.onExtensionInstall(name).logError()
+        list = list.filter(e => e !== name)
+        statusItem.text = `Installing ${list.join(' ')}`
       }, err => {
         workspace.showMessage(`Error on install ${def}: ${err}`)
       })


### PR DESCRIPTION
- `g:coc_status` should change every time a new extension is installed.
-  I just add two lines, with one line duplicated... No idea how to make it more elegant. If there are better ways, ignore this PR.