### PR TITLE
fix(workspace): fix error line number under duplicate call with count prefix

### DIFF
--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -127,8 +127,7 @@ export function isRunning(pid: number): boolean {
 }
 
 export function getKeymapModifier(mode: MapMode): string {
-  if (mode == 'o' || mode == 'x' || mode == 'v') return '<C-U>'
-  if (mode == 'n') return ''
+  if (mode == 'n' || mode == 'o' || mode == 'x' || mode == 'v') return '<C-U>'
   if (mode == 'i') return '<C-o>'
   if (mode == 's') return '<Esc>'
   return ''

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1139,7 +1139,8 @@ export class Workspace implements IWorkspace {
     let id = uuid()
     let { nvim } = this
     this.keymaps.set(id, [fn, false])
-    nvim.command(`${mode}noremap <silent><nowait><buffer> ${key} :<c-u>call coc#rpc#${notify ? 'notify' : 'request'}('doKeymap', ['${id}'])<CR>`, true)
+    let modify = getKeymapModifier(mode)
+    nvim.command(`${mode}noremap <silent><nowait><buffer> ${key} :${modify}call coc#rpc#${notify ? 'notify' : 'request'}('doKeymap', ['${id}'])<CR>`, true)
     return Disposable.create(() => {
       this.keymaps.delete(id)
       nvim.command(`${mode}unmap <buffer> ${key}`, true)


### PR DESCRIPTION
### Example
```typescript
import { workspace } from "coc.nvim";

export async function activate() {
  const { nvim } = workspace;
  workspace.registerKeymap(["n", "v"], "echoline", async () => {
    const [line, count] = (await nvim.eval("[line('.'), v:count]")) as [
      number,
      number
    ];
    workspace.showMessage(`line: ${line}, count: ${count}`);
  });
  nvim.command("map gl <Plug>(coc-echoline)");
}
```

### Steps:
1. Open buffer
2. type `3gl`

### Output
Before patch:
```
[coc.nvim] line: 1, count: 3
[coc.nvim] line: 2, count: 3  -> When I was on the second call, I can't get the correct line number
[coc.nvim] line: 3, count: 3
```

After patch:
```
[coc.nvim] line: 1, count: 3
```


### Related

https://github.com/weirongxu/coc-explorer/issues/56