### PR TITLE
update example configuration

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -269,9 +269,10 @@ endfunction
 " Use <c-space> to trigger completion.
 inoremap <silent><expr> <c-space> coc#refresh()
 
-" Use <cr> to confirm completion, `<C-g>u` means break undo chain at current position.
+" Use <cr> to confirm completion if selected, `<C-g>u` means break undo chain at current position.
 " Coc only does snippet and additional edit on confirm.
 inoremap <expr> <cr> pumvisible() ? "\<C-y>" : "\<C-g>u\<CR>"
+inoremap <expr> <cr> complete_info()["selected"] != "-1" ? "\<C-y>" : "\<C-g>u\<CR>"
 
 " Use `[g` and `]g` to navigate diagnostics
 nmap <silent> [g <Plug>(coc-diagnostic-prev)


### PR DESCRIPTION
Use complete_info instead of pumvisible to determine whether new
line should start or not. Current mapping requires two cr key press
to get to newline when completion item is not selected.

I found it really annoying, but if it's intended behavior just close it.
Thanks for the great project. I should say that it literally changed my life.