### PR TITLE
fix(signature): clear old active range highlight in floatBuffer when reusing

### DIFF
--- a/src/model/floatBuffer.ts
+++ b/src/model/floatBuffer.ts
@@ -154,11 +154,7 @@ export default class FloatBuffer {
 
   public setLines(): void {
     let { buffer, lines, nvim, highlights } = this
-    if (this.window) {
-      nvim.call('win_execute', [this.window.id, 'call clearmatches([])'], true)
-    } else {
-      nvim.call('clearmatches', [], true)
-    }
+    nvim.call('clearmatches', this.window ? [this.window.id] : [], true)
     buffer.clearNamespace(-1, 0, -1)
     buffer.setLines(lines, { start: 0, end: -1, strictIndexing: false }, true)
     if (highlights.length) {


### PR DESCRIPTION
Previously the active ranges would "accumulate" as signature help proceeded:

```
int foo(int x, int y, int z);
int a = foo(    // "int x" is shown active
int a = foo(1,  // "int x, int y" is shown active
int a = foo(1,2,// "int x, int y, int z" is shown active
```

This is because the highlight matches weren't being properly cleared.

I'm not sure exactly why win_execute doesn't work, but the fact that the
clearmatches([win]) variant exists hints there's some problem here :-)

Verified bug+fix with vim+nvim and clangd.