### PR TITLE
adding number highlighting

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -545,6 +545,11 @@
       "default": true,
       "description": "Enable signs for diagnostics."
     },
+    "diagnostic.enableHiglightLineNumber": {
+      "type": "boolean",
+      "default": true,
+      "description": "Enable higlighting line numbers for diagnostics."
+    },
     "diagnostic.enableMessage": {
       "type": "string",
       "default": "always",

--- a/data/schema.json
+++ b/data/schema.json
@@ -545,10 +545,10 @@
       "default": true,
       "description": "Enable signs for diagnostics."
     },
-    "diagnostic.enableHiglightLineNumber": {
+    "diagnostic.enableHighlightLineNumber": {
       "type": "boolean",
       "default": true,
-      "description": "Enable higlighting line numbers for diagnostics."
+      "description": "Enable highlighting line numbers for diagnostics."
     },
     "diagnostic.enableMessage": {
       "type": "string",

--- a/src/__tests__/modules/diagnosticBuffer.test.ts
+++ b/src/__tests__/modules/diagnosticBuffer.test.ts
@@ -10,6 +10,7 @@ const config: DiagnosticConfig = {
   joinMessageLines: false,
   checkCurrentLine: false,
   enableSign: true,
+  enableHighlightLineNumber: true,
   maxWindowHeight: 8,
   maxWindowWidth: 80,
   enableMessage: 'always',

--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -139,8 +139,8 @@ export class DiagnosticManager implements Disposable {
     }, null, this.disposables)
     let { errorSign, warningSign, infoSign, hintSign } = this.config
     nvim.pauseNotification()
-    nvim.command(`sign define CocError   text=${errorSign}   linehl=CocErrorLine texthl=CocErrorSign`, true)
-    nvim.command(`sign define CocWarning text=${warningSign} linehl=CocWarningLine texthl=CocWarningSign`, true)
+    nvim.command(`sign define CocError   text=${errorSign}   linehl=CocErrorLine texthl=CocErrorSign numhl=CocErrorSign`, true)
+    nvim.command(`sign define CocWarning text=${warningSign} linehl=CocWarningLine texthl=CocWarningSign numhl=CocWarningSign`, true)
     nvim.command(`sign define CocInfo    text=${infoSign}    linehl=CocInfoLine  texthl=CocInfoSign`, true)
     nvim.command(`sign define CocHint    text=${hintSign}    linehl=CocHintLine  texthl=CocHintSign`, true)
     if (this.config.virtualText && workspace.isNvim) {

--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -15,6 +15,7 @@ const logger = require('../util/logger')('diagnostic-manager')
 
 export interface DiagnosticConfig {
   enableSign: boolean
+  enableHighlightLineNumber: boolean
   checkCurrentLine: boolean
   enableMessage: string
   virtualText: boolean
@@ -139,8 +140,14 @@ export class DiagnosticManager implements Disposable {
     }, null, this.disposables)
     let { errorSign, warningSign, infoSign, hintSign } = this.config
     nvim.pauseNotification()
-    nvim.command(`sign define CocError   text=${errorSign}   linehl=CocErrorLine texthl=CocErrorSign numhl=CocErrorSign`, true)
-    nvim.command(`sign define CocWarning text=${warningSign} linehl=CocWarningLine texthl=CocWarningSign numhl=CocWarningSign`, true)
+    let nvimCocErrorSign = `sign define CocError   text=${errorSign}   linehl=CocErrorLine texthl=CocErrorSign`;
+    let nvimCocWarningSign = `sign define CocWarning text=${warningSign} linehl=CocWarningLine texthl=CocWarningSign`;
+    if (this.config.enableHighlightLineNumber) {
+      nvimCocErrorSign += ' numhl=CocErrorSign';
+      nvimCocWarningSign += ' numhl=CocWarningSign';
+    }
+    nvim.command(nvimCocErrorSign);
+    nvim.command(nvimCocWarningSign);
     nvim.command(`sign define CocInfo    text=${infoSign}    linehl=CocInfoLine  texthl=CocInfoSign`, true)
     nvim.command(`sign define CocHint    text=${hintSign}    linehl=CocHintLine  texthl=CocHintSign`, true)
     if (this.config.virtualText && workspace.isNvim) {
@@ -529,6 +536,7 @@ export class DiagnosticManager implements Disposable {
       virtualTextSrcId: workspace.createNameSpace('diagnostic-virtualText'),
       checkCurrentLine: getConfig<boolean>('checkCurrentLine', false),
       enableSign: getConfig<boolean>('enableSign', true),
+      enableHighlightLineNumber: getConfig<boolean>('enableHighlightLineNumber', true),
       maxWindowHeight: getConfig<number>('maxWindowHeight', 10),
       maxWindowWidth: getConfig<number>('maxWindowWidth', 80),
       enableMessage: getConfig<string>('enableMessage', 'always'),

--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -146,8 +146,8 @@ export class DiagnosticManager implements Disposable {
       nvimCocErrorSign += ' numhl=CocErrorSign'
       nvimCocWarningSign += ' numhl=CocWarningSign'
     }
-    nvim.command(nvimCocErrorSign)
-    nvim.command(nvimCocWarningSign)
+    nvim.command(nvimCocErrorSign, true)
+    nvim.command(nvimCocWarningSign, true)
     nvim.command(`sign define CocInfo    text=${infoSign}    linehl=CocInfoLine  texthl=CocInfoSign`, true)
     nvim.command(`sign define CocHint    text=${hintSign}    linehl=CocHintLine  texthl=CocHintSign`, true)
     if (this.config.virtualText && workspace.isNvim) {

--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -140,14 +140,14 @@ export class DiagnosticManager implements Disposable {
     }, null, this.disposables)
     let { errorSign, warningSign, infoSign, hintSign } = this.config
     nvim.pauseNotification()
-    let nvimCocErrorSign = `sign define CocError   text=${errorSign}   linehl=CocErrorLine texthl=CocErrorSign`;
-    let nvimCocWarningSign = `sign define CocWarning text=${warningSign} linehl=CocWarningLine texthl=CocWarningSign`;
+    let nvimCocErrorSign = `sign define CocError   text=${errorSign}   linehl=CocErrorLine texthl=CocErrorSign`
+    let nvimCocWarningSign = `sign define CocWarning text=${warningSign} linehl=CocWarningLine texthl=CocWarningSign`
     if (this.config.enableHighlightLineNumber) {
-      nvimCocErrorSign += ' numhl=CocErrorSign';
-      nvimCocWarningSign += ' numhl=CocWarningSign';
+      nvimCocErrorSign += ' numhl=CocErrorSign'
+      nvimCocWarningSign += ' numhl=CocWarningSign'
     }
-    nvim.command(nvimCocErrorSign);
-    nvim.command(nvimCocWarningSign);
+    nvim.command(nvimCocErrorSign)
+    nvim.command(nvimCocWarningSign)
     nvim.command(`sign define CocInfo    text=${infoSign}    linehl=CocInfoLine  texthl=CocInfoSign`, true)
     nvim.command(`sign define CocHint    text=${hintSign}    linehl=CocHintLine  texthl=CocHintSign`, true)
     if (this.config.virtualText && workspace.isNvim) {


### PR DESCRIPTION
Highlights numbers with the same style as the previous signs; this eliminates the need for the signcolumn if you don't want it, i.e. numbers are red for errors and yellow/brown for warnings.