### PR TITLE
Do not set foldcolumn for lists

### DIFF
--- a/autoload/coc/list.vim
+++ b/autoload/coc/list.vim
@@ -202,7 +202,6 @@ function! coc#list#create(position, height, name, numberSelect)
     setl number
   else
     setl nonumber
-    setl foldcolumn=2
   endif
   return [bufnr('%'), win_getid()]
 endfunction


### PR DESCRIPTION
Foldcolumn wont get highlighted for the selected line, which looks "ugly". Is having the same indentation as with "number-select" so important? Because a "number-select" list and a normal list are never at the same time visible.