### PR TITLE
CocCurrentWorkspacePath returns workspace path

### DIFF
--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -13,10 +13,6 @@ if get(g:, 'coc_start_at_startup', 1) && !s:is_gvim
   call coc#rpc#start_server()
 endif
 
-function! CocCurrentWorkspacePath()
-  return coc#rpc#request('currentWorkspacePath',[])
-endfunction
-
 function! CocAction(...) abort
   return coc#rpc#request('CocAction', a:000)
 endfunction

--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -13,6 +13,10 @@ if get(g:, 'coc_start_at_startup', 1) && !s:is_gvim
   call coc#rpc#start_server()
 endif
 
+function! CocCurrentWorkspacePath()
+  return coc#rpc#request('currentWorkspacePath',[])
+endfunction
+
 function! CocAction(...) abort
   return coc#rpc#request('CocAction', a:000)
 endfunction

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -46,6 +46,9 @@ export default class Plugin extends EventEmitter {
     this.addMethod('codeActionRange', (start, end, only) => {
       return this.handler.codeActionRange(start, end, only)
     })
+    this.addMethod('currentWorkspacePath', () => {
+        return workspace.rootPath
+    })
     this.addMethod('rootPatterns', bufnr => {
       let doc = workspace.getDocument(bufnr)
       if (!doc) return null

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -417,6 +417,8 @@ export default class Plugin extends EventEmitter {
           return await handler.getWordEdit()
         case 'addRanges':
           return await this.cursors.addRanges(args[1])
+        case 'currentWorkspacePath':
+         return workspace.rootPath 
         default:
           workspace.showMessage(`unknown action ${args[0]}`, 'error')
       }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -46,9 +46,6 @@ export default class Plugin extends EventEmitter {
     this.addMethod('codeActionRange', (start, end, only) => {
       return this.handler.codeActionRange(start, end, only)
     })
-    this.addMethod('currentWorkspacePath', () => {
-        return workspace.rootPath
-    })
     this.addMethod('rootPatterns', bufnr => {
       let doc = workspace.getDocument(bufnr)
       if (!doc) return null

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -418,7 +418,7 @@ export default class Plugin extends EventEmitter {
         case 'addRanges':
           return await this.cursors.addRanges(args[1])
         case 'currentWorkspacePath':
-         return workspace.rootPath 
+         return workspace.rootPath
         default:
           workspace.showMessage(`unknown action ${args[0]}`, 'error')
       }


### PR DESCRIPTION
I think it's valuable to have a function to easily return the current buffer workspace path.

This makes it easier to make mappings to run/build projects by reusing functionality Coc already has.