### PR TITLE
fixed test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "lint": "tslint -c tslint.json -p .",
     "build": "tsc -p tsconfig.json",
     "watch": "tsc -p tsconfig.json --watch true --sourceMap",
-    "test": "node --trace-warnings node_modules/.bin/jest --runInBand --detectOpenHandles --forceExit",
-    "test-build": "node --trace-warnings node_modules/.bin/jest --runInBand --coverage --forceExit",
+    "test": "node --trace-warnings node_modules/jest/bin/jest.js --runInBand --detectOpenHandles --forceExit",
+    "test-build": "node --trace-warnings node_modules/jest/bin/jest.js --runInBand --coverage --forceExit",
     "prepare": "npm-run-all clean build"
   },
   "repository": {


### PR DESCRIPTION
`node_modules/.bin/jest` is a sh script. Therefore it only runs on *nix systems. When run on Windows, a syntax error is thrown.

I have found a [reference](https://github.com/facebook/jest/issues/3750) to this issue.

The changed scripts have been tested on windows. Although some tests failed, jest was working as expected.