### PR TITLE
feat(handler): formatOnTypeFiletypes support

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -853,6 +853,14 @@
       "description": "Set to true to enable format on type",
       "default": false
     },
+    "coc.preferences.formatOnTypeFiletypes": {
+      "type": "array",
+      "default": [],
+      "description": "Filetypes that should run format on typing. Only take effect when `coc.preferences.formatOnType` set `true`",
+      "items": {
+        "type": "string"
+      }
+    },
     "coc.preferences.highlightTimeout": {
       "type": "integer",
       "default": 500,

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -564,6 +564,12 @@ Builtin configurations:~
 
 	Set to true to enable format on type,  default: `false`
 
+"coc.preferences.formatOnTypeFiletypes":~
+
+	Filetypes that should run format on typing,  default: `[]`
+
+	Note: only take effect when `coc.preferences.formatOnType` set `true`
+
 "coc.preferences.snippets.enable":~
 
 	Set to false to disable snippets support.,  default: `true`

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -63,6 +63,7 @@ interface Preferences {
   triggerSignatureHelp: boolean
   triggerSignatureWait: number
   formatOnType: boolean
+  formatOnTypeFiletypes: string[]
   formatOnInsertLeave: boolean
   hoverTarget: string
   previewAutoClose: boolean
@@ -803,6 +804,11 @@ export default class Handler {
     let doc = workspace.getDocument(bufnr)
     if (!doc || doc.paused) return
     if (!languages.hasOnTypeProvider(ch, doc.textDocument)) return
+    const filetypes = this.preferences.formatOnTypeFiletypes
+    if (filetypes.length && !filetypes.includes(doc.filetype)) {
+      // Only check formatOnTypeFiletypes when set, avoid breaking change
+      return
+    }
     let position = await workspace.getCursorPosition()
     let origLine = doc.getline(position.line)
     let { changedtick, dirty } = doc
@@ -1211,6 +1217,7 @@ export default class Handler {
       signatureFloatMaxWidth: signatureConfig.get<number>('floatMaxWidth', 80),
       signatureHideOnChange: signatureConfig.get<boolean>('hideOnTextChange', false),
       formatOnType: config.get<boolean>('formatOnType', false),
+      formatOnTypeFiletypes: config.get('formatOnTypeFiletypes', []),
       formatOnInsertLeave: config.get<boolean>('formatOnInsertLeave', false),
       bracketEnterImprove: config.get<boolean>('bracketEnterImprove', true),
       previewAutoClose: config.get<boolean>('previewAutoClose', false),


### PR DESCRIPTION
This will only take effect when `coc.preferences.formatOnType` is `true`, and will only check this setting when not empty, in order to avoid breaking change.

close #1472 
