### PR TITLE
feat(diagnostic): checkCurrentLine is a fallback behavior

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -486,7 +486,7 @@
     },
     "diagnostic.checkCurrentLine": {
       "type": "boolean",
-      "description": "When enabled, show all diagnostics of current line instead of current position.",
+      "description": "When enabled, show all diagnostics of current line if there are none at the current position.",
       "default": false
     },
     "diagnostic.messageTarget": {

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -292,8 +292,8 @@ Builtin configurations:~
 
 "diagnostic.checkCurrentLine":~
 
-	When enabled, show all diagnostics of current line instead of current
-	position.,  default: `false`
+	When enabled, show all diagnostics of current line if there are none
+	at the current position.,  default: `false`
 
 "diagnostic.messageTarget":~
 

--- a/src/__tests__/modules/diagnosticManager.test.ts
+++ b/src/__tests__/modules/diagnosticManager.test.ts
@@ -122,12 +122,21 @@ describe('diagnostic manager', () => {
   })
 
   it('should get diagnostics under corsor', async () => {
+    let config = workspace.getConfiguration('diagnostic')
     await createDocument()
     let diagnostics = await manager.getCurrentDiagnostics()
     expect(diagnostics.length).toBe(0)
     await nvim.call('cursor', [1, 4])
     diagnostics = await manager.getCurrentDiagnostics()
     expect(diagnostics.length).toBe(1)
+
+    config.update('checkCurrentLine', true)
+    diagnostics = await manager.getCurrentDiagnostics()
+    expect(diagnostics.length).toBe(1) // cursor on a diagnostic
+    await nvim.call('cursor', [1, 2])
+    diagnostics = await manager.getCurrentDiagnostics()
+    expect(diagnostics.length).toBe(2) // cursor not on a specific diagnostic
+    config.update('checkCurrentLine', false)
   })
 
   it('should jump to related position', async () => {

--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -392,10 +392,10 @@ export class DiagnosticManager implements Disposable {
     let buffer = this.buffers.find(o => o.bufnr == bufnr)
     if (!buffer) return []
     let { checkCurrentLine } = this.config
-    let diagnostics = buffer.diagnostics.filter(o => {
-      if (checkCurrentLine) return lineInRange(pos.line, o.range)
-      return positionInRange(pos, o.range) == 0
-    })
+    let diagnostics = buffer.diagnostics.filter(o => positionInRange(pos, o.range) == 0)
+    if (diagnostics.length == 0 && checkCurrentLine) {
+      diagnostics = buffer.diagnostics.filter(o => lineInRange(pos.line, o.range))
+    }
     diagnostics.sort((a, b) => a.severity - b.severity)
     return diagnostics
   }


### PR DESCRIPTION
When checkCurrentLine is enabled but there are diagnostics exactly under the
cursor, only show those. If there are none, show all diagnostics from the line.

That way it's still easy to inspect diagnostics with small ranges, but
it's possible to distinguish when there's several diagnostics on a line.