### PR TITLE
feat(workspace): rm .vim from default rootPatterns

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -816,7 +816,7 @@
     },
     "coc.preferences.rootPatterns": {
       "type": "array",
-      "default": [".vim", ".git", ".hg", ".projections.json"],
+      "default": [".git", ".hg", ".projections.json"],
       "description": "Root patterns to resolve workspaceFolder from parent folders of opened files, resolved from up to down.",
       "items": {
         "type": "string"

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -533,7 +533,7 @@ Builtin configurations:~
 
 	Root patterns to resolve workspaceFolder from parent folders of opened
 	files, resolved from up to down.,  default:
-	`[".vim",".git",".hg",".projections.json"]`
+	`[".git",".hg",".projections.json"]`
 
 "coc.preferences.watchmanPath":~
 

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1489,7 +1489,7 @@ augroup end`
     if (patternType == PatternType.Buffer) return document.getVar('root_patterns', []) || []
     if (patternType == PatternType.LanguageServer) return this.getServerRootPatterns(document.filetype)
     const preferences = this.getConfiguration('coc.preferences', uri)
-    return preferences.get<string[]>('rootPatterns', ['.vim', '.git', '.hg', '.projections.json']).slice()
+    return preferences.get<string[]>('rootPatterns', ['.git', '.hg', '.projections.json']).slice()
   }
 
   public async renameCurrent(): Promise<void> {


### PR DESCRIPTION
`.vim` folder is always in $HOME, used as default pattern will always resolved `$HOME` to rootPath