### PR TITLE
fix(outline): adds uri to location if it's undefined.

### DIFF
--- a/src/list/source/outline.ts
+++ b/src/list/source/outline.ts
@@ -56,6 +56,9 @@ export default class Outline extends LocationList {
       for (let s of symbols as SymbolInformation[]) {
         let kind = getSymbolKind(s.kind)
         if (s.name.endsWith(') callback')) continue
+        if (s.location.uri === undefined) {
+            s.location.uri = document.uri
+        }
         items.push({
           label: `${s.name} [${kind}] ${s.location.range.start.line + 1}`,
           filterText: `${s.name}`,


### PR DESCRIPTION
Vetur lsp server doesn't provide uri for 'stylus' locations.
I think it should be fixed on the server's side, but in order to not break user's experience because of missing uri in Location, we can restore uri on client's side.