### PR TITLE
change util function to be more explicit and also extendable

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -329,16 +329,18 @@ function! coc#util#on_error(msg) abort
   echohl Error | echom '[coc.nvim] '.a:msg | echohl None
 endfunction
 
-function! coc#util#preview_info(info, ...) abort
-  let filetype = get(a:, 1, 'markdown')
+function! coc#util#preview_info(info, filetype, ...) abort
   pclose
   keepalt new +setlocal\ previewwindow|setlocal\ buftype=nofile|setlocal\ noswapfile|setlocal\ wrap [Document]
   setl bufhidden=wipe
   setl nobuflisted
   setl nospell
-  exe 'setl filetype='.filetype
+  exe 'setl filetype='.a:filetype
   setl conceallevel=2
   setl nofoldenable
+  for command in a:000
+    execute command
+  endfor
   let lines = a:info
   call append(0, lines)
   exe "normal! z" . len(lines) . "\<cr>"


### PR DESCRIPTION
I came across this when working on a feature for [coc-metals](https://github.com/ckipp01/coc-metals) where I wanted a quick way to pass some text to a temporary preview window, and then just throw it away.

<img width="1679" alt="Screenshot 2019-12-23 at 21 46 21" src="https://user-images.githubusercontent.com/13974112/71379952-b3020980-25cd-11ea-81f2-a80ac31d346e.png">

I found `coc#util#preview_info` to be exactly what I needed, but I just wanted a couple of other things to be set. For example, I wanted a `setl nonumber` to also be set. I played around with just making another call to do this when I realized that `coc#util#preview_info` is only used twice in the code base, and each time the `filetype` is passed in, so there is really no need for it to be a varargs. So if we just make filetype explicit, and then make the varargs a list of commands that we want to be executed, it will allow for the function to be used with some additional setting passed in. I know this would work perfectly for me.

If there would be a different way to accomplish what I'm trying to do, please let me know. If not, I think this is a good option to be more explicit with filetype, and then also allow for more extensibility for others that want to reuses this function.

For example, now I can use this like so `workspace.nvim.call('coc#util#preview_info', [<lines to display>, 'text', 'setl nonumber', 'setl nowrap'], true)`. It won't affect they way it's currently being used at all.
