### PR TITLE
Add a check if a file exists before attempting to read it

### DIFF
--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -130,6 +130,9 @@ export function getFileLineCount(filepath: string): Promise<number> {
 }
 
 export function readFileLines(fullpath: string, start: number, end: number): Promise<string[]> {
+  if (!fs.existsSync(fullpath)) {
+    return Promise.reject(new Error(`file does not exist: ${fullpath}`));
+  }
   let res: string[] = []
   const rl = readline.createInterface({
     input: fs.createReadStream(fullpath, { encoding: 'utf8' }),
@@ -159,6 +162,9 @@ export function readFileLines(fullpath: string, start: number, end: number): Pro
 }
 
 export function readFileLine(fullpath: string, count: number): Promise<string> {
+  if (!fs.existsSync(fullpath)) {
+    return Promise.reject(new Error(`file does not exist: ${fullpath}`));
+  }
   const rl = readline.createInterface({
     input: fs.createReadStream(fullpath, { encoding: 'utf8' }),
     crlfDelay: Infinity,

--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -131,7 +131,7 @@ export function getFileLineCount(filepath: string): Promise<number> {
 
 export function readFileLines(fullpath: string, start: number, end: number): Promise<string[]> {
   if (!fs.existsSync(fullpath)) {
-    return Promise.reject(new Error(`file does not exist: ${fullpath}`));
+    return Promise.reject(new Error(`file does not exist: ${fullpath}`))
   }
   let res: string[] = []
   const rl = readline.createInterface({
@@ -163,7 +163,7 @@ export function readFileLines(fullpath: string, start: number, end: number): Pro
 
 export function readFileLine(fullpath: string, count: number): Promise<string> {
   if (!fs.existsSync(fullpath)) {
-    return Promise.reject(new Error(`file does not exist: ${fullpath}`));
+    return Promise.reject(new Error(`file does not exist: ${fullpath}`))
   }
   const rl = readline.createInterface({
     input: fs.createReadStream(fullpath, { encoding: 'utf8' }),


### PR DESCRIPTION
Part of the implementation of yarn's new PnP feature (https://yarnpkg.com/en/docs/pnp/getting-started) is that project dependencies are stored in .zip archives. When coc-nvim tries to read one of those files (for example, during a "goto definition" jump), the `createReadStream` function throws an exception which currently causes Vim to hang completely.

With this change, coc-nvim checks if the file exists before attempting to read it, preventing the thrown exception and preventing Vim from hanging when jumping to a definition located in a PnP module.

There is still an error visible in the UI (the "file does not exist: ...." error), but in this case it doesn't hang the UI completely