### PR TITLE
fix(api.vim): clear highlight namespace cached

### DIFF
--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -282,6 +282,7 @@ function! s:funcs.buf_clear_namespace(bufnr, srcId, startLine, endLine) abort
     if empty(cached)
       return
     endif
+    call setbufvar(a:bufnr, 'prop_namespace_'.a:srcId, [])
     for id in cached
       if a:endLine == -1
         if a:startLine == 0 && a:endLine == -1


### PR DESCRIPTION
After repeated calls the `buffer.addHighlight` and `buffer.clearNamespace`, cached will very large, causing `clearNamespace` too slow.