### PR TITLE
Add basic tagfunc support using current location

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -343,6 +343,8 @@ export default class Plugin extends EventEmitter {
           break
         case 'diagnosticList':
           return diagnosticManager.getDiagnosticList()
+        case 'getTagFuncLocations':
+          return await handler.getTagFuncLocations(args[1], args[2], args[3])
         case 'jumpDefinition':
           return await handler.gotoDefinition(args[1])
         case 'jumpDeclaration':


### PR DESCRIPTION
(Just a draft for now)

Long time user, first time contributor. I'm fine with JS/TS but only so-so in terms of VimL and I'm not familiar with the codebase at all so I welcome any and all direct feedback.

This attempts to address part of https://github.com/neoclide/coc.nvim/issues/1054

I went the route of putting as much logic in the JS code as possible. With something as simple as:
```viml
function! CocTagFunc(pattern, flags, info)
  return CocAction('getTagFuncLocations', a:pattern, a:flags, a:info)
endfunction
set tagfunc=CocTagFunc
```

 `^]` seemed to work (and `^T`!)

As you can tell, this does not (yet) support arbitrary `:tags` with no cursor location or completion using `^X^]` but I am more than willing to work on that with a few pointers/feedback on the existing approach.