### PR TITLE
fix(completion): support allCommitCharacters as fallback for commitCharacters

### DIFF
--- a/src/language-client/client.ts
+++ b/src/language-client/client.ts
@@ -1728,6 +1728,7 @@ class CompletionItemFeature extends TextDocumentFeature<
     options: CompletionRegistrationOptions
   ): Disposable {
     let triggerCharacters = options.triggerCharacters || []
+    let allCommitCharacters = options.allCommitCharacters || []
     let client = this._client
     let provideCompletionItems: ProvideCompletionItemsSignature = (
       document,
@@ -1807,7 +1808,8 @@ class CompletionItemFeature extends TextDocumentFeature<
           }
           : undefined
       },
-      triggerCharacters
+      triggerCharacters,
+      allCommitCharacters
     )
   }
 }

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -190,10 +190,11 @@ class Languages {
     languageIds: string | string[] | null,
     provider: CompletionItemProvider,
     triggerCharacters: string[] = [],
+    allCommitCharacters: string[] = [],
     priority?: number
   ): Disposable {
     languageIds = typeof languageIds == 'string' ? [languageIds] : languageIds
-    let source = this.createCompleteSource(name, shortcut, provider, languageIds, triggerCharacters, priority)
+    let source = this.createCompleteSource(name, shortcut, provider, languageIds, triggerCharacters, allCommitCharacters, priority)
     sources.addSource(source)
     logger.debug('created service source', name)
     return {
@@ -510,6 +511,7 @@ class Languages {
     provider: CompletionItemProvider,
     languageIds: string[] | null,
     triggerCharacters: string[],
+    allCommitCharacters: string[],
     priority?: number
   ): ISource {
     // track them for resolve
@@ -647,11 +649,8 @@ class Languages {
       shouldCommit: (item: VimCompleteItem, character: string): boolean => {
         let completeItem = completeItems[item.index]
         if (!completeItem) return false
-        let { commitCharacters } = completeItem
-        if (commitCharacters && commitCharacters.indexOf(character) !== -1) {
-          return true
-        }
-        return false
+        let commitCharacters = completeItem.commitCharacters || allCommitCharacters
+        return commitCharacters.indexOf(character) !== -1
       }
     }
     return source


### PR DESCRIPTION
LSP says if commitCharacters is not provided for a particular completion option,
CompletionOptions.allCommitCharacters should be used instead.