### PR TITLE
feat(diagnostic): classify ALE items by their source

### DIFF
--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -570,19 +570,28 @@ export class DiagnosticManager implements Disposable {
         if (level) {
           diagnostics = diagnostics.filter(o => o.severity && o.severity <= level)
         }
-        let aleItems = diagnostics.map(o => {
-          let { range } = o
-          return {
-            text: o.message,
-            code: o.code,
+        let sourceItemsMap = diagnostics.reduce((prev, cur) => {
+          let { range } = cur
+          let items = prev.get(cur.source)
+          if (!items) {
+            items = []
+          }
+          items.push({
+            text: cur.message,
+            code: cur.code,
             lnum: range.start.line + 1,
             col: range.start.character + 1,
             end_lnum: range.end.line + 1,
             end_col: range.end.character,
-            type: getSeverityType(o.severity)
-          }
-        })
-        nvim.call('ale#other_source#ShowResults', [buf.bufnr, collection.name, aleItems], true)
+            type: getSeverityType(cur.severity)
+          })
+          prev.set(cur.source, items)
+          return prev
+        }, new Map())
+        for (let sourceItems of sourceItemsMap) {
+          let [source, items] = sourceItems
+          nvim.call('ale#other_source#ShowResults', [buf.bufnr, source, items], true)
+        }
       }
       nvim.resumeNotification(false, true).logError()
     }


### PR DESCRIPTION
With coc-python extension, pylint and flake8 enabled and `displayByAle` is on, say we have this file:
``` python
def foo():
    print('foo')

def bar():
    print('bar')


var = baz
```

Then there are error messages:
```
test.py|4 col 1 error| [python] E302: expected 2 blank lines, found 1
test.py|8 col 7 error| [python] F821: undefined name 'baz'
test.py|8 col 7 error| [python] E0602: Undefined variable 'baz' (undefined-variable)
```

Note that they all have `[python]` header. This patch changes this to:
```
test.py|4 col 1 error| [flake8] E302: expected 2 blank lines, found 1
test.py|8 col 7 error| [flake8] F821: undefined name 'baz'
test.py|8 col 7 error| [pylint] E0602: Undefined variable 'baz' (undefined-variable)
```
And this behavior is more similar to ALE's one.