### PR TITLE
Fix typo in coc-range-select-backward

### DIFF
--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -344,7 +344,7 @@ call s:Enable()
 call s:AddAnsiGroups()
 
 vnoremap <Plug>(coc-range-select)          :<C-u>call       CocAction('rangeSelect',     visualmode(), v:true)<CR>
-vnoremap <Plug>(coc-range-select-backword) :<C-u>call       CocAction('rangeSelect',     visualmode(), v:false)<CR>
+vnoremap <Plug>(coc-range-select-backward) :<C-u>call       CocAction('rangeSelect',     visualmode(), v:false)<CR>
 nnoremap <Plug>(coc-range-select)          :<C-u>call       CocAction('rangeSelect',     '', v:true)<CR>
 nnoremap <Plug>(coc-codelens-action)       :<C-u>call       CocActionAsync('codeLensAction')<CR>
 vnoremap <Plug>(coc-format-selected)       :<C-u>call       CocActionAsync('formatSelected',     visualmode())<CR>


### PR DESCRIPTION
Found a typo in the `coc-range-select-backward` definition. Note the doc contains the correct spelling: https://github.com/neoclide/coc.nvim/blob/77695b071afc78bfa4eea322b746c0ec308f221a/doc/coc.txt#L774

Thanks for the great software.