### PR TITLE
Fix completion for Haskell

### DIFF
--- a/src/util/complete.ts
+++ b/src/util/complete.ts
@@ -3,7 +3,7 @@ import { SnippetParser } from '../snippets/parser'
 import { CompleteOption } from '../types'
 import { byteSlice, characterIndex } from './string'
 const logger = require('./logger')('util-complete')
-const invalidInsertCharacters = ['(', '<', '{', '[', '\r', '\n']
+const invalidInsertCharacters = [' ', '(', '<', '{', '[', '\r', '\n']
 
 export function getPosition(opt: CompleteOption): Position {
   let { line, linenr, colnr } = opt


### PR DESCRIPTION
Haskell and many other functional languages don't use parentheses or any other symbol to denote calling.