### PR TITLE
Added option to include the kind in filtering the outline

### DIFF
--- a/src/list/source/outline.ts
+++ b/src/list/source/outline.ts
@@ -19,7 +19,7 @@ function getFilterText(s: DocumentSymbol | SymbolInformation, args: {[key: strin
         result += ` ${kind}`
     }
 
-    return result;
+    return result
 }
 
 export default class Outline extends LocationList {


### PR DESCRIPTION
The outline coc list is not quite that useful (at least for me) if I cannot filter also by kind. 

What I want to do is this:

`CocList --normal --no-sort --input=Method outline -kind` and see only the methods form the current file, which in a lot of cases will be the current class. 

Then I can even press `i` and add a method name in input (for example `Method doHighlight`) and find my method.

The issue for me is that sometimes I don't know the method name, so I want to have a class outline. Hope this clarifies. 

The option by default is false, which means that the behavior is the current one. 