### PR TITLE
fix(api.vim): nvim_win_get_cursor() col index start from 0

### DIFF
--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -428,7 +428,7 @@ endfunction
 function! s:funcs.win_get_cursor(win_id) abort
   let winid = win_getid()
   call win_gotoid(a:win_id)
-  let pos = [line('.'), col('.')]
+  let pos = [line('.'), col('.')-1]
   call win_gotoid(winid)
   return pos
 endfunction


### PR DESCRIPTION
Test demo
```typescript
import { workspace } from "coc.nvim";

export async function activate() {
  const { nvim } = workspace;
  workspace.registerKeymap(["n"], "storeCursor", () => {
    async function test() {
      const winid = await nvim.call("win_getid", []);
      const win = nvim.createWindow(winid);
      const [line, col] = await win.cursor;
      win.setCursor([line, col]);
      workspace.showMessage([line, col].join(","));
    }
    test();
  });
  nvim.command("nmap gs <Plug>(coc-storeCursor)");
}
```