### PR TITLE
feat(completion) support `score` extension on LSP CompletionItem

### DIFF
--- a/src/__tests__/modules/completion.test.ts
+++ b/src/__tests__/modules/completion.test.ts
@@ -439,6 +439,31 @@ describe('completion TextChangedP', () => {
     expect(items[0].word).toBe('foo#abc')
   })
 
+  it('should use source-provided score', async () => {
+      let source: ISource = {
+          priority: 0,
+          enable: true,
+          name: 'source',
+          sourceType: SourceType.Service,
+          doComplete: (_opt: CompleteOption) : Promise<CompleteResult> => {
+              return Promise.resolve({
+                  items: [
+                      { word: 'candidate_a', score: 0.1 },
+                      { word: 'candidate_b', score: 10 },
+                      { word: 'candidate_c' },
+                  ]
+              })
+          },
+      }
+      disposables.push(sources.addSource(source))
+      await nvim.input('ocand')
+      await helper.waitPopup()
+      let items = await helper.getItems()
+      expect(items[0].word).toBe('candidate_b')
+      expect(items[1].word).toBe('candidate_c')
+      expect(items[2].word).toBe('candidate_a')
+  })
+
   it('should do resolve for complete item', async () => {
     let source: ISource = {
       priority: 0,

--- a/src/completion/complete.ts
+++ b/src/completion/complete.ts
@@ -231,7 +231,7 @@ export default class Complete {
         }
         item.priority = priority
         item.abbr = item.abbr || item.word
-        item.score = input.length ? score : 0
+        item.score = input.length ? score * (item.score || 1) : 0
         item.localBonus = this.localBonus ? this.localBonus.get(filterText) || 0 : 0
         words.add(word)
         if (item.isSnippet && item.word == input) {

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -733,6 +733,7 @@ class Languages {
       abbr: label,
       menu: `[${shortcut}]`,
       kind: complete.completionKindString(item.kind, this.completionItemKindMap, this.completeConfig.defaultKindText),
+      score: item['score'] || null,
       sortText: item.sortText || null,
       filterText: item.filterText || label,
       isSnippet,


### PR DESCRIPTION
Client-side filtering and ranking of LSP results is great for latency,
but can't take into account server-side signals such as popularity,
type-matches-context etc.

This extension lets the server provide a numeric score multiplier.
It's documented here: https://clangd.github.io/extensions.html
clangd implements it at trunk and in the pending 10.0 release.

This is the main blocker for recommending coc.nvim for clangd. (currently we
recommend YCM and just turn all client-side filtering off).
https://github.com/clangd/clangd/issues/284

My attempt to get something like this standardized doesn't seem to be moving:
https://github.com/microsoft/language-server-protocol/issues/348