### PR TITLE
Fixes the usage of documentChanges

### DIFF
--- a/src/handler/refactor.ts
+++ b/src/handler/refactor.ts
@@ -578,8 +578,8 @@ export default class Refactor {
     let res: FileItem[] = []
     let { beforeContext, afterContext } = this.config
     let { changes, documentChanges } = edit
-    changes = changes || {}
     if (!changes) {
+      changes = {}
       for (let change of documentChanges || []) {
         if (TextDocumentEdit.is(change)) {
           let { textDocument, edits } = change


### PR DESCRIPTION
This PR fixes the usage of `documentChanges`. Previously `if (!changes)` could never be true because right in the line before `changes` is initialized with `{}` as a fallback.

This - at least for me - broke the php language server.