### PR TITLE
fix(on_enter): document not synced when using VIM

### DIFF
--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -146,6 +146,7 @@ export default class Handler {
         let line = (await nvim.call('line', '.') as number) - 1
         let doc = workspace.getDocument(bufnr)
         if (!doc) return
+        await doc.checkDocument()
         let pre = doc.getline(line - 1)
         let curr = doc.getline(line)
         let prevChar = pre[pre.length - 1]


### PR DESCRIPTION
This fixes #1372 

on_enter not working correctly when using VIM