### PR TITLE
Fix "coc.source.*.disableSyntaxes" not working

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -406,9 +406,6 @@ function! coc#util#get_complete_option()
     return
   endif
   let synname = synIDattr(synID(pos[1], l:start, 1),"name")
-  if !synname
-    let synname = ''
-  endif
   return {
         \ 'word': matchstr(line[l:start : ], '^\k\+'),
         \ 'input': input,


### PR DESCRIPTION
I set `"coc.source.{buffer,around}.disableSyntaxes"` to suppress unwanted completion, but it doesn't seem to working.

I found it is because here the conditional expression `!synname` is nonsense, since Vim script converts `synname` from string to number before the `!` operation. (`:help expr7`)
`synIDattr()` seems to return empty string if no info was found, so the three lines can simply be removed.

neoclide/coc-sources#21 may be related.