### PR TITLE
fix(extensions): add console.debug to extension sandbox

### DIFF
--- a/src/util/factory.ts
+++ b/src/util/factory.ts
@@ -99,6 +99,9 @@ function createSandbox(filename: string, logger: Logger): ISandbox {
     module,
     Buffer,
     console: {
+      debug: (...args: any[]) => {
+        logger.debug.apply(logger, args)
+      },
       log: (...args: any[]) => {
         logger.debug.apply(logger, args)
       },


### PR DESCRIPTION
Fixes: #1540

Some extensions are calling console.debug (for instance coc-metals through metals-languageclient) which is normally available on the NodeJS console object.