### PR TITLE
fix(workspace) improved lsp rootPatterns handling

### DIFF
--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1657,6 +1657,7 @@ augroup end`
         patterns.push(...rootPatterns)
       }
     }
+    if (patterns.length) return distinct(patterns)
     patterns = patterns.concat(this.rootPatterns.get(filetype) || [])
     return patterns.length ? distinct(patterns) : null
   }


### PR DESCRIPTION
**Update:**
- After a bit more thinking I realized the Set is not needed and I have brought this pull request back to one line :)
- Tried to clarify the issue this pull request solves

When root patterns are defined in lsp configuration like:

```
"vue": {
  "command": "vls",
  "filetypes": ["vue"],
  "rootPatterns": ["vue.config.js"]
}
```

They will still be merged with root patterns from the language server extension, so instead of looking for ['vue.config.js'] which you would expect, coc will look for ['package.json', 'vue.config.js'] 

package.json is coming coc-vetur's package.json's root patterns:
```
contributes": {        
 rootPatterns: [       
   {                   
     filetype: vue,    
     patterns: [       
       package.json,   
       vue.config.js   
     ]                 
   }                   
 ],    
```                

Let me try to clarify this with an example:

Project structure:
  ./project/package.json
  ./project/packages/frontend/package.json
  ./project/packages/frontend/vue.config.js
  ./project/packages/frontend/src/App.vue

old situation (before this patch):
- Open ./project/packages/frontend/src/App.vue
- Coc.nvim will determine root Patterns as: ['package.json', 'vue.config.js']
- Coc.nvim will try to resolve workspace folder and will match:
  **./project** since it starts scanning from bottom up and package.json
  is still in the root patterns

new situation (after this patch):
- Open ./project/packages/frontend/src/App.vue
- Coc.nvim will determine root Patterns as['vue.config.js']
- Coc.nvim will try to resolve workspace folder and will now match:
  **./project/packages/frontend** since it starts scanning from bottom up and package.json
  is not defined in the root patterns anymore