### PR TITLE
fix object not extensible error when supplying env as part of LSP config

### DIFF
--- a/src/language-client/index.ts
+++ b/src/language-client/index.ts
@@ -426,7 +426,7 @@ export class LanguageClient extends BaseLanguageClient {
       let command: Executable = json as Executable
       let args = command.args || []
       let options = Object.assign({}, command.options)
-      options.env = options.env ? Object.assign(options.env, process.env) : process.env
+      options.env = options.env ? Object.assign({}, options.env, process.env) : process.env
       options.cwd = options.cwd || serverWorkingDir
       let cmd = json.command
       if (cmd.startsWith('~')) {


### PR DESCRIPTION
I tried setting some custom environment for my LSP using the following config:
```js
  "languageserver": {
    "golang": {
      "command": "gopls",
      "rootPatterns": ["go.mod"],
      "filetypes": ["go"],
      "env": {
        "GOFLAGS": "-tags=endtoend"
      }
    }
  }
```

However the language server fails to start as `options.env` is not extensible.

Output from CocInfo:
```
## versions

vim version: NVIM v0.4.3
node version: v13.5.0
coc.nvim version: 0.0.74-6700e7468d
term: screen-256color
platform: linux

## Messages
[coc.nvim] Server golang failed to start: Cannot add property AP, object is not extensible
## Output channel: languageserver.golang

[Error  - 3:58:46 pm] Starting client failed:
TypeError: Cannot add property AP, object is not extensible
    at Function.assign (<anonymous>)
    at LanguageClient.createMessageTransports (/home/brendan/.local/share/nvim/plugged/coc.nvim/build/index.js:54315:48)
```

The proposed change fixes this issue.
