### PR TITLE
fix(completion): add sourceScore for CompletionItem

### DIFF
--- a/src/__tests__/modules/completion.test.ts
+++ b/src/__tests__/modules/completion.test.ts
@@ -448,8 +448,8 @@ describe('completion TextChangedP', () => {
           doComplete: (_opt: CompleteOption) : Promise<CompleteResult> => {
               return Promise.resolve({
                   items: [
-                      { word: 'candidate_a', score: 0.1 },
-                      { word: 'candidate_b', score: 10 },
+                      { word: 'candidate_a', sourceScore: 0.1 },
+                      { word: 'candidate_b', sourceScore: 10 },
                       { word: 'candidate_c' },
                   ]
               })

--- a/src/completion/complete.ts
+++ b/src/completion/complete.ts
@@ -231,7 +231,7 @@ export default class Complete {
         }
         item.priority = priority
         item.abbr = item.abbr || item.word
-        item.score = input.length ? score * (item.score || 1) : 0
+        item.score = input.length ? score * (item.sourceScore || 1) : 0
         item.localBonus = this.localBonus ? this.localBonus.get(filterText) || 0 : 0
         words.add(word)
         if (item.isSnippet && item.word == input) {

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -732,7 +732,7 @@ class Languages {
       abbr: label,
       menu: `[${shortcut}]`,
       kind: complete.completionKindString(item.kind, this.completionItemKindMap, this.completeConfig.defaultKindText),
-      score: item['score'] || null,
+      sourceScore: item['score'] || null,
       sortText: item.sortText || null,
       filterText: item.filterText || label,
       isSnippet,

--- a/src/types.ts
+++ b/src/types.ts
@@ -477,6 +477,7 @@ export interface VimCompleteItem {
   user_data?: string
   // it's not saved by vim, for temporarily usage
   score?: number
+  sourceScore?: number
   sortText?: string
   filterText?: string
   isSnippet?: boolean


### PR DESCRIPTION
PR #1559 adds score from LS to CompletionItem, but coc will compute `item.score` as user types, so we can't use `item.score` to save score from LS.