### PR TITLE
feat(snippets): fix multiple lines variable indent

### DIFF
--- a/src/snippets/parser.ts
+++ b/src/snippets/parser.ts
@@ -455,8 +455,13 @@ export class Variable extends TransformableMarker {
       if (previous && previous instanceof Text) {
         let ms = previous.value.match(/\n([ \t]*)$/)
         if (ms) {
-          let newLines = value.split('\n').map((s, i) => {
-            return i == 0 ? s : ms[1] + s.replace(/^\s*/, '')
+          let lines = value.split('\n')
+          let indents = lines.filter(s => s.length > 0).map(s => s.match(/^\s*/)[0])
+          let minIndent = indents.length == 0 ? '' :
+            indents.reduce((p, c) => p.length < c.length ? p : c)
+          let newLines = lines.map((s, i) => {
+            return i == 0 || s.length == 0 || !s.startsWith(minIndent) ? s :
+              ms[1] + s.slice(minIndent.length)
           })
           value = newLines.join('\n')
         }


### PR DESCRIPTION
- Keep inner indent of variables
- Keep empty line empty

Still known issues:
- If first line is empty, it will still be indented
- Mixing tab and space may cause unexpected result

For example, suppose we have a snippet
```ultisnips
snippet forever "forever loop"
while (true) {
	${VISUAL}
}
endsnippet
```
and code
```c
int main() {
    if (cond) {
        // aa

        // bb
    }
    return 0;
}
```
Now we select the `if` statement and expand the snippet (with coc-snippets), with current implement, we would get
```c
int main() {
    while (true) {
        if (cond) {
        // aa
        
        // bb
        }
    }
    return 0;
}
```
but what we want is
```c
int main() {
    while (true) {
        if (cond) {
            // aa

            // bb
        }
    }
    return 0;
}
```