### PR TITLE
Link CocFloating to NormalFloat in neovim

### DIFF
--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -259,8 +259,13 @@ hi default link CocInfoHighlight    CocUnderline
 hi default link CocHintHighlight    CocUnderline
 hi default link CocListMode ModeMsg
 hi default link CocListPath Comment
-hi default link CocFloating Pmenu
 hi default link CocHighlightText  CursorColumn
+if has('nvim')
+  hi default link CocFloating NormalFloat
+else
+  hi default link CocFloating Pmenu
+endif
+
 
 hi default link CocHoverRange     Search
 hi default link CocCursorRange    Search


### PR DESCRIPTION
#1276 
I have made changes to `CocFloating` highlight only for neovim, because i believe that vim doesn't have `NormalFloat` highlight group.