### PR TITLE
feat(diagnostics): show diagnostic message first, hide severity

### DIFF
--- a/src/__tests__/modules/diagnosticManager.test.ts
+++ b/src/__tests__/modules/diagnosticManager.test.ts
@@ -200,7 +200,7 @@ describe('diagnostic manager', () => {
     let bufnr = await nvim.call('nvim_win_get_buf', winid) as number
     let buf = nvim.createBuffer(bufnr)
     let lines = await buf.lines
-    expect(lines.length).toBe(3)
+    expect(lines).toStrictEqual(['error', '[test]', '———————', 'warning', '[test]'])
     config.update('checkCurrentLine', false)
   })
 

--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -440,11 +440,10 @@ export class DiagnosticManager implements Disposable {
     }
     diagnostics.forEach(diagnostic => {
       let { source, code, severity, message } = diagnostic
-      let s = getSeverityName(severity)[0]
-      let str = `[${source}${code ? ' ' + code : ''}] [${s}] ${message}`
+      let str = `${message}\n[${source}${code ? ': ' + code : ''}]`
       let filetype = 'Error'
       if (ft === '') {
-        switch (diagnostic.severity) {
+        switch (severity) {
           case DiagnosticSeverity.Hint:
             filetype = 'Hint'
             break


### PR DESCRIPTION
This is aimed at improving the clarity/readability of the popups.

There's currently a lot of "tags" displayed before the diagnostic
message in the floating window.

The message is usually the most relevant information, but starts partway
through the line and is often wrapped or truncated. Having to hunt for
this info conflicts with the immediate/contextual nature of the popup.

The severity is almost always redundant: the text is colored and the
gutter signs show the severity too.

Before:
```
[clang ovl_no_viable_function_in_call] [E] No matching function for call to 'foo'
```
![image](https://user-images.githubusercontent.com/548993/74849698-530fb100-5339-11ea-9b10-662e9c48ea42.png)
![image](https://user-images.githubusercontent.com/548993/74849717-59059200-5339-11ea-97b8-4bc692f59ec3.png)

After:
```
No matching function for call to 'foo'
[clang: ovl_no_viable_function_in_call]
```
![image](https://user-images.githubusercontent.com/548993/74849735-5f940980-5339-11ea-9f05-6c0a56bd7464.png)
![image](https://user-images.githubusercontent.com/548993/74849754-63279080-5339-11ea-9b94-513e32826eca.png)

(Personally I'd probably prefer to drop the source information from the
hover version entirely, and keep it for `diagnosticPreview` where
there's more space. But that's a more invasive change!)