### PR TITLE
Allow coc_config_home to be configurable

### DIFF
--- a/autoload/coc/rpc.vim
+++ b/autoload/coc/rpc.vim
@@ -15,7 +15,7 @@ function! coc#rpc#start_server()
   if empty(s:client)
     let cmd = coc#util#job_command()
     if empty(cmd) | return | endif
-    let $VIMCONFIG = coc#util#get_config_home()
+    let $COC_VIMCONFIG = coc#util#get_config_home()
     let s:client = coc#client#create(s:name, cmd)
   endif
   if !coc#client#is_running('coc')

--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -347,6 +347,9 @@ function! coc#util#preview_info(info, ...) abort
 endfunction
 
 function! coc#util#get_config_home()
+  if exists("g:coc_config_home")
+      return get(g:, 'coc_config_home', "")
+  endif
   if exists('$VIMCONFIG')
     return resolve($VIMCONFIG)
   endif

--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -347,8 +347,8 @@ function! coc#util#preview_info(info, ...) abort
 endfunction
 
 function! coc#util#get_config_home()
-  if exists("g:coc_config_home")
-      return get(g:, 'coc_config_home', "")
+  if !empty(get(g:, 'coc_config_home', ''))
+      return g:coc_config_home
   endif
   if exists('$VIMCONFIG')
     return resolve($VIMCONFIG)

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -1021,7 +1021,8 @@ g:coc_cursors_activated				*g:coc_cursors_activated*
 g:coc_config_home				*g:coc_config_home*
 
 			Configure the directory which will be used to look
-			for coc-settings.json
+			for coc-settings.json and install extensions.
+			
 ------------------------------------------------------------------------------
 
 Some variables are provided by coc.nvim so you can use them in your 

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -1018,6 +1018,10 @@ g:coc_cursors_activated				*g:coc_cursors_activated*
 			Use expression `get(g:, 'coc_cursors_activated',0)` to
 			check if cursors session is activated.
 
+g:coc_config_home				*g:coc_config_home*
+
+			Configure the directory which will be used to look
+			for coc-settings.json
 ------------------------------------------------------------------------------
 
 Some variables are provided by coc.nvim so you can use them in your 

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -455,8 +455,8 @@ export class Extensions {
   }
 
   private async loadFileExtensions(): Promise<void> {
-    if (!process.env.VIMCONFIG) return
-    let folder = path.join(process.env.VIMCONFIG, 'coc-extensions')
+    if (!process.env.COC_VIMCONFIG) return
+    let folder = path.join(process.env.COC_VIMCONFIG, 'coc-extensions')
     if (!fs.existsSync(folder)) return
     let files = await readdirAsync(folder)
     files = files.filter(f => f.endsWith('.js'))

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1305,7 +1305,7 @@ augroup end`
   }
 
   private createConfigurations(): Configurations {
-    let home = process.env.VIMCONFIG || path.join(os.homedir(), '.vim')
+    let home = process.env.COC_VIMCONFIG || path.join(os.homedir(), '.vim')
     if (global.hasOwnProperty('__TEST__')) {
       home = path.join(this.pluginRoot, 'src/__tests__')
     }


### PR DESCRIPTION
This is something that has been asked about in the past - one example (https://github.com/neoclide/coc.nvim/issues/718)

This helps improve maintenance of dotfiles for both vim and neovim. It allows for a way to use coc.nvim with neovim without needing to add a symbolic link somewhere to to .config. Everything is configurable from within the vimrc.

Let me know your thoughts.