### PR TITLE
Upgrade to LSP 3.15 and port vscode-languageclient 6.1.1 to language-client

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -88,6 +88,11 @@
           "description": "Configure message level to show the output channel buffer",
           "enum": ["info", "warn", "error", "never"]
         },
+        "progressOnInitialization": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable progress request to languageserver"
+        },
         "initializationOptions": {
           "type": "object",
           "default": {},
@@ -132,6 +137,7 @@
         "filetypes": {},
         "additionalSchemes": {},
         "revealOutputChannelOn": {},
+        "progressOnInitialization": {},
         "initializationOptions": {},
         "settings": {},
         "stdioEncoding": {},
@@ -193,6 +199,7 @@
         "filetypes": {},
         "additionalSchemes": {},
         "revealOutputChannelOn": {},
+        "progressOnInitialization": {},
         "initializationOptions": {},
         "stdioEncoding": {},
         "settings": {},
@@ -241,6 +248,7 @@
         "filetypes": {},
         "additionalSchemes": {},
         "revealOutputChannelOn": {},
+        "progressOnInitialization": {},
         "initializationOptions": {},
         "stdioEncoding": {},
         "settings": {},

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "npm-run-all": "^4.1.5",
     "ts-jest": "^24.2.0",
     "tslint": "^5.19.0",
-    "typescript": "3.6.2",
+    "typescript": "^3.8.2",
     "vscode-languageserver": "5.3.0-next.8"
   },
   "dependencies": {
@@ -91,8 +91,8 @@
     "tslib": "^1.11.0",
     "tunnel": "^0.0.6",
     "uuid": "^3.3.3",
-    "vscode-languageserver-protocol": "3.15.0-next.6",
-    "vscode-languageserver-types": "3.15.0-next.2",
+    "vscode-languageserver-protocol": "^3.15.3",
+    "vscode-languageserver-types": "^3.15.1",
     "vscode-uri": "^2.0.3",
     "which": "^1.3.1"
   }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "ts-jest": "^24.2.0",
     "tslint": "^5.19.0",
     "typescript": "^3.8.2",
-    "vscode-languageserver": "5.3.0-next.8"
+    "vscode-languageserver": "^6.1.1"
   },
   "dependencies": {
     "@chemzqm/neovim": "5.1.9",

--- a/src/__tests__/client/server/testInitializeResult.js
+++ b/src/__tests__/client/server/testInitializeResult.js
@@ -20,7 +20,7 @@ connection.onInitialize((params) => {
   assert.equal(params.capabilities.textDocument.completion.completionItem.preselectSupport, true);
   assert.equal(params.capabilities.textDocument.signatureHelp.signatureInformation.parameterInformation.labelOffsetSupport, true);
   assert.equal(params.capabilities.textDocument.definition.linkSupport, undefined);
-  // assert.equal(params.capabilities.textDocument.declaration.linkSupport, undefined);
+  assert.equal(params.capabilities.textDocument.declaration.linkSupport, undefined);
   assert.equal(params.capabilities.textDocument.implementation.linkSupport, undefined);
   assert.equal(params.capabilities.textDocument.typeDefinition.linkSupport, undefined);
   assert.equal(params.capabilities.textDocument.rename.prepareSupport, true);

--- a/src/cursors/index.ts
+++ b/src/cursors/index.ts
@@ -141,6 +141,7 @@ export default class Cursors {
       if (e.textDocument.uri != doc.uri) return
       if (doc.version - this.version == 1 || !this.ranges.length) return
       let change = e.contentChanges[0]
+      if (!('range' in change)) return
       let { original } = e
       let { text, range } = change
       // ignore change after last range

--- a/src/handler/colors.ts
+++ b/src/handler/colors.ts
@@ -56,7 +56,6 @@ export default class Colors {
       if (workspace.insertMode) return
       let doc = workspace.getDocument(textDocument.uri)
       if (doc && doc.bufnr == workspace.bufnr) {
-        let { range, text } = contentChanges[0]
         await wait(50)
         await this.highlightColors(doc)
       }

--- a/src/handler/refactor.ts
+++ b/src/handler/refactor.ts
@@ -400,6 +400,7 @@ export default class Refactor {
     }
     if (this.changing) return
     let { uri } = e.textDocument
+    if (!('range' in e.contentChanges[0])) return
     let { range, text } = e.contentChanges[0]
     let filepath = URI.parse(uri).fsPath
     let fileItem = this.fileItems.find(o => o.filepath == filepath)
@@ -515,6 +516,7 @@ export default class Refactor {
     let { fileItems } = this
     if (!fileItems.length) return
     let change = e.contentChanges[0]
+    if (!('range' in change)) return
     let { original } = e
     if (change.range.end.line < 2) return
     doc.buffer.setOption('modified', true, true)

--- a/src/language-client/client.ts
+++ b/src/language-client/client.ts
@@ -3545,7 +3545,6 @@ export abstract class BaseLanguageClient {
       workspaceFolders: null
     }
     this.fillInitializeParams(initParams)
-    this._clientOptions.value().progressOnInitialization
     if (this._clientOptions.value().progressOnInitialization) {
       const token: ProgressToken = UUID.generateUuid()
       const part: ProgressPart = new ProgressPart(connection, token)

--- a/src/language-client/client.ts
+++ b/src/language-client/client.ts
@@ -4,29 +4,30 @@
  *--------------------------------------------------------------------------------------------*/
 /*tslint:disable*/
 import path from 'path'
-import { ApplyWorkspaceEditParams, ApplyWorkspaceEditRequest, ApplyWorkspaceEditResponse, CancellationToken, ClientCapabilities, CodeAction, CodeActionContext, CodeActionKind, CodeActionParams, CodeActionRegistrationOptions, CodeActionRequest, CodeLens, CodeLensRegistrationOptions, CodeLensRequest, CodeLensResolveRequest, Command, CompletionContext, CompletionItem, CompletionItemKind, CompletionList, CompletionRegistrationOptions, CompletionRequest, CompletionResolveRequest, createProtocolConnection, Definition, DefinitionRequest, Diagnostic, DidChangeConfigurationNotification, DidChangeConfigurationParams, DidChangeConfigurationRegistrationOptions, DidChangeTextDocumentNotification, DidChangeTextDocumentParams, DidChangeWatchedFilesNotification, DidChangeWatchedFilesParams, DidChangeWatchedFilesRegistrationOptions, DidCloseTextDocumentNotification, DidCloseTextDocumentParams, DidOpenTextDocumentNotification, DidOpenTextDocumentParams, DidSaveTextDocumentNotification, DidSaveTextDocumentParams, Disposable, DocumentFormattingParams, DocumentFormattingRequest, DocumentHighlight, DocumentHighlightRequest, DocumentLink, DocumentLinkRegistrationOptions, DocumentLinkRequest, DocumentLinkResolveRequest, DocumentOnTypeFormattingParams, DocumentOnTypeFormattingRegistrationOptions, DocumentOnTypeFormattingRequest, DocumentRangeFormattingParams, DocumentRangeFormattingRequest, DocumentSelector, DocumentSymbol, DocumentSymbolRequest, Emitter, ErrorCodes, Event, ExecuteCommandParams, ExecuteCommandRegistrationOptions, ExecuteCommandRequest, ExitNotification, FailureHandlingKind, FileChangeType, FileEvent, FormattingOptions, GenericNotificationHandler, GenericRequestHandler, Hover, HoverRequest, InitializedNotification, InitializeError, InitializeParams, InitializeRequest, InitializeResult, Location, Logger, LogMessageNotification, LogMessageParams, MarkupKind, Message, MessageReader, MessageType, MessageWriter, NotificationHandler, NotificationHandler0, NotificationType, NotificationType0, Position, PrepareRenameRequest, PublishDiagnosticsNotification, PublishDiagnosticsParams, Range, ReferencesRequest, RegistrationParams, RegistrationRequest, RenameParams, RenameRegistrationOptions, RenameRequest, RequestHandler, RequestHandler0, RequestType, RequestType0, ResourceOperationKind, ResponseError, RPCMessageType, ServerCapabilities, ShowMessageNotification, ShowMessageParams, ShowMessageRequest, ShutdownRequest, SignatureHelp, SignatureHelpRegistrationOptions, SignatureHelpRequest, SymbolInformation, SymbolKind, TelemetryEventNotification, TextDocument, TextDocumentChangeRegistrationOptions, TextDocumentPositionParams, TextDocumentRegistrationOptions, TextDocumentSaveRegistrationOptions, TextDocumentSyncKind, TextDocumentSyncOptions, TextEdit, Trace, TraceFormat, TraceOptions, Tracer, UnregistrationParams, UnregistrationRequest, WatchKind, WillSaveTextDocumentNotification, WillSaveTextDocumentParams, WillSaveTextDocumentWaitUntilRequest, WorkspaceEdit, WorkspaceFolder, WorkspaceSymbolRequest } from 'vscode-languageserver-protocol'
+import { ApplyWorkspaceEditParams, ApplyWorkspaceEditRequest, ApplyWorkspaceEditResponse, CancellationToken, ClientCapabilities, CodeAction, CodeActionContext, CodeActionKind, CodeActionOptions, CodeActionParams, CodeActionRegistrationOptions, CodeActionRequest, CodeLens, CodeLensOptions, CodeLensRegistrationOptions, CodeLensRequest, CodeLensResolveRequest, Command, CompletionContext, CompletionItem, CompletionItemKind, CompletionItemTag, CompletionList, CompletionOptions, CompletionRegistrationOptions, CompletionRequest, CompletionResolveRequest, createProtocolConnection, DeclarationRequest, Definition, DefinitionOptions, DefinitionRegistrationOptions, DefinitionRequest, Diagnostic, DiagnosticTag, DidChangeConfigurationNotification, DidChangeConfigurationParams, DidChangeConfigurationRegistrationOptions, DidChangeTextDocumentNotification, DidChangeTextDocumentParams, DidChangeWatchedFilesNotification, DidChangeWatchedFilesParams, DidChangeWatchedFilesRegistrationOptions, DidCloseTextDocumentNotification, DidCloseTextDocumentParams, DidOpenTextDocumentNotification, DidOpenTextDocumentParams, DidSaveTextDocumentNotification, DidSaveTextDocumentParams, Disposable, DocumentColorRequest, DocumentFormattingOptions, DocumentFormattingParams, DocumentFormattingRequest, DocumentHighlight, DocumentHighlightOptions, DocumentHighlightRegistrationOptions, DocumentHighlightRequest, DocumentLink, DocumentLinkOptions, DocumentLinkRegistrationOptions, DocumentLinkRequest, DocumentLinkResolveRequest, DocumentOnTypeFormattingOptions, DocumentOnTypeFormattingParams, DocumentOnTypeFormattingRegistrationOptions, DocumentOnTypeFormattingRequest, DocumentRangeFormattingOptions, DocumentRangeFormattingParams, DocumentRangeFormattingRegistrationOptions, DocumentRangeFormattingRequest, DocumentSelector, DocumentSymbol, DocumentSymbolOptions, DocumentSymbolRegistrationOptions, DocumentSymbolRequest, Emitter, ErrorCodes, Event, ExecuteCommandParams, ExecuteCommandRegistrationOptions, ExecuteCommandRequest, ExitNotification, FailureHandlingKind, FileChangeType, FileEvent, FoldingRangeRequest, FormattingOptions, GenericNotificationHandler, GenericRequestHandler, Hover, HoverOptions, HoverRegistrationOptions, HoverRequest, ImplementationRequest, InitializedNotification, InitializeError, InitializeParams, InitializeRequest, InitializeResult, Location, Logger, LogMessageNotification, LogMessageParams, MarkupKind, Message, MessageReader, MessageType, MessageWriter, NotificationHandler, NotificationHandler0, NotificationType, NotificationType0, Position, PrepareRenameRequest, ProgressToken, ProgressType, Proposed, PublishDiagnosticsNotification, PublishDiagnosticsParams, Range, ReferenceOptions, ReferenceRegistrationOptions, ReferencesRequest, RegistrationParams, RegistrationRequest, RenameOptions, RenameParams, RenameRegistrationOptions, RenameRequest, RequestHandler, RequestHandler0, RequestType, RequestType0, ResourceOperationKind, ResponseError, RPCMessageType, SelectionRangeRequest, ServerCapabilities, ShowMessageNotification, ShowMessageParams, ShowMessageRequest, ShutdownRequest, SignatureHelp, SignatureHelpOptions, SignatureHelpRegistrationOptions, SignatureHelpRequest, StaticRegistrationOptions, SymbolInformation, SymbolKind, SymbolTag, TelemetryEventNotification, TextDocument, TextDocumentChangeRegistrationOptions, TextDocumentEdit, TextDocumentPositionParams, TextDocumentRegistrationOptions, TextDocumentSaveRegistrationOptions, TextDocumentSyncKind, TextDocumentSyncOptions, TextEdit, Trace, TraceFormat, TraceOptions, Tracer, TypeDefinitionRequest, UnregistrationParams, UnregistrationRequest, WatchKind, WillSaveTextDocumentNotification, WillSaveTextDocumentParams, WillSaveTextDocumentWaitUntilRequest, WorkDoneProgressOptions, WorkspaceEdit, WorkspaceFolder, WorkspaceSymbolRegistrationOptions, WorkspaceSymbolRequest } from 'vscode-languageserver-protocol'
 import { URI } from 'vscode-uri'
 import commands from '../commands'
 import languages from '../languages'
 import FileWatcher from '../model/fileSystemWatcher'
-import { ProviderResult } from '../provider'
-import { DiagnosticCollection, OutputChannel, TextDocumentWillSaveEvent, Thenable } from '../types'
+import { CodeActionProvider, CodeLensProvider, CompletionItemProvider, DeclarationProvider, DefinitionProvider, DocumentColorProvider, DocumentFormattingEditProvider, DocumentHighlightProvider, DocumentLinkProvider, DocumentRangeFormattingEditProvider, DocumentSymbolProvider, FoldingRangeProvider, HoverProvider, ImplementationProvider, OnTypeFormattingEditProvider, ProviderResult, ReferenceProvider, RenameProvider, SelectionRangeProvider, SignatureHelpProvider, TypeDefinitionProvider, WorkspaceSymbolProvider } from '../provider'
+import { ConfigurationChangeEvent, DiagnosticCollection, OutputChannel, TextDocumentWillSaveEvent, Thenable } from '../types'
+import { Lazy } from '../util'
 import { resolveRoot } from '../util/fs'
 import * as Is from '../util/is'
+import { omit } from '../util/lodash'
 import workspace from '../workspace'
 import { ColorProviderMiddleware } from './colorProvider'
 import { ConfigurationWorkspaceMiddleware } from './configuration'
+import { DeclarationMiddleware } from './declaration'
 import { FoldingRangeProviderMiddleware } from './foldingRange'
 import { ImplementationMiddleware } from './implementation'
+import { ProgressPart } from './progressPart'
+import { SelectionRangeProviderMiddleware } from './selectionRange'
 import { TypeDefinitionMiddleware } from './typeDefinition'
-import { DeclarationMiddleware } from './declaration'
 import { Delayer } from './utils/async'
 import * as cv from './utils/converter'
 import * as UUID from './utils/uuid'
 import { WorkspaceFolderWorkspaceMiddleware } from './workspaceFolders'
-import { SelectionRangeProviderMiddleware } from './selectionRange'
-import { omit } from '../util/lodash'
-import { Lazy } from '../util'
 
 const logger = require('../util/logger')('language-client-client')
 
@@ -36,19 +37,19 @@ interface IConnection {
   sendRequest<R, E, RO>(
     type: RequestType0<R, E, RO>,
     token?: CancellationToken
-  ): Thenable<R>
+  ): Promise<R>
   sendRequest<P, R, E, RO>(
     type: RequestType<P, R, E, RO>,
     params: P,
     token?: CancellationToken
-  ): Thenable<R>
-  sendRequest<R>(method: string, token?: CancellationToken): Thenable<R>
+  ): Promise<R>
+  sendRequest<R>(method: string, token?: CancellationToken): Promise<R>
   sendRequest<R>(
     method: string,
     param: any,
     token?: CancellationToken
-  ): Thenable<R>
-  sendRequest<R>(type: string | RPCMessageType, ...params: any[]): Thenable<R>
+  ): Promise<R>
+  sendRequest<R>(type: string | RPCMessageType, ...params: any[]): Promise<R>
 
   onRequest<R, E, RO>(
     type: RequestType0<R, E, RO>,
@@ -84,12 +85,14 @@ interface IConnection {
     handler: GenericNotificationHandler
   ): void
 
+  onProgress<P>(type: ProgressType<P>, token: string | number, handler: NotificationHandler<P>): Disposable
+  sendProgress<P>(type: ProgressType<P>, token: string | number, value: P): void
+
   trace(value: Trace, tracer: Tracer, sendNotification?: boolean): void
   trace(value: Trace, tracer: Tracer, traceOptions?: TraceOptions): void
 
-
-  initialize(params: InitializeParams): Thenable<InitializeResult>
-  shutdown(): Thenable<void>
+  initialize(params: InitializeParams): Promise<InitializeResult>
+  shutdown(): Promise<void>
   exit(): void
 
   onLogMessage(handle: NotificationHandler<LogMessageParams>): void
@@ -157,7 +160,7 @@ function createConnection(
   let result: IConnection = {
     listen: (): void => connection.listen(),
 
-    sendRequest: <R>(type: string | RPCMessageType, ...params: any[]): Thenable<R> =>
+    sendRequest: <R>(type: string | RPCMessageType, ...params: any[]): Promise<R> =>
       connection.sendRequest(Is.string(type) ? type : type.method, ...params),
     onRequest: <R, E>(type: string | RPCMessageType, handler: GenericRequestHandler<R, E>): void =>
       connection.onRequest(Is.string(type) ? type : type.method, handler),
@@ -165,6 +168,8 @@ function createConnection(
       connection.sendNotification(Is.string(type) ? type : type.method, params),
     onNotification: (type: string | RPCMessageType, handler: GenericNotificationHandler): void =>
       connection.onNotification(Is.string(type) ? type : type.method, handler),
+    onProgress: connection.onProgress,
+    sendProgress: connection.sendProgress,
 
     trace: (
       value: Trace,
@@ -328,11 +333,12 @@ export enum RevealOutputChannelOn {
 }
 
 export interface HandleDiagnosticsSignature {
-  (uri: string, diagnostics: Diagnostic[]): void
+  (this: void, uri: string, diagnostics: Diagnostic[]): void
 }
 
 export interface ProvideCompletionItemsSignature {
   (
+    this: void,
     document: TextDocument,
     position: Position,
     context: CompletionContext,
@@ -341,11 +347,12 @@ export interface ProvideCompletionItemsSignature {
 }
 
 export interface ResolveCompletionItemSignature {
-  (item: CompletionItem, token: CancellationToken): ProviderResult<CompletionItem>
+  (this: void, item: CompletionItem, token: CancellationToken): ProviderResult<CompletionItem>
 }
 
 export interface ProvideHoverSignature {
   (
+    this: void,
     document: TextDocument,
     position: Position,
     token: CancellationToken
@@ -354,6 +361,7 @@ export interface ProvideHoverSignature {
 
 export interface ProvideSignatureHelpSignature {
   (
+    this: void,
     document: TextDocument,
     position: Position,
     token: CancellationToken
@@ -362,6 +370,7 @@ export interface ProvideSignatureHelpSignature {
 
 export interface ProvideDefinitionSignature {
   (
+    this: void,
     document: TextDocument,
     position: Position,
     token: CancellationToken
@@ -370,6 +379,7 @@ export interface ProvideDefinitionSignature {
 
 export interface ProvideReferencesSignature {
   (
+    this: void,
     document: TextDocument,
     position: Position,
     options: { includeDeclaration: boolean },
@@ -379,6 +389,7 @@ export interface ProvideReferencesSignature {
 
 export interface ProvideDocumentHighlightsSignature {
   (
+    this: void,
     document: TextDocument,
     position: Position,
     token: CancellationToken
@@ -386,15 +397,16 @@ export interface ProvideDocumentHighlightsSignature {
 }
 
 export interface ProvideDocumentSymbolsSignature {
-  (document: TextDocument, token: CancellationToken): ProviderResult<SymbolInformation[] | DocumentSymbol[]>
+  (this: void, document: TextDocument, token: CancellationToken): ProviderResult<SymbolInformation[] | DocumentSymbol[]>
 }
 
 export interface ProvideWorkspaceSymbolsSignature {
-  (query: string, token: CancellationToken): ProviderResult<SymbolInformation[]>
+  (this: void, query: string, token: CancellationToken): ProviderResult<SymbolInformation[]>
 }
 
 export interface ProvideCodeActionsSignature {
   (
+    this: void,
     document: TextDocument,
     range: Range,
     context: CodeActionContext,
@@ -403,15 +415,16 @@ export interface ProvideCodeActionsSignature {
 }
 
 export interface ProvideCodeLensesSignature {
-  (document: TextDocument, token: CancellationToken): ProviderResult<CodeLens[]>
+  (this: void, document: TextDocument, token: CancellationToken): ProviderResult<CodeLens[]>
 }
 
 export interface ResolveCodeLensSignature {
-  (codeLens: CodeLens, token: CancellationToken): ProviderResult<CodeLens>
+  (this: void, codeLens: CodeLens, token: CancellationToken): ProviderResult<CodeLens>
 }
 
 export interface ProvideDocumentFormattingEditsSignature {
   (
+    this: void,
     document: TextDocument,
     options: FormattingOptions,
     token: CancellationToken
@@ -420,6 +433,7 @@ export interface ProvideDocumentFormattingEditsSignature {
 
 export interface ProvideDocumentRangeFormattingEditsSignature {
   (
+    this: void,
     document: TextDocument,
     range: Range,
     options: FormattingOptions,
@@ -429,6 +443,7 @@ export interface ProvideDocumentRangeFormattingEditsSignature {
 
 export interface ProvideOnTypeFormattingEditsSignature {
   (
+    this: void,
     document: TextDocument,
     position: Position,
     ch: string,
@@ -438,11 +453,12 @@ export interface ProvideOnTypeFormattingEditsSignature {
 }
 
 export interface PrepareRenameSignature {
-  (document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Range | { range: Range, placeholder: string }>
+  (this: void, document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Range | { range: Range, placeholder: string }>
 }
 
 export interface ProvideRenameEditsSignature {
   (
+    this: void,
     document: TextDocument,
     position: Position,
     newName: string,
@@ -451,11 +467,15 @@ export interface ProvideRenameEditsSignature {
 }
 
 export interface ProvideDocumentLinksSignature {
-  (document: TextDocument, token: CancellationToken): ProviderResult<DocumentLink[]>
+  (this: void, document: TextDocument, token: CancellationToken): ProviderResult<DocumentLink[]>
 }
 
 export interface ResolveDocumentLinkSignature {
-  (link: DocumentLink, token: CancellationToken): ProviderResult<DocumentLink>
+  (this: void, link: DocumentLink, token: CancellationToken): ProviderResult<DocumentLink>
+}
+
+export interface ExecuteCommandSignature {
+  (this: void, command: string, args: any[]): ProviderResult<any>
 }
 
 export interface NextSignature<P, R> {
@@ -463,7 +483,11 @@ export interface NextSignature<P, R> {
 }
 
 export interface DidChangeConfigurationSignature {
-  (sections: string[] | undefined): void
+  (this: void, sections: string[] | undefined): void
+}
+
+export interface DidChangeWatchedFileSignature {
+  (this: void, event: FileEvent): void
 }
 
 export interface _WorkspaceMiddleware {
@@ -472,6 +496,7 @@ export interface _WorkspaceMiddleware {
     sections: string[] | undefined,
     next: DidChangeConfigurationSignature
   ) => void
+  didChangeWatchedFile?: (this: void, event: FileEvent, next: DidChangeWatchedFileSignature) => void
 }
 
 export type WorkspaceMiddleware = _WorkspaceMiddleware & ConfigurationWorkspaceMiddleware & WorkspaceFolderWorkspaceMiddleware
@@ -629,6 +654,12 @@ export interface _Middleware {
     token: CancellationToken,
     next: ResolveDocumentLinkSignature
   ) => ProviderResult<DocumentLink>
+  executeCommand?: (
+    this: void,
+    command: string,
+    args: any[],
+    next: ExecuteCommandSignature
+  ) => ProviderResult<any>
   workspace?: WorkspaceMiddleware
 }
 
@@ -659,6 +690,7 @@ export interface LanguageClientOptions {
   stdioEncoding?: string
   initializationOptions?: any | (() => any)
   initializationFailedHandler?: InitializationFailedHandler
+  progressOnInitialization?: boolean
   errorHandler?: ErrorHandler
   middleware?: Middleware
   workspaceFolder?: WorkspaceFolder
@@ -678,6 +710,7 @@ interface ResolvedClientOptions {
   stdioEncoding: string
   initializationOptions?: any | (() => any)
   initializationFailedHandler?: InitializationFailedHandler
+  progressOnInitialization: boolean
   errorHandler: ErrorHandler
   middleware: Middleware
   workspaceFolder?: WorkspaceFolder
@@ -703,7 +736,7 @@ export enum ClientState {
   Stopped
 }
 
-const SupporedSymbolKinds: SymbolKind[] = [
+const SupportedSymbolKinds: SymbolKind[] = [
   SymbolKind.File,
   SymbolKind.Module,
   SymbolKind.Namespace,
@@ -758,6 +791,10 @@ const SupportedCompletionItemKinds: CompletionItemKind[] = [
   CompletionItemKind.Event,
   CompletionItemKind.Operator,
   CompletionItemKind.TypeParameter
+]
+
+const SupportedSymbolTags: SymbolTag[] = [
+  SymbolTag.Deprecated
 ]
 
 function ensure<T, K extends keyof T>(target: T, key: K): T[K] {
@@ -868,6 +905,13 @@ export interface DynamicFeature<T> {
   dispose(): void
 }
 
+export interface NotificationFeature<T extends Function> {
+	/**
+	 * Triggers the corresponding RPC method.
+	 */
+  getProvider(document: TextDocument): { send: T }
+}
+
 namespace DynamicFeature {
   export function is<T>(value: any): value is DynamicFeature<T> {
     let candidate: DynamicFeature<T> = value
@@ -876,7 +920,7 @@ namespace DynamicFeature {
       Is.func(candidate.register) &&
       Is.func(candidate.unregister) &&
       Is.func(candidate.dispose) &&
-      candidate.messages != null
+      candidate.messages !== void 0
     )
   }
 }
@@ -885,26 +929,8 @@ interface CreateParamsSignature<E, P> {
   (data: E): P
 }
 
-class OnReady {
-  private _used: boolean
-  constructor(private _resolve: () => void, private _reject: (error: any) => void) {
-    this._used = false
-  }
-  public get isUsed(): boolean {
-    return this._used
-  }
-  public resolve(): void {
-    this._used = true
-    this._resolve()
-  }
-  public reject(error: any): void {
-    this._used = true
-    this._reject(error)
-  }
-}
-
 abstract class DocumentNotifiactions<P, E>
-  implements DynamicFeature<TextDocumentRegistrationOptions> {
+  implements DynamicFeature<TextDocumentRegistrationOptions>, NotificationFeature<(data: E) => void> {
   private _listener: Disposable | undefined
   protected _selectors: Map<string, DocumentSelector> = new Map()
 
@@ -986,6 +1012,19 @@ abstract class DocumentNotifiactions<P, E>
       this._listener.dispose()
       this._listener = undefined
     }
+  }
+
+  public getProvider(document: TextDocument): { send: (data: E) => void } {
+    for (const selector of this._selectors.values()) {
+      if (workspace.match(selector, document)) {
+        return {
+          send: (data: E) => {
+            this.callback(data)
+          }
+        }
+      }
+    }
+    throw new Error(`No provider available for the given text document`)
   }
 }
 
@@ -1149,7 +1188,7 @@ interface DidChangeTextDocumentData {
 }
 
 class DidChangeTextDocumentFeature
-  implements DynamicFeature<TextDocumentChangeRegistrationOptions> {
+  implements DynamicFeature<TextDocumentChangeRegistrationOptions>, NotificationFeature<(event: DidChangeTextDocumentParams) => void> {
   private _listener: Disposable | undefined
   private _changeData: Map<string, DidChangeTextDocumentData> = new Map<string, DidChangeTextDocumentData>()
 
@@ -1168,7 +1207,7 @@ class DidChangeTextDocumentFeature
     if (
       documentSelector &&
       textDocumentSyncOptions &&
-      textDocumentSyncOptions.change != null &&
+      textDocumentSyncOptions.change !== void 0 &&
       textDocumentSyncOptions.change !== TextDocumentSyncKind.None
     ) {
       this.register(this.messages, {
@@ -1257,6 +1296,19 @@ class DidChangeTextDocumentFeature
       this._listener.dispose()
       this._listener = undefined
     }
+  }
+
+  public getProvider(document: TextDocument): { send: (event: DidChangeTextDocumentParams) => void } {
+    for (const changeData of this._changeData.values()) {
+      if (workspace.match(changeData.documentSelector, document)) {
+        return {
+          send: (event: DidChangeTextDocumentParams): void => {
+            this.callback(event)
+          }
+        }
+      }
+    }
+    throw new Error(`No provider available for the given text document`)
   }
 }
 
@@ -1583,10 +1635,23 @@ class FileSystemWatcherFeature
   }
 }
 
+interface TextDocumentFeatureRegistration<RO, PR> {
+  disposable: Disposable
+  data: RegistrationData<RO>
+  provider: PR
+}
+
+export interface TextDocumentProviderFeature<T> {
+	/**
+	 * Triggers the corresponding RPC method.
+	 */
+  getProvider(textDocument: TextDocument): T
+}
+
 export abstract class TextDocumentFeature<
-  T extends TextDocumentRegistrationOptions
-  > implements DynamicFeature<T> {
-  protected _providers: Map<string, Disposable> = new Map<string, Disposable>()
+  PO, RO extends TextDocumentRegistrationOptions & PO, PR
+  > implements DynamicFeature<RO> {
+  private _registrations: Map<string, TextDocumentFeatureRegistration<RO, PR>> = new Map()
 
   constructor(
     protected _client: BaseLanguageClient,
@@ -1604,7 +1669,7 @@ export abstract class TextDocumentFeature<
     documentSelector: DocumentSelector
   ): void
 
-  public register(message: RPCMessageType, data: RegistrationData<T>): void {
+  public register(message: RPCMessageType, data: RegistrationData<RO>): void {
     if (message.method !== this.messages.method) {
       throw new Error(
         `Register called on wrong feature. Requested ${
@@ -1615,31 +1680,74 @@ export abstract class TextDocumentFeature<
     if (!data.registerOptions.documentSelector) {
       return
     }
-    let provider = this.registerLanguageProvider(data.registerOptions)
-    if (provider) {
-      this._providers.set(data.id, provider)
-    }
+    let registration = this.registerLanguageProvider(data.registerOptions)
+    this._registrations.set(data.id, { disposable: registration[0], data, provider: registration[1] })
   }
 
-  protected abstract registerLanguageProvider(languageIds: T): Disposable
+  protected abstract registerLanguageProvider(options: RO): [Disposable, PR]
 
   public unregister(id: string): void {
-    let provider = this._providers.get(id)
-    if (provider) {
-      provider.dispose()
+    let registration = this._registrations.get(id)
+    if (registration) {
+      registration.disposable.dispose()
     }
   }
 
   public dispose(): void {
-    this._providers.forEach(value => {
-      value.dispose()
+    this._registrations.forEach(value => {
+      value.disposable.dispose()
     })
-    this._providers.clear()
+    this._registrations.clear()
+  }
+
+  protected getRegistration(documentSelector: DocumentSelector | undefined, capability: undefined | PO | (RO & StaticRegistrationOptions)): [string | undefined, (RO & { documentSelector: DocumentSelector }) | undefined] {
+    if (!capability) {
+      return [undefined, undefined]
+    } else if (TextDocumentRegistrationOptions.is(capability)) {
+      const id = StaticRegistrationOptions.hasId(capability) ? capability.id : UUID.generateUuid()
+      const selector = capability.documentSelector || documentSelector
+      if (selector) {
+        return [id, Object.assign({}, capability, { documentSelector: selector })]
+      }
+    } else if (Is.boolean(capability) && capability === true || WorkDoneProgressOptions.is(capability)) {
+      if (!documentSelector) {
+        return [undefined, undefined]
+      }
+      let options: RO & { documentSelector: DocumentSelector } = (Is.boolean(capability) && capability === true ? { documentSelector } : Object.assign({}, capability, { documentSelector })) as any
+      return [UUID.generateUuid(), options]
+    }
+    return [undefined, undefined]
+  }
+
+  protected getRegistrationOptions(documentSelector: DocumentSelector | undefined, capability: undefined | PO): (RO & { documentSelector: DocumentSelector }) | undefined {
+    if (!documentSelector || !capability) {
+      return undefined
+    }
+    return (Is.boolean(capability) && capability === true ? { documentSelector } : Object.assign({}, capability, { documentSelector })) as RO & { documentSelector: DocumentSelector }
+  }
+
+  public getProvider(textDocument: TextDocument): PR {
+    for (const registration of this._registrations.values()) {
+      let selector = registration.data.registerOptions.documentSelector
+      if (selector !== null && workspace.match(selector, textDocument)) {
+        return registration.provider
+      }
+    }
+    throw new Error(`The feature has no registration for the provided text document ${textDocument.uri.toString()}`)
   }
 }
 
-abstract class WorkspaceFeature<T> implements DynamicFeature<T> {
-  protected _providers: Map<string, Disposable> = new Map<string, Disposable>()
+export interface WorkspaceProviderFeature<PR> {
+  getProviders(): PR[]
+}
+
+interface WorkspaceFeatureRegistration<PR> {
+  disposable: Disposable
+  provider: PR
+}
+
+abstract class WorkspaceFeature<RO, PR> implements DynamicFeature<RO> {
+  protected _registrations: Map<string, WorkspaceFeatureRegistration<PR>> = new Map()
 
   constructor(
     protected _client: BaseLanguageClient,
@@ -1657,38 +1765,47 @@ abstract class WorkspaceFeature<T> implements DynamicFeature<T> {
     documentSelector: DocumentSelector | undefined
   ): void
 
-  public register(message: RPCMessageType, data: RegistrationData<T>): void {
+  public register(message: RPCMessageType, data: RegistrationData<RO>): void {
     if (message.method !== this.messages.method) {
       throw new Error(
         `Register called on wrong feature. Requested ${message.method} but reached feature ${this.messages.method}`
       )
     }
-    let provider = this.registerLanguageProvider(data.registerOptions)
-    if (provider) {
-      this._providers.set(data.id, provider)
-    }
+    const registration = this.registerLanguageProvider(data.registerOptions)
+    this._registrations.set(data.id, { disposable: registration[0], provider: registration[1] })
   }
 
-  protected abstract registerLanguageProvider(options: T): Disposable
+  protected abstract registerLanguageProvider(options: RO): [Disposable, PR]
 
   public unregister(id: string): void {
-    let provider = this._providers.get(id)
-    if (provider) {
-      provider.dispose()
+    const registration = this._registrations.get(id)
+    if (registration) {
+      registration.disposable.dispose()
     }
   }
 
   public dispose(): void {
-    this._providers.forEach(value => {
-      value.dispose()
+    this._registrations.forEach(value => {
+      value.disposable.dispose()
     })
-    this._providers.clear()
+    this._registrations.clear()
+  }
+
+  public getProviders(): PR[] {
+    const result: PR[] = []
+    for (const registration of this._registrations.values()) {
+      result.push(registration.provider)
+    }
+    return result
   }
 }
 
-class CompletionItemFeature extends TextDocumentFeature<
-  CompletionRegistrationOptions
-  > {
+export interface ProvideResolveFeature<T1 extends Function, T2 extends Function> {
+  provide: T1
+  resolve: T2
+}
+
+class CompletionItemFeature extends TextDocumentFeature<CompletionOptions, CompletionRegistrationOptions, CompletionItemProvider> {
   constructor(client: BaseLanguageClient) {
     super(client, CompletionRequest.type)
   }
@@ -1702,7 +1819,8 @@ class CompletionItemFeature extends TextDocumentFeature<
       commitCharactersSupport: true,
       documentationFormat: [MarkupKind.Markdown, MarkupKind.PlainText],
       deprecatedSupport: true,
-      preselectSupport: true
+      preselectSupport: true,
+      tagSupport: { valueSet: [CompletionItemTag.Deprecated] },
     }
     completion.completionItemKind = { valueSet: SupportedCompletionItemKinds }
   }
@@ -1711,111 +1829,68 @@ class CompletionItemFeature extends TextDocumentFeature<
     capabilities: ServerCapabilities,
     documentSelector: DocumentSelector
   ): void {
-    if (!capabilities.completionProvider || !documentSelector) {
+    const options = this.getRegistrationOptions(documentSelector, capabilities.completionProvider)
+    if (!options) {
       return
     }
     this.register(this.messages, {
       id: UUID.generateUuid(),
-      registerOptions: Object.assign(
-        {},
-        { documentSelector: documentSelector },
-        capabilities.completionProvider
-      )
+      registerOptions: options
     })
   }
 
-  protected registerLanguageProvider(
-    options: CompletionRegistrationOptions
-  ): Disposable {
+  protected registerLanguageProvider(options: CompletionRegistrationOptions): [Disposable, CompletionItemProvider] {
     let triggerCharacters = options.triggerCharacters || []
     let allCommitCharacters = options.allCommitCharacters || []
-    let client = this._client
-    let provideCompletionItems: ProvideCompletionItemsSignature = (
-      document,
-      position,
-      context,
-      token
-    ) => {
-      return client
-        .sendRequest(
-          CompletionRequest.type,
-          cv.asCompletionParams(
-            document,
-            position,
-            context
-          ),
-          token
-        )
-        .then(result => {
-          // logger.debug('result', result)
-          return result
-        }, error => {
-          client.logFailedRequest(CompletionRequest.type, error)
-          return Promise.resolve([])
-        })
-    }
-    let resolveCompletionItem: ResolveCompletionItemSignature = (
-      item,
-      token
-    ) => {
-      return client
-        .sendRequest(
-          CompletionResolveRequest.type,
-          item,
-          token
-        )
-        .then(res => res, error => {
-          client.logFailedRequest(CompletionResolveRequest.type, error)
-          return Promise.resolve(item)
-        })
+    const provider: CompletionItemProvider = {
+      provideCompletionItems: (document: TextDocument, position: Position, token: CancellationToken, context: CompletionContext): ProviderResult<CompletionList | CompletionItem[]> => {
+        const client = this._client
+        const middleware = this._client.clientOptions.middleware!
+        const provideCompletionItems: ProvideCompletionItemsSignature = (document, position, context, token) => {
+          return client.sendRequest(
+            CompletionRequest.type,
+            cv.asCompletionParams(document, position, context),
+            token
+          ).then(result => result, error => {
+            client.logFailedRequest(CompletionRequest.type, error)
+            return Promise.resolve([])
+          })
+        }
+
+        return middleware.provideCompletionItem
+          ? middleware.provideCompletionItem(document, position, context, token, provideCompletionItems)
+          : provideCompletionItems(document, position, context, token)
+      },
+      resolveCompletionItem: options.resolveProvider
+        ? (item: CompletionItem, token: CancellationToken): ProviderResult<CompletionItem> => {
+          const client = this._client
+          const middleware = this._client.clientOptions.middleware!
+          const resolveCompletionItem: ResolveCompletionItemSignature = (item, token) => {
+            return client.sendRequest(
+              CompletionResolveRequest.type,
+              item,
+              token
+            ).then(res => res, error => {
+              client.logFailedRequest(CompletionResolveRequest.type, error)
+              return Promise.resolve(item)
+            })
+          }
+
+          return middleware.resolveCompletionItem
+            ? middleware.resolveCompletionItem(item, token, resolveCompletionItem)
+            : resolveCompletionItem(item, token)
+        }
+        : undefined
     }
 
-    let middleware = this._client.clientOptions.middleware!
-    let languageIds = cv.asLanguageIds(options.documentSelector!)
-    return languages.registerCompletionItemProvider(
-      this._client.id,
-      'LS',
-      languageIds,
-      {
-        provideCompletionItems: (
-          document: TextDocument,
-          position: Position,
-          token: CancellationToken,
-          context: CompletionContext
-        ): ProviderResult<CompletionList | CompletionItem[]> => {
-          return middleware.provideCompletionItem
-            ? middleware.provideCompletionItem(
-              document,
-              position,
-              context,
-              token,
-              provideCompletionItems
-            )
-            : provideCompletionItems(document, position, context, token)
-        },
-        resolveCompletionItem: options.resolveProvider
-          ? (
-            item: CompletionItem,
-            token: CancellationToken
-          ): ProviderResult<CompletionItem> => {
-            return middleware.resolveCompletionItem
-              ? middleware.resolveCompletionItem(
-                item,
-                token,
-                resolveCompletionItem
-              )
-              : resolveCompletionItem(item, token)
-          }
-          : undefined
-      },
-      triggerCharacters,
-      allCommitCharacters
-    )
+    const languageIds = cv.asLanguageIds(options.documentSelector!)
+    const disposable = languages.registerCompletionItemProvider(this._client.id, 'LS', languageIds, provider, triggerCharacters, allCommitCharacters)
+    return [disposable, provider]
   }
 }
 
 class HoverFeature extends TextDocumentFeature<
-  TextDocumentRegistrationOptions
+  boolean | HoverOptions, HoverRegistrationOptions, HoverProvider
   > {
   constructor(client: BaseLanguageClient) {
     super(client, HoverRequest.type)
@@ -1834,52 +1909,46 @@ class HoverFeature extends TextDocumentFeature<
     capabilities: ServerCapabilities,
     documentSelector: DocumentSelector
   ): void {
-    if (!capabilities.hoverProvider || !documentSelector) {
+    const options = this.getRegistrationOptions(documentSelector, capabilities.hoverProvider)
+    if (!options) {
       return
     }
     this.register(this.messages, {
       id: UUID.generateUuid(),
-      registerOptions: Object.assign({}, { documentSelector: documentSelector })
+      registerOptions: options
     })
   }
 
   protected registerLanguageProvider(
-    options: TextDocumentRegistrationOptions
-  ): Disposable {
-    let client = this._client
-    let provideHover: ProvideHoverSignature = (document, position, token) => {
-      return client
-        .sendRequest(
-          HoverRequest.type,
-          cv.asTextDocumentPositionParams(
-            document,
-            position
-          ),
-          token
-        )
-        .then(res => res, error => {
-          client.logFailedRequest(HoverRequest.type, error)
-          return Promise.resolve(null)
-        })
-    }
-    let middleware = client.clientOptions.middleware!
-    return languages.registerHoverProvider(
-      options.documentSelector!, {
-        provideHover: (
-          document: TextDocument,
-          position: Position,
-          token: CancellationToken
-        ): ProviderResult<Hover> => {
-          return middleware.provideHover
-            ? middleware.provideHover(document, position, token, provideHover)
-            : provideHover(document, position, token)
+    options: HoverRegistrationOptions
+  ): [Disposable, HoverProvider] {
+    const provider: HoverProvider = {
+      provideHover: (document, position, token) => {
+        const client = this._client
+        const provideHover: ProvideHoverSignature = (document, position, token) => {
+          return client.sendRequest(
+            HoverRequest.type,
+            cv.asTextDocumentPositionParams(document, position),
+            token
+          ).then(res => res, error => {
+            client.logFailedRequest(HoverRequest.type, error)
+            return Promise.resolve(null)
+          })
         }
-      })
+
+        const middleware = client.clientOptions.middleware!
+        return middleware.provideHover
+          ? middleware.provideHover(document, position, token, provideHover)
+          : provideHover(document, position, token)
+      }
+    }
+
+    return [languages.registerHoverProvider(options.documentSelector!, provider), provider]
   }
 }
 
 class SignatureHelpFeature extends TextDocumentFeature<
-  SignatureHelpRegistrationOptions
+  SignatureHelpOptions, SignatureHelpRegistrationOptions, SignatureHelpProvider
   > {
   constructor(client: BaseLanguageClient) {
     super(client, SignatureHelpRequest.type)
@@ -1888,6 +1957,7 @@ class SignatureHelpFeature extends TextDocumentFeature<
   public fillClientCapabilities(capabilites: ClientCapabilities): void {
     let config = ensure(ensure(capabilites, 'textDocument')!, 'signatureHelp')!
     config.dynamicRegistration = true
+    // config.contextSupport = true // TODO context and meta support
     config.signatureInformation = {
       documentationFormat: [MarkupKind.Markdown, MarkupKind.PlainText],
       parameterInformation: {
@@ -1900,69 +1970,49 @@ class SignatureHelpFeature extends TextDocumentFeature<
     capabilities: ServerCapabilities,
     documentSelector: DocumentSelector
   ): void {
-    if (!capabilities.signatureHelpProvider || !documentSelector) {
+    const options = this.getRegistrationOptions(documentSelector, capabilities.signatureHelpProvider)
+    if (!options) {
       return
     }
     this.register(this.messages, {
       id: UUID.generateUuid(),
-      registerOptions: Object.assign(
-        {},
-        { documentSelector: documentSelector },
-        capabilities.signatureHelpProvider
-      )
+      registerOptions: options
     })
   }
 
   protected registerLanguageProvider(
     options: SignatureHelpRegistrationOptions
-  ): Disposable {
-    let client = this._client
-    let providerSignatureHelp: ProvideSignatureHelpSignature = (
-      document,
-      position,
-      token
-    ) => {
-      return client
-        .sendRequest(
-          SignatureHelpRequest.type,
-          cv.asTextDocumentPositionParams(
-            document,
-            position
-          ),
-          token
-        )
-        .then(res => res, error => {
-          client.logFailedRequest(SignatureHelpRequest.type, error)
-          return Promise.resolve(null)
-        })
-    }
-    let middleware = client.clientOptions.middleware!
-    let triggerCharacters = options.triggerCharacters || []
-    return languages.registerSignatureHelpProvider(
-      options.documentSelector!,
-      {
-        provideSignatureHelp: (
-          document: TextDocument,
-          position: Position,
-          token: CancellationToken
-        ): ProviderResult<SignatureHelp> => {
-          return middleware.provideSignatureHelp
-            ? middleware.provideSignatureHelp(
-              document,
-              position,
-              token,
-              providerSignatureHelp
-            )
-            : providerSignatureHelp(document, position, token)
+  ): [Disposable, SignatureHelpProvider] {
+    const provider: SignatureHelpProvider = {
+      provideSignatureHelp: (document, position, token) => {
+        const client = this._client
+        const providerSignatureHelp: ProvideSignatureHelpSignature = (document, position, token) => {
+          return client.sendRequest(
+            SignatureHelpRequest.type,
+            cv.asTextDocumentPositionParams(document, position),
+            token
+          ).then(res => res, error => {
+            client.logFailedRequest(SignatureHelpRequest.type, error)
+            return Promise.resolve(null)
+          }
+          )
         }
-      },
-      triggerCharacters
-    )
+
+        const middleware = client.clientOptions.middleware!
+        return middleware.provideSignatureHelp
+          ? middleware.provideSignatureHelp(document, position, token, providerSignatureHelp)
+          : providerSignatureHelp(document, position, token)
+      }
+    }
+
+    const triggerCharacters = options.triggerCharacters || []
+    const disposable = languages.registerSignatureHelpProvider(options.documentSelector!, provider, triggerCharacters)
+    return [disposable, provider]
   }
 }
 
 class DefinitionFeature extends TextDocumentFeature<
-  TextDocumentRegistrationOptions
+  boolean | DefinitionOptions, DefinitionRegistrationOptions, DefinitionProvider
   > {
   constructor(client: BaseLanguageClient) {
     super(client, DefinitionRequest.type)
@@ -1978,61 +2028,45 @@ class DefinitionFeature extends TextDocumentFeature<
     capabilities: ServerCapabilities,
     documentSelector: DocumentSelector
   ): void {
-    if (!capabilities.definitionProvider || !documentSelector) {
+    const options = this.getRegistrationOptions(documentSelector, capabilities.definitionProvider)
+    if (!options) {
       return
     }
     this.register(this.messages, {
       id: UUID.generateUuid(),
-      registerOptions: Object.assign({}, { documentSelector: documentSelector })
+      registerOptions: options
     })
   }
 
   protected registerLanguageProvider(
-    options: TextDocumentRegistrationOptions
-  ): Disposable {
-    let client = this._client
-    let provideDefinition: ProvideDefinitionSignature = (
-      document,
-      position,
-      token
-    ) => {
-      return client
-        .sendRequest(
-          DefinitionRequest.type,
-          cv.asTextDocumentPositionParams(
-            document,
-            position
-          ),
-          token
-        )
-        .then(res => res, error => {
-          client.logFailedRequest(DefinitionRequest.type, error)
-          return Promise.resolve(null)
-        })
-    }
-    let middleware = client.clientOptions.middleware!
-    return languages.registerDefinitionProvider(
-      options.documentSelector!, {
-        provideDefinition: (
-          document: TextDocument,
-          position: Position,
-          token: CancellationToken
-        ): ProviderResult<Definition> => {
-          return middleware.provideDefinition
-            ? middleware.provideDefinition(
-              document,
-              position,
-              token,
-              provideDefinition
-            )
-            : provideDefinition(document, position, token)
+    options: DefinitionRegistrationOptions
+  ): [Disposable, DefinitionProvider] {
+    const provider: DefinitionProvider = {
+      provideDefinition: (document, position, token) => {
+        const client = this._client
+        const provideDefinition: ProvideDefinitionSignature = (document, position, token) => {
+          return client.sendRequest(
+            DefinitionRequest.type,
+            cv.asTextDocumentPositionParams(document, position),
+            token
+          ).then(res => res, error => {
+            client.logFailedRequest(DefinitionRequest.type, error)
+            return Promise.resolve(null)
+          })
         }
-      })
+        const middleware = client.clientOptions.middleware!
+        return middleware.provideDefinition
+          ? middleware.provideDefinition(document, position, token, provideDefinition)
+          : provideDefinition(document, position, token)
+      }
+    }
+
+    return [languages.registerDefinitionProvider(options.documentSelector!, provider), provider]
   }
 }
 
 class ReferencesFeature extends TextDocumentFeature<
-  TextDocumentRegistrationOptions
+  boolean | ReferenceOptions, ReferenceRegistrationOptions, ReferenceProvider
   > {
   constructor(client: BaseLanguageClient) {
     super(client, ReferencesRequest.type)
@@ -2049,65 +2083,44 @@ class ReferencesFeature extends TextDocumentFeature<
     capabilities: ServerCapabilities,
     documentSelector: DocumentSelector
   ): void {
-    if (!capabilities.referencesProvider || !documentSelector) {
+    const options = this.getRegistrationOptions(documentSelector, capabilities.referencesProvider)
+    if (!options) {
       return
     }
     this.register(this.messages, {
       id: UUID.generateUuid(),
-      registerOptions: Object.assign({}, { documentSelector: documentSelector })
+      registerOptions: options
     })
   }
 
   protected registerLanguageProvider(
     options: TextDocumentRegistrationOptions
-  ): Disposable {
-    let client = this._client
-    let providerReferences: ProvideReferencesSignature = (
-      document,
-      position,
-      options,
-      token
-    ) => {
-      return client
-        .sendRequest(
-          ReferencesRequest.type,
-          cv.asReferenceParams(
-            document,
-            position,
-            options
-          ),
-          token
-        )
-        .then(res => res, error => {
-          client.logFailedRequest(ReferencesRequest.type, error)
-          return Promise.resolve([])
-        })
-    }
-    let middleware = client.clientOptions.middleware!
-    return languages.registerReferencesProvider(
-      options.documentSelector!, {
-        provideReferences: (
-          document: TextDocument,
-          position: Position,
-          options: { includeDeclaration: boolean },
-          token: CancellationToken
-        ): ProviderResult<Location[]> => {
-          return middleware.provideReferences
-            ? middleware.provideReferences(
-              document,
-              position,
-              options,
-              token,
-              providerReferences
-            )
-            : providerReferences(document, position, options, token)
+  ): [Disposable, ReferenceProvider] {
+    const provider: ReferenceProvider = {
+      provideReferences: (document, position, options, token) => {
+        const client = this._client
+        const _providerReferences: ProvideReferencesSignature = (document, position, options, token) => {
+          return client.sendRequest(
+            ReferencesRequest.type,
+            cv.asReferenceParams(document, position, options),
+            token
+          ).then(res => res, error => {
+            client.logFailedRequest(ReferencesRequest.type, error)
+            return Promise.resolve([])
+          })
         }
-      })
+        const middleware = client.clientOptions.middleware!
+        return middleware.provideReferences
+          ? middleware.provideReferences(document, position, options, token, _providerReferences)
+          : _providerReferences(document, position, options, token)
+      }
+    }
+    return [languages.registerReferencesProvider(options.documentSelector!, provider), provider]
   }
 }
 
 class DocumentHighlightFeature extends TextDocumentFeature<
-  TextDocumentRegistrationOptions
+  boolean | DocumentHighlightOptions, DocumentHighlightRegistrationOptions, DocumentHighlightProvider
   > {
   constructor(client: BaseLanguageClient) {
     super(client, DocumentHighlightRequest.type)
@@ -2124,63 +2137,44 @@ class DocumentHighlightFeature extends TextDocumentFeature<
     capabilities: ServerCapabilities,
     documentSelector: DocumentSelector
   ): void {
-    if (!capabilities.documentHighlightProvider || !documentSelector) {
+    const options = this.getRegistrationOptions(documentSelector, capabilities.documentHighlightProvider)
+    if (!options) {
       return
     }
     this.register(this.messages, {
       id: UUID.generateUuid(),
-      registerOptions: Object.assign({}, { documentSelector: documentSelector })
+      registerOptions: options
     })
   }
 
   protected registerLanguageProvider(
     options: TextDocumentRegistrationOptions
-  ): Disposable {
-    let client = this._client
-    let provideDocumentHighlights: ProvideDocumentHighlightsSignature = (
-      document,
-      position,
-      token
-    ) => {
-      return client
-        .sendRequest(
-          DocumentHighlightRequest.type,
-          cv.asTextDocumentPositionParams(
-            document,
-            position
-          ),
-          token
-        )
-        .then(res => res, error => {
-          client.logFailedRequest(DocumentHighlightRequest.type, error)
-          return Promise.resolve([])
-        })
-    }
-    let middleware = client.clientOptions.middleware!
-    return languages.registerDocumentHighlightProvider(
-      options.documentSelector!,
-      {
-        provideDocumentHighlights: (
-          document: TextDocument,
-          position: Position,
-          token: CancellationToken
-        ): ProviderResult<DocumentHighlight[]> => {
-          return middleware.provideDocumentHighlights
-            ? middleware.provideDocumentHighlights(
-              document,
-              position,
-              token,
-              provideDocumentHighlights
-            )
-            : provideDocumentHighlights(document, position, token)
+  ): [Disposable, DocumentHighlightProvider] {
+    const provider: DocumentHighlightProvider = {
+      provideDocumentHighlights: (document, position, token) => {
+        const client = this._client
+        const _provideDocumentHighlights: ProvideDocumentHighlightsSignature = (document, position, token) => {
+          return client.sendRequest(
+            DocumentHighlightRequest.type,
+            cv.asTextDocumentPositionParams(document, position),
+            token
+          ).then(res => res, error => {
+            client.logFailedRequest(DocumentHighlightRequest.type, error)
+            return Promise.resolve([])
+          })
         }
+        const middleware = client.clientOptions.middleware!
+        return middleware.provideDocumentHighlights
+          ? middleware.provideDocumentHighlights(document, position, token, _provideDocumentHighlights)
+          : _provideDocumentHighlights(document, position, token)
       }
-    )
+    }
+    return [languages.registerDocumentHighlightProvider(options.documentSelector!, provider), provider]
   }
 }
 
 class DocumentSymbolFeature extends TextDocumentFeature<
-  TextDocumentRegistrationOptions
+  boolean | DocumentSymbolOptions, DocumentSymbolRegistrationOptions, DocumentSymbolProvider
   > {
   constructor(client: BaseLanguageClient) {
     super(client, DocumentSymbolRequest.type)
@@ -2193,62 +2187,71 @@ class DocumentSymbolFeature extends TextDocumentFeature<
     )!
     symbolCapabilities.dynamicRegistration = true
     symbolCapabilities.symbolKind = {
-      valueSet: SupporedSymbolKinds
+      valueSet: SupportedSymbolKinds
     }
+    symbolCapabilities.hierarchicalDocumentSymbolSupport // TODO
   }
 
   public initialize(
     capabilities: ServerCapabilities,
     documentSelector: DocumentSelector
   ): void {
-    if (!capabilities.documentSymbolProvider || !documentSelector) {
+    const options = this.getRegistrationOptions(documentSelector, capabilities.documentSymbolProvider)
+    if (!options) {
       return
     }
     this.register(this.messages, {
       id: UUID.generateUuid(),
-      registerOptions: Object.assign({}, { documentSelector: documentSelector })
+      registerOptions: options
     })
   }
 
   protected registerLanguageProvider(
     options: TextDocumentRegistrationOptions
-  ): Disposable {
-    let client = this._client
-    let provideDocumentSymbols: ProvideDocumentSymbolsSignature = (
-      document,
-      token
-    ) => {
-      return client
-        .sendRequest(
-          DocumentSymbolRequest.type,
-          cv.asDocumentSymbolParams(document),
-          token
-        )
-        .then(res => res, error => {
-          client.logFailedRequest(DocumentSymbolRequest.type, error)
-          return Promise.resolve([])
-        })
-    }
-    let middleware = client.clientOptions.middleware!
-    return languages.registerDocumentSymbolProvider(
-      options.documentSelector!, {
-        provideDocumentSymbols: (
-          document: TextDocument,
-          token: CancellationToken
-        ): ProviderResult<SymbolInformation[] | DocumentSymbol[]> => {
-          return middleware.provideDocumentSymbols
-            ? middleware.provideDocumentSymbols(
-              document,
-              token,
-              provideDocumentSymbols
-            )
-            : provideDocumentSymbols(document, token)
+  ): [Disposable, DocumentSymbolProvider] {
+    const provider: DocumentSymbolProvider = {
+      provideDocumentSymbols: (document, token) => {
+        const client = this._client
+        const _provideDocumentSymbols: ProvideDocumentSymbolsSignature = (document, token) => {
+          return client.sendRequest(
+            DocumentSymbolRequest.type,
+            cv.asDocumentSymbolParams(document),
+            token
+          ).then(
+            (data) => {
+              if (data === null) {
+                return undefined
+              }
+              if (data.length === 0) {
+                return []
+              } else {
+                let element = data[0]
+                // TODO
+                if (DocumentSymbol.is(element)) {
+                  return data as DocumentSymbol[]
+                } else {
+                  return data as SymbolInformation[]
+                }
+              }
+            },
+            (error) => {
+              client.logFailedRequest(DocumentSymbolRequest.type, error)
+              return Promise.resolve([])
+            }
+          )
         }
-      })
+        const middleware = client.clientOptions.middleware!
+        return middleware.provideDocumentSymbols
+          ? middleware.provideDocumentSymbols(document, token, _provideDocumentSymbols)
+          : _provideDocumentSymbols(document, token)
+      }
+    }
+    return [languages.registerDocumentSymbolProvider(options.documentSelector!, provider), provider]
   }
 }
 
-class WorkspaceSymbolFeature extends WorkspaceFeature<TextDocumentRegistrationOptions> {
+class WorkspaceSymbolFeature extends WorkspaceFeature<WorkspaceSymbolRegistrationOptions, WorkspaceSymbolProvider
+  > {
   constructor(client: BaseLanguageClient) {
     super(client, WorkspaceSymbolRequest.type)
   }
@@ -2260,7 +2263,7 @@ class WorkspaceSymbolFeature extends WorkspaceFeature<TextDocumentRegistrationOp
     )!
     symbolCapabilities.dynamicRegistration = true
     symbolCapabilities.symbolKind = {
-      valueSet: SupporedSymbolKinds
+      valueSet: SupportedSymbolKinds
     }
   }
 
@@ -2273,43 +2276,34 @@ class WorkspaceSymbolFeature extends WorkspaceFeature<TextDocumentRegistrationOp
     }
     this.register(this.messages, {
       id: UUID.generateUuid(),
-      registerOptions: Object.assign({}, { documentSelector: documentSelector })
+      registerOptions: capabilities.workspaceSymbolProvider === true ? { workDoneProgress: false } : capabilities.workspaceSymbolProvider
     })
   }
 
-  protected registerLanguageProvider(options: TextDocumentRegistrationOptions): Disposable {
-    let client = this._client
-    let provideWorkspaceSymbols: ProvideWorkspaceSymbolsSignature = (
-      query,
-      token
-    ) => {
-      return client
-        .sendRequest(WorkspaceSymbolRequest.type, { query }, token)
-        .then(res => res, error => {
-          client.logFailedRequest(WorkspaceSymbolRequest.type, error)
-          return Promise.resolve([])
-        })
-    }
-    let middleware = client.clientOptions.middleware!
-    return languages.registerWorkspaceSymbolProvider(
-      options.documentSelector!, {
-        provideWorkspaceSymbols: (
-          query: string,
-          token: CancellationToken
-        ): ProviderResult<SymbolInformation[]> => {
-          return middleware.provideWorkspaceSymbols
-            ? middleware.provideWorkspaceSymbols(
-              query,
-              token,
-              provideWorkspaceSymbols
-            )
-            : provideWorkspaceSymbols(query, token)
+  protected registerLanguageProvider(options: WorkspaceSymbolRegistrationOptions): [Disposable, WorkspaceSymbolProvider] {
+    const provider: WorkspaceSymbolProvider = {
+      provideWorkspaceSymbols: (query, token) => {
+        const client = this._client
+        const provideWorkspaceSymbols: ProvideWorkspaceSymbolsSignature = (query, token) => {
+          return client.sendRequest(WorkspaceSymbolRequest.type, { query }, token).then(
+            res => res,
+            error => {
+              client.logFailedRequest(WorkspaceSymbolRequest.type, error)
+              return Promise.resolve([])
+            })
         }
-      })
+        const middleware = client.clientOptions.middleware!
+        return middleware.provideWorkspaceSymbols
+          ? middleware.provideWorkspaceSymbols(query, token, provideWorkspaceSymbols)
+          : provideWorkspaceSymbols(query, token)
+      }
+    }
+    // TODO: selector to null
+    return [languages.registerWorkspaceSymbolProvider(null, provider), provider]
   }
 }
 
-class CodeActionFeature extends TextDocumentFeature<CodeActionRegistrationOptions> {
+class CodeActionFeature extends TextDocumentFeature<boolean | CodeActionOptions, CodeActionRegistrationOptions, CodeActionProvider> {
   constructor(client: BaseLanguageClient) {
     super(client, CodeActionRequest.type)
   }
@@ -2317,10 +2311,11 @@ class CodeActionFeature extends TextDocumentFeature<CodeActionRegistrationOption
   public fillClientCapabilities(capabilites: ClientCapabilities): void {
     const cap = ensure(ensure(capabilites, 'textDocument')!, 'codeAction')!
     cap.dynamicRegistration = true
+    cap.isPreferredSupport = true
     cap.codeActionLiteralSupport = {
       codeActionKind: {
         valueSet: [
-          '',
+          CodeActionKind.Empty,
           CodeActionKind.QuickFix,
           CodeActionKind.Refactor,
           CodeActionKind.RefactorExtract,
@@ -2337,74 +2332,56 @@ class CodeActionFeature extends TextDocumentFeature<CodeActionRegistrationOption
     capabilities: ServerCapabilities,
     documentSelector: DocumentSelector
   ): void {
-    if (!capabilities.codeActionProvider || !documentSelector) {
-      return
+    const options = this.getRegistrationOptions(documentSelector, capabilities.codeActionProvider);
+    if (!options) {
+      return;
     }
-    let codeActionKinds: CodeActionKind[] | undefined
-    if (!Is.boolean(capabilities.codeActionProvider)) {
-      codeActionKinds = capabilities.codeActionProvider.codeActionKinds
-    }
-
 
     this.register(this.messages, {
       id: UUID.generateUuid(),
-      registerOptions: Object.assign({}, { documentSelector: documentSelector, codeActionKinds })
+      registerOptions: options
     })
   }
 
   protected registerLanguageProvider(
     options: CodeActionRegistrationOptions
-  ): Disposable {
-    let client = this._client
-    let provideCodeActions: ProvideCodeActionsSignature = (
-      document,
-      range,
-      context,
-      token
-    ) => {
-      let params: CodeActionParams = {
-        textDocument: {
-          uri: document.uri
-        },
-        range,
-        context,
+  ): [Disposable, CodeActionProvider] {
+    const provider: CodeActionProvider = {
+      provideCodeActions: (document, range, context, token) => {
+        const client = this._client
+        const _provideCodeActions: ProvideCodeActionsSignature = (document, range, context, token) => {
+          const params: CodeActionParams = {
+            textDocument: {
+              uri: document.uri
+            },
+            range,
+            context,
+          }
+          return client.sendRequest(CodeActionRequest.type, params, token).then(
+            (values) => {
+              if (values === null) {
+                return undefined
+              }
+              return values
+            },
+            (error) => {
+              client.logFailedRequest(CodeActionRequest.type, error);
+              return Promise.resolve([]);
+            }
+          );
+        };
+        const middleware = client.clientOptions.middleware!;
+        return middleware.provideCodeActions
+          ? middleware.provideCodeActions(document, range, context, token, _provideCodeActions)
+          : _provideCodeActions(document, range, context, token);
       }
-      return client.sendRequest(CodeActionRequest.type, params, token).then(
-        values => {
-          if (values == null) return null
-          return values
-        },
-        error => {
-          client.logFailedRequest(CodeActionRequest.type, error)
-          return Promise.resolve([])
-        }
-      )
     }
-    let middleware = client.clientOptions.middleware!
-    return languages.registerCodeActionProvider(
-      options.documentSelector,
-      {
-        provideCodeActions: (
-          document: TextDocument,
-          range: Range,
-          context: CodeActionContext,
-          token: CancellationToken
-        ): ProviderResult<(Command | CodeAction)[]> => {
-          return middleware.provideCodeActions
-            ? middleware.provideCodeActions(
-              document,
-              range,
-              context,
-              token,
-              provideCodeActions
-            )
-            : provideCodeActions(document, range, context, token)
-        }
-      }, client.id, options.codeActionKinds)
+
+    return [languages.registerCodeActionProvider(options.documentSelector, provider, this._client.id, options.codeActionKinds), provider]
   }
 }
 
-class CodeLensFeature extends TextDocumentFeature<CodeLensRegistrationOptions> {
+class CodeLensFeature extends TextDocumentFeature<CodeLensOptions, CodeLensRegistrationOptions, CodeLensProvider> {
   constructor(client: BaseLanguageClient) {
     super(client, CodeLensRequest.type)
   }
@@ -2420,72 +2397,65 @@ class CodeLensFeature extends TextDocumentFeature<CodeLensRegistrationOptions> {
     capabilities: ServerCapabilities,
     documentSelector: DocumentSelector
   ): void {
-    if (!capabilities.codeLensProvider || !documentSelector) {
-      return
+    const options = this.getRegistrationOptions(documentSelector, capabilities.codeLensProvider);
+    if (!options) {
+      return;
     }
     this.register(this.messages, {
       id: UUID.generateUuid(),
-      registerOptions: Object.assign(
-        {},
-        { documentSelector: documentSelector },
-        capabilities.codeLensProvider
-      )
+      registerOptions: options
     })
   }
 
   protected registerLanguageProvider(
     options: CodeLensRegistrationOptions
-  ): Disposable {
-    let client = this._client
-    let provideCodeLenses: ProvideCodeLensesSignature = (document, token) => {
-      return client
-        .sendRequest(
-          CodeLensRequest.type,
-          cv.asCodeLensParams(document),
-          token
-        ).then(res => res, error => {
-          client.logFailedRequest(CodeLensRequest.type, error)
-          return Promise.resolve([])
-        })
+  ): [Disposable, CodeLensProvider] {
+    const provider: CodeLensProvider = {
+      provideCodeLenses: (document, token) => {
+        const client = this._client
+        const provideCodeLenses: ProvideCodeLensesSignature = (document, token) => {
+          return client.sendRequest(
+            CodeLensRequest.type,
+            cv.asCodeLensParams(document),
+            token
+          ).then(res => res, error => {
+            client.logFailedRequest(CodeLensRequest.type, error)
+            return Promise.resolve([])
+          })
+        }
+        const middleware = client.clientOptions.middleware!
+        return middleware.provideCodeLenses
+          ? middleware.provideCodeLenses(document, token, provideCodeLenses)
+          : provideCodeLenses(document, token)
+      },
+      resolveCodeLens: (options.resolveProvider)
+        ? (codeLens: CodeLens, token: CancellationToken): ProviderResult<CodeLens> => {
+          const client = this._client
+          const resolveCodeLens: ResolveCodeLensSignature = (codeLens, token) => {
+            return client.sendRequest(
+              CodeLensResolveRequest.type,
+              codeLens,
+              token
+            ).then(res => res, error => {
+              client.logFailedRequest(CodeLensResolveRequest.type, error);
+              return codeLens;
+            })
+          };
+          const middleware = client.clientOptions.middleware!;
+          return middleware.resolveCodeLens
+            ? middleware.resolveCodeLens(codeLens, token, resolveCodeLens)
+            : resolveCodeLens(codeLens, token);
+        }
+        : undefined
     }
-    let resolveCodeLens: ResolveCodeLensSignature = (codeLens, token) => {
-      return client
-        .sendRequest(
-          CodeLensResolveRequest.type,
-          codeLens,
-          token
-        )
-        .then(res => res, error => {
-          client.logFailedRequest(CodeLensResolveRequest.type, error)
-          return codeLens
-        })
-    }
-    let middleware = client.clientOptions.middleware!
-    return languages.registerCodeLensProvider(
-      options.documentSelector, {
-        provideCodeLenses: (
-          document: TextDocument,
-          token: CancellationToken
-        ): ProviderResult<CodeLens[]> => {
-          return middleware.provideCodeLenses
-            ? middleware.provideCodeLenses(document, token, provideCodeLenses)
-            : provideCodeLenses(document, token)
-        },
-        resolveCodeLens: options.resolveProvider
-          ? (
-            codeLens: CodeLens,
-            token: CancellationToken
-          ): ProviderResult<CodeLens> => {
-            return middleware.resolveCodeLens
-              ? middleware.resolveCodeLens(codeLens, token, resolveCodeLens)
-              : resolveCodeLens(codeLens, token)
-          }
-          : undefined
-      })
+
+    return [languages.registerCodeLensProvider(options.documentSelector, provider), provider]
   }
 }
 
-class DocumentFormattingFeature extends TextDocumentFeature<TextDocumentRegistrationOptions> {
+class DocumentFormattingFeature extends TextDocumentFeature<
+  boolean | DocumentFormattingOptions, DocumentHighlightRegistrationOptions, DocumentFormattingEditProvider
+  > {
 
   constructor(client: BaseLanguageClient) {
     super(client, DocumentFormattingRequest.type)
@@ -2502,61 +2472,46 @@ class DocumentFormattingFeature extends TextDocumentFeature<TextDocumentRegistra
     capabilities: ServerCapabilities,
     documentSelector: DocumentSelector
   ): void {
-    if (!capabilities.documentFormattingProvider || !documentSelector) {
-      return
+    const options = this.getRegistrationOptions(documentSelector, capabilities.documentFormattingProvider);
+    if (!options) {
+      return;
     }
     this.register(this.messages, {
       id: UUID.generateUuid(),
-      registerOptions: Object.assign({}, { documentSelector: documentSelector })
+      registerOptions: options
     })
   }
 
   protected registerLanguageProvider(
     options: TextDocumentRegistrationOptions
-  ): Disposable {
-    let client = this._client
-    let provideDocumentFormattingEdits: ProvideDocumentFormattingEditsSignature = (
-      document,
-      options,
-      token
-    ) => {
-      let params: DocumentFormattingParams = {
-        textDocument: {
-          uri: document.uri
-        },
-        options
-      }
-      return client
-        .sendRequest(DocumentFormattingRequest.type, params, token)
-        .then(res => res, error => {
-          client.logFailedRequest(DocumentFormattingRequest.type, error)
-          return Promise.resolve([])
-        })
-    }
-    let middleware = client.clientOptions.middleware!
-    return languages.registerDocumentFormatProvider(
-      options.documentSelector!,
-      {
-        provideDocumentFormattingEdits: (
-          document: TextDocument,
-          options: FormattingOptions,
-          token: CancellationToken
-        ): ProviderResult<TextEdit[]> => {
-          return middleware.provideDocumentFormattingEdits
-            ? middleware.provideDocumentFormattingEdits(
-              document,
-              options,
-              token,
-              provideDocumentFormattingEdits
-            )
-            : provideDocumentFormattingEdits(document, options, token)
+  ): [Disposable, DocumentFormattingEditProvider] {
+    const provider: DocumentFormattingEditProvider = {
+      provideDocumentFormattingEdits: (document, options, token) => {
+        const client = this._client
+        const provideDocumentFormattingEdits: ProvideDocumentFormattingEditsSignature = (document, options, token) => {
+          const params: DocumentFormattingParams = {
+            textDocument: { uri: document.uri },
+            options
+          }
+          return client.sendRequest(DocumentFormattingRequest.type, params, token).then(res => res, (error) => {
+            client.logFailedRequest(DocumentFormattingRequest.type, error)
+            return Promise.resolve([])
+          })
         }
+        const middleware = client.clientOptions.middleware!
+        return middleware.provideDocumentFormattingEdits
+          ? middleware.provideDocumentFormattingEdits(document, options, token, provideDocumentFormattingEdits)
+          : provideDocumentFormattingEdits(document, options, token)
       }
-    )
+    }
+
+    return [languages.registerDocumentFormatProvider(options.documentSelector!, provider), provider]
   }
 }
 
-class DocumentRangeFormattingFeature extends TextDocumentFeature<TextDocumentRegistrationOptions> {
+class DocumentRangeFormattingFeature extends TextDocumentFeature<
+  boolean | DocumentRangeFormattingOptions, DocumentRangeFormattingRegistrationOptions, DocumentRangeFormattingEditProvider
+  > {
   constructor(client: BaseLanguageClient) {
     super(client, DocumentRangeFormattingRequest.type)
   }
@@ -2572,70 +2527,47 @@ class DocumentRangeFormattingFeature extends TextDocumentFeature<TextDocumentReg
     capabilities: ServerCapabilities,
     documentSelector: DocumentSelector
   ): void {
-    if (!capabilities.documentRangeFormattingProvider || !documentSelector) {
-      return
+    const options = this.getRegistrationOptions(documentSelector, capabilities.documentRangeFormattingProvider);
+    if (!options) {
+      return;
     }
     this.register(this.messages, {
       id: UUID.generateUuid(),
-      registerOptions: Object.assign({}, { documentSelector: documentSelector })
+      registerOptions: options
     })
   }
 
   protected registerLanguageProvider(
     options: TextDocumentRegistrationOptions
-  ): Disposable {
-    let client = this._client
-    let provideDocumentRangeFormattingEdits: ProvideDocumentRangeFormattingEditsSignature = (
-      document,
-      range,
-      options,
-      token
-    ) => {
-      let params: DocumentRangeFormattingParams = {
-        textDocument: {
-          uri: document.uri
-        },
-        range,
-        options,
-      }
-      return client
-        .sendRequest(DocumentRangeFormattingRequest.type, params, token)
-        .then(res => res, error => {
-          client.logFailedRequest(DocumentRangeFormattingRequest.type, error)
-          return Promise.resolve([])
-        })
-    }
-    let middleware = client.clientOptions.middleware!
-    return languages.registerDocumentRangeFormatProvider(
-      options.documentSelector!,
-      {
-        provideDocumentRangeFormattingEdits: (
-          document: TextDocument,
-          range: Range,
-          options: FormattingOptions,
-          token: CancellationToken
-        ): ProviderResult<TextEdit[]> => {
-          return middleware.provideDocumentRangeFormattingEdits
-            ? middleware.provideDocumentRangeFormattingEdits(
-              document,
-              range,
-              options,
-              token,
-              provideDocumentRangeFormattingEdits
-            )
-            : provideDocumentRangeFormattingEdits(
-              document,
-              range,
-              options,
-              token
-            )
+  ): [Disposable, DocumentRangeFormattingEditProvider] {
+    const provider: DocumentRangeFormattingEditProvider = {
+      provideDocumentRangeFormattingEdits: (document, range, options, token) => {
+        const client = this._client
+        const provideDocumentRangeFormattingEdits: ProvideDocumentRangeFormattingEditsSignature = (document, range, options, token) => {
+          const params: DocumentRangeFormattingParams = {
+            textDocument: { uri: document.uri },
+            range,
+            options,
+          }
+          return client.sendRequest(DocumentRangeFormattingRequest.type, params, token).then(res => res, error => {
+            client.logFailedRequest(DocumentRangeFormattingRequest.type, error)
+            return Promise.resolve([])
+          })
         }
+        const middleware = client.clientOptions.middleware!
+        return middleware.provideDocumentRangeFormattingEdits
+          ? middleware.provideDocumentRangeFormattingEdits(document, range, options, token, provideDocumentRangeFormattingEdits)
+          : provideDocumentRangeFormattingEdits(document, range, options, token)
       }
-    )
+    }
+
+    return [languages.registerDocumentRangeFormatProvider(options.documentSelector, provider), provider]
   }
 }
 
-class DocumentOnTypeFormattingFeature extends TextDocumentFeature<DocumentOnTypeFormattingRegistrationOptions> {
+class DocumentOnTypeFormattingFeature extends TextDocumentFeature<
+  DocumentOnTypeFormattingOptions, DocumentOnTypeFormattingRegistrationOptions, OnTypeFormattingEditProvider
+  > {
 
   constructor(client: BaseLanguageClient) {
     super(client, DocumentOnTypeFormattingRequest.type)
@@ -2646,45 +2578,46 @@ class DocumentOnTypeFormattingFeature extends TextDocumentFeature<DocumentOnType
   }
 
   public initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {
-    if (!capabilities.documentOnTypeFormattingProvider || !documentSelector) {
-      return
+    const options = this.getRegistrationOptions(documentSelector, capabilities.documentOnTypeFormattingProvider);
+    if (!options) {
+      return;
     }
     this.register(this.messages, {
       id: UUID.generateUuid(),
-      registerOptions: Object.assign({}, { documentSelector: documentSelector }, capabilities.documentOnTypeFormattingProvider)
+      registerOptions: options
     })
   }
 
-  protected registerLanguageProvider(options: DocumentOnTypeFormattingRegistrationOptions): Disposable {
-    let client = this._client
-    let moreTriggerCharacter = options.moreTriggerCharacter || []
-    let provideOnTypeFormattingEdits: ProvideOnTypeFormattingEditsSignature = (document, position, ch, options, token) => {
-      let params: DocumentOnTypeFormattingParams = {
-        textDocument: cv.asVersionedTextDocumentIdentifier(document),
-        position,
-        ch,
-        options
+  protected registerLanguageProvider(options: DocumentOnTypeFormattingRegistrationOptions): [Disposable, OnTypeFormattingEditProvider] {
+    const provider: OnTypeFormattingEditProvider = {
+      provideOnTypeFormattingEdits: (document, position, ch, options, token) => {
+        const client = this._client
+        const provideOnTypeFormattingEdits: ProvideOnTypeFormattingEditsSignature = (document, position, ch, options, token) => {
+          const params: DocumentOnTypeFormattingParams = {
+            textDocument: cv.asVersionedTextDocumentIdentifier(document),
+            position,
+            ch,
+            options
+          }
+          return client.sendRequest(DocumentOnTypeFormattingRequest.type, params, token).then(res => res, (error) => {
+            client.logFailedRequest(DocumentOnTypeFormattingRequest.type, error)
+            return Promise.resolve([])
+          })
+        };
+        const middleware = client.clientOptions.middleware!;
+        return middleware.provideOnTypeFormattingEdits
+          ? middleware.provideOnTypeFormattingEdits(document, position, ch, options, token, provideOnTypeFormattingEdits)
+          : provideOnTypeFormattingEdits(document, position, ch, options, token);
       }
-      return client.sendRequest(DocumentOnTypeFormattingRequest.type, params, token).then(res => res, error => {
-        client.logFailedRequest(DocumentOnTypeFormattingRequest.type, error)
-        return Promise.resolve([])
-      })
     }
 
-    let middleware = client.clientOptions.middleware!
-    let characters = [options.firstTriggerCharacter, ...moreTriggerCharacter]
-    return languages.registerOnTypeFormattingEditProvider(
-      options.documentSelector!, {
-        provideOnTypeFormattingEdits: (document: TextDocument, position: Position, ch: string, options: FormattingOptions, token: CancellationToken): ProviderResult<TextEdit[]> => {
-          return middleware.provideOnTypeFormattingEdits
-            ? middleware.provideOnTypeFormattingEdits(document, position, ch, options, token, provideOnTypeFormattingEdits)
-            : provideOnTypeFormattingEdits(document, position, ch, options, token)
-        }
-      }, characters)
+    const moreTriggerCharacter = options.moreTriggerCharacter || []
+    const characters = [options.firstTriggerCharacter, ...moreTriggerCharacter]
+    return [languages.registerOnTypeFormattingEditProvider(options.documentSelector!, provider, characters), provider]
   }
 }
 
-class RenameFeature extends TextDocumentFeature<TextDocumentRegistrationOptions> {
+class RenameFeature extends TextDocumentFeature<boolean | RenameOptions, RenameRegistrationOptions, RenameProvider> {
   constructor(client: BaseLanguageClient) {
     super(client, RenameRequest.type)
   }
@@ -2699,181 +2632,148 @@ class RenameFeature extends TextDocumentFeature<TextDocumentRegistrationOptions>
     capabilities: ServerCapabilities,
     documentSelector: DocumentSelector
   ): void {
-    if (!capabilities.renameProvider || !documentSelector) {
-      return
+    const options = this.getRegistrationOptions(documentSelector, capabilities.renameProvider);
+    if (!options) {
+      return;
+    }
+    if (Is.boolean(capabilities.renameProvider)) {
+      options.prepareProvider = false;
     }
     this.register(this.messages, {
       id: UUID.generateUuid(),
-      registerOptions: Object.assign({}, { documentSelector: documentSelector }, capabilities.renameProvider || {})
+      registerOptions: options
     })
   }
 
-  protected registerLanguageProvider(options: RenameRegistrationOptions): Disposable {
-    let client = this._client
-    let provideRenameEdits: ProvideRenameEditsSignature = (
-      document,
-      position,
-      newName,
-      token
-    ) => {
-      let params: RenameParams = {
-        textDocument: {
-          uri: document.uri
-        },
-        position,
-        newName: newName
-      }
-      return client
-        .sendRequest(RenameRequest.type, params, token)
-        .then(res => res, (error: ResponseError<void>) => {
-          client.logFailedRequest(RenameRequest.type, error)
-          return Promise.reject(new Error(error.message))
+  protected registerLanguageProvider(options: RenameRegistrationOptions): [Disposable, RenameProvider] {
+    const provider: RenameProvider = {
+      provideRenameEdits: (document, position, newName, token) => {
+        const client = this._client
+        const provideRenameEdits: ProvideRenameEditsSignature = (document, position, newName, token) => {
+          const params: RenameParams = {
+            textDocument: { uri: document.uri },
+            position,
+            newName: newName
+          }
+          return client.sendRequest(RenameRequest.type, params, token).then(res => res, (error: ResponseError<void>) => {
+            client.logFailedRequest(RenameRequest.type, error)
+            return Promise.reject(new Error(error.message))
+          })
         }
-        )
-    }
-    let prepareRename: PrepareRenameSignature = (document, position, token) => {
-      let params: TextDocumentPositionParams = {
-        textDocument: cv.asTextDocumentIdentifier(document),
-        position
-      }
-      return client.sendRequest(PrepareRenameRequest.type, params, token).then(result => {
-        return result
+        const middleware = client.clientOptions.middleware!;
+        return middleware.provideRenameEdits
+          ? middleware.provideRenameEdits(document, position, newName, token, provideRenameEdits)
+          : provideRenameEdits(document, position, newName, token)
       },
-        (error: ResponseError<void>) => {
-          client.logFailedRequest(PrepareRenameRequest.type, error)
-          return Promise.reject(new Error(error.message))
+      prepareRename: options.prepareProvider
+        ? (document, position, token) => {
+          const client = this._client
+          const prepareRename: PrepareRenameSignature = (document, position, token) => {
+            const params: TextDocumentPositionParams = {
+              textDocument: cv.asTextDocumentIdentifier(document),
+              position
+            }
+            return client.sendRequest(PrepareRenameRequest.type, params, token).then(
+              (result) => {
+                if (Range.is(result)) {
+                  return result
+                } else if (result && Range.is(result.range)) {
+                  return {
+                    range: result.range,
+                    placeholder: result.placeholder
+                  };
+                }
+                // To cancel the rename vscode API expects a rejected promise.
+                return Promise.reject(new Error(`The element can't be renamed.`));
+              },
+              (error: ResponseError<void>) => {
+                client.logFailedRequest(PrepareRenameRequest.type, error);
+                return Promise.reject(new Error(error.message))
+              }
+            )
+          }
+          const middleware = client.clientOptions.middleware!;
+          return middleware.prepareRename
+            ? middleware.prepareRename(document, position, token, prepareRename)
+            : prepareRename(document, position, token);
         }
-      )
+        : undefined
     }
 
-    let middleware = client.clientOptions.middleware!
-    return languages.registerRenameProvider(
-      options.documentSelector, {
-        provideRenameEdits: (
-          document: TextDocument,
-          position: Position,
-          newName: string,
-          token: CancellationToken
-        ): ProviderResult<WorkspaceEdit> => {
-          return middleware.provideRenameEdits
-            ? middleware.provideRenameEdits(
-              document,
-              position,
-              newName,
-              token,
-              provideRenameEdits
-            )
-            : provideRenameEdits(document, position, newName, token)
-        },
-        prepareRename: options.prepareProvider
-          ? (document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Range | { range: Range, placeholder: string }> => {
-            return middleware.prepareRename
-              ? middleware.prepareRename(document, position, token, prepareRename)
-              : prepareRename(document, position, token)
-          } : undefined
-      })
+    return [languages.registerRenameProvider(options.documentSelector, provider), provider]
   }
 }
 
-class DocumentLinkFeature extends TextDocumentFeature<
-  DocumentLinkRegistrationOptions
-  > {
+class DocumentLinkFeature extends TextDocumentFeature<DocumentLinkOptions, DocumentLinkRegistrationOptions, DocumentLinkProvider> {
   constructor(client: BaseLanguageClient) {
     super(client, DocumentLinkRequest.type)
   }
 
   public fillClientCapabilities(capabilites: ClientCapabilities): void {
-    ensure(
-      ensure(capabilites, 'textDocument')!,
-      'documentLink'
-    )!.dynamicRegistration = true
+    const documentLinkCapabilities = ensure(ensure(capabilites, 'textDocument')!, 'documentLink')!
+    documentLinkCapabilities.dynamicRegistration = true
+    documentLinkCapabilities.tooltipSupport = true // TODO
   }
 
   public initialize(
     capabilities: ServerCapabilities,
     documentSelector: DocumentSelector
   ): void {
-    if (!capabilities.documentLinkProvider || !documentSelector) {
-      return
+    const options = this.getRegistrationOptions(documentSelector, capabilities.documentLinkProvider);
+    if (!options) {
+      return;
     }
     this.register(this.messages, {
       id: UUID.generateUuid(),
-      registerOptions: Object.assign(
-        {},
-        { documentSelector: documentSelector },
-        capabilities.documentLinkProvider
-      )
+      registerOptions: options
     })
   }
 
   protected registerLanguageProvider(
     options: DocumentLinkRegistrationOptions
-  ): Disposable {
-    let client = this._client
-    let provideDocumentLinks: ProvideDocumentLinksSignature = (document, token) => {
-      return client.sendRequest(
-        DocumentLinkRequest.type,
-        {
-          textDocument: {
-            uri: document.uri
-          }
-        },
-        token
-      ).then(
-        res => res,
-        (error: ResponseError<void>) => {
-          client.logFailedRequest(DocumentLinkRequest.type, error)
-          Promise.resolve(new Error(error.message))
+  ): [Disposable, DocumentLinkProvider] {
+    const provider: DocumentLinkProvider = {
+      provideDocumentLinks: (document: TextDocument, token: CancellationToken): ProviderResult<DocumentLink[]> => {
+        const client = this._client
+        const provideDocumentLinks: ProvideDocumentLinksSignature = (document, token) => {
+          return client.sendRequest(
+            DocumentLinkRequest.type,
+            {
+              textDocument: { uri: document.uri }
+            },
+            token
+          ).then(res => res, (error: ResponseError<void>) => {
+            client.logFailedRequest(DocumentLinkRequest.type, error)
+            return Promise.resolve([])
+          })
         }
-      )
-    }
-    let resolveDocumentLink = (link, token) => {
-      return client
-        .sendRequest(
-          DocumentLinkResolveRequest.type,
-          link,
-          token
-        )
-        .then(
-          res => res,
-          (error: ResponseError<void>) => {
-            client.logFailedRequest(DocumentLinkResolveRequest.type, error)
-            Promise.resolve(new Error(error.message))
+        const middleware = client.clientOptions.middleware!
+        return middleware.provideDocumentLinks
+          ? middleware.provideDocumentLinks(document, token, provideDocumentLinks)
+          : provideDocumentLinks(document, token)
+      },
+      resolveDocumentLink: options.resolveProvider
+        ? (link, token) => {
+          const client = this._client
+          let resolveDocumentLink: ResolveDocumentLinkSignature = (link, token) => {
+            return client.sendRequest(DocumentLinkResolveRequest.type, link, token).then(res => res, (error: ResponseError<void>) => {
+              client.logFailedRequest(DocumentLinkResolveRequest.type, error)
+              return Promise.resolve(link)
+            })
           }
-        )
+          const middleware = client.clientOptions.middleware!
+          return middleware.resolveDocumentLink
+            ? middleware.resolveDocumentLink(link, token, resolveDocumentLink)
+            : resolveDocumentLink(link, token)
+        }
+        : undefined
     }
-    let middleware = client.clientOptions.middleware!
-    return languages.registerDocumentLinkProvider(
-      options.documentSelector!,
-      {
-        provideDocumentLinks: (
-          document: TextDocument,
-          token: CancellationToken
-        ): ProviderResult<DocumentLink[]> => {
-          return middleware.provideDocumentLinks
-            ? middleware.provideDocumentLinks(
-              document,
-              token,
-              provideDocumentLinks
-            )
-            : provideDocumentLinks(document, token)
-        },
-        resolveDocumentLink: options.resolveProvider
-          ? (
-            link: DocumentLink,
-            token: CancellationToken
-          ): ProviderResult<DocumentLink> => {
-            return middleware.resolveDocumentLink
-              ? middleware.resolveDocumentLink(link, token, resolveDocumentLink)
-              : resolveDocumentLink(link, token)
-          }
-          : undefined
-      })
+
+    return [languages.registerDocumentLinkProvider(options.documentSelector, provider), provider]
   }
 }
 
-class ConfigurationFeature
-  implements DynamicFeature<DidChangeConfigurationRegistrationOptions> {
+class ConfigurationFeature implements DynamicFeature<DidChangeConfigurationRegistrationOptions> {
   private _listeners: Map<string, Disposable> = new Map<string, Disposable>()
 
   constructor(private _client: BaseLanguageClient) { }
@@ -2888,7 +2788,7 @@ class ConfigurationFeature
 
   public initialize(): void {
     let section = this._client.clientOptions.synchronize!.configurationSection
-    if (section != null) {
+    if (section !== void 0) {
       this.register(this.messages, {
         id: UUID.generateUuid(),
         registerOptions: {
@@ -2903,9 +2803,9 @@ class ConfigurationFeature
     data: RegistrationData<DidChangeConfigurationRegistrationOptions>
   ): void {
     let { section } = data.registerOptions
-    let disposable = workspace.onDidChangeConfiguration(() => {
+    let disposable = workspace.onDidChangeConfiguration((event) => {
       if (section != null) {
-        this.onDidChangeConfiguration(data.registerOptions.section)
+        this.onDidChangeConfiguration(data.registerOptions.section, event)
       }
     })
     this._listeners.set(data.id, disposable)
@@ -2914,7 +2814,7 @@ class ConfigurationFeature
       if (!settings || Is.emptyObject(settings)) return
     }
     if (section != null) {
-      this.onDidChangeConfiguration(data.registerOptions.section)
+      this.onDidChangeConfiguration(data.registerOptions.section, undefined)
     }
   }
 
@@ -2933,12 +2833,18 @@ class ConfigurationFeature
     this._listeners.clear()
   }
 
-  private onDidChangeConfiguration(configurationSection: string | string[]): void {
+  private onDidChangeConfiguration(configurationSection: string | string[], event: ConfigurationChangeEvent | undefined): void {
     let sections: string[] | undefined
     if (Is.string(configurationSection)) {
       sections = [configurationSection]
     } else {
       sections = configurationSection
+    }
+    if (sections !== void 0 && event !== void 0) {
+      const affected = sections.some((section) => event.affectsConfiguration(section));
+      if (!affected) {
+        return
+      }
     }
     let isConfigured = sections.length == 1 && /^languageserver\..+\.settings$/.test(sections[0])
     let didChangeConfiguration = (sections: string[] | undefined): void => {
@@ -3035,23 +2941,25 @@ class ExecuteCommandFeature
     _message: RPCMessageType,
     data: RegistrationData<ExecuteCommandRegistrationOptions>
   ): void {
-    let client = this._client
+    const client = this._client
+    const middleware = client.clientOptions.middleware!
+    const executeCommand: ExecuteCommandSignature = (command: string, args: any[]): any => {
+      const params: ExecuteCommandParams = {
+        command,
+        arguments: args
+      }
+      return client.sendRequest(ExecuteCommandRequest.type, params).then(undefined, (error) => {
+        client.logFailedRequest(ExecuteCommandRequest.type, error)
+      })
+    }
     if (data.registerOptions.commands) {
       let disposables: Disposable[] = []
       for (const command of data.registerOptions.commands) {
-        disposables.push(
-          commands.registerCommand(command, (...args: any[]) => {
-            let params: ExecuteCommandParams = {
-              command,
-              arguments: args
-            }
-            return client
-              .sendRequest(ExecuteCommandRequest.type, params)
-              .then(undefined, error => {
-                client.logFailedRequest(ExecuteCommandRequest.type, error)
-              })
-          }, null, true)
-        )
+        disposables.push(commands.registerCommand(command, (...args: any[]) => {
+          return middleware.executeCommand
+            ? middleware.executeCommand(command, args, executeCommand)
+            : executeCommand(command, args)
+        }, null, true))
       }
       this._commands.set(data.id, disposables)
     }
@@ -3089,6 +2997,27 @@ export namespace MessageTransports {
   }
 }
 
+class OnReady {
+  private _used: boolean
+  constructor(private _resolve: () => void, private _reject: (error: any) => void) {
+    this._used = false
+  }
+
+  public get isUsed(): boolean {
+    return this._used
+  }
+
+  public resolve(): void {
+    this._used = true
+    this._resolve()
+  }
+
+  public reject(error: any): void {
+    this._used = true
+    this._reject(error)
+  }
+}
+
 export abstract class BaseLanguageClient {
   private _id: string
   private _name: string
@@ -3097,14 +3026,13 @@ export abstract class BaseLanguageClient {
   protected _state: ClientState
   private _onReady: Promise<void>
   private _onReadyCallbacks: OnReady
-  private _onStop: Thenable<void> | undefined
-  private _connectionPromise: Thenable<IConnection> | undefined
+  private _onStop: Promise<void> | undefined
+  private _connectionPromise: Promise<IConnection> | undefined
   private _resolvedConnection: IConnection | undefined
   private _initializeResult: InitializeResult | undefined
   private _disposeOutputChannel: boolean
   private _outputChannel: OutputChannel | undefined
-  private _capabilities: ServerCapabilities &
-    ResolvedTextDocumentSyncCapabilities
+  private _capabilities: ServerCapabilities & ResolvedTextDocumentSyncCapabilities
 
   private _listeners: Disposable[] | undefined
   private _providers: Disposable[] | undefined
@@ -3152,8 +3080,8 @@ export abstract class BaseLanguageClient {
         stdioEncoding: clientOptions.stdioEncoding || 'utf8',
         initializationOptions: clientOptions.initializationOptions,
         initializationFailedHandler: clientOptions.initializationFailedHandler,
-        errorHandler:
-          clientOptions.errorHandler || new DefaultErrorHandler(this._id),
+        progressOnInitialization: !!clientOptions.progressOnInitialization,
+        errorHandler: clientOptions.errorHandler || new DefaultErrorHandler(this._id),
         middleware: clientOptions.middleware || {},
         workspaceFolder: clientOptions.workspaceFolder
       }
@@ -3227,22 +3155,22 @@ export abstract class BaseLanguageClient {
   public sendRequest<R, E, RO>(
     type: RequestType0<R, E, RO>,
     token?: CancellationToken
-  ): Thenable<R>
+  ): Promise<R>
   public sendRequest<P, R, E, RO>(
     type: RequestType<P, R, E, RO>,
     params: P,
     token?: CancellationToken
-  ): Thenable<R>
-  public sendRequest<R>(method: string, token?: CancellationToken): Thenable<R>
+  ): Promise<R>
+  public sendRequest<R>(method: string, token?: CancellationToken): Promise<R>
   public sendRequest<R>(
     method: string,
     param: any,
     token?: CancellationToken
-  ): Thenable<R>
+  ): Promise<R>
   public sendRequest<R>(
     type: string | RPCMessageType,
     ...params: any[]
-  ): Thenable<R> {
+  ): Promise<R> {
     if (!this.isConnectionActive()) {
       throw new Error('Language client is not ready yet')
     }
@@ -3291,10 +3219,7 @@ export abstract class BaseLanguageClient {
   }
 
   public sendNotification<RO>(type: NotificationType0<RO>): void
-  public sendNotification<P, RO>(
-    type: NotificationType<P, RO>,
-    params?: P
-  ): void
+  public sendNotification<P, RO>(type: NotificationType<P, RO>, params?: P): void
   public sendNotification(method: string): void
   public sendNotification(method: string, params: any): void
   public sendNotification<P>(type: string | RPCMessageType, params?: P): void {
@@ -3314,18 +3239,9 @@ export abstract class BaseLanguageClient {
   }
 
   public onNotification<RO>(type: NotificationType0<RO>, handler: NotificationHandler0): void
-  public onNotification<P, RO>(
-    type: NotificationType<P, RO>,
-    handler: NotificationHandler<P>
-  ): void
-  public onNotification(
-    method: string,
-    handler: GenericNotificationHandler
-  ): void
-  public onNotification(
-    type: string | RPCMessageType,
-    handler: GenericNotificationHandler
-  ): void {
+  public onNotification<P, RO>(type: NotificationType<P, RO>, handler: NotificationHandler<P>): void
+  public onNotification(method: string, handler: GenericNotificationHandler): void
+  public onNotification(type: string | RPCMessageType, handler: GenericNotificationHandler): void {
     if (!this.isConnectionActive()) {
       throw new Error('Language client is not ready yet')
     }
@@ -3339,6 +3255,31 @@ export abstract class BaseLanguageClient {
         error
       )
       throw error
+    }
+  }
+
+  public onProgress<P>(type: ProgressType<P>, token: string | number, handler: NotificationHandler<P>): Disposable {
+    if (!this.isConnectionActive()) {
+      throw new Error('Language client is not ready yet');
+    }
+    try {
+      return this._resolvedConnection!.onProgress(type, token, handler);
+    } catch (error) {
+      this.error(`Registering progress handler for token ${token} failed.`, error);
+      throw error;
+    }
+  }
+
+  public sendProgress<P>(type: ProgressType<P>, token: string | number, value: P): void {
+    if (!this.isConnectionActive()) {
+      throw new Error('Language client is not ready yet');
+    }
+    this.forceDocumentSync();
+    try {
+      this._resolvedConnection!.sendProgress(type, token, value);
+    } catch (error) {
+      this.error(`Sending progress for token ${token} failed.`, error);
+      throw error;
     }
   }
 
@@ -3555,7 +3496,7 @@ export abstract class BaseLanguageClient {
     })
   }
 
-  private resolveConnection(): Thenable<IConnection> {
+  private resolveConnection(): Promise<IConnection> {
     if (!this._connectionPromise) {
       this._connectionPromise = this.createConnection()
     }
@@ -3587,7 +3528,7 @@ export abstract class BaseLanguageClient {
     return rootPath
   }
 
-  private initialize(connection: IConnection): Thenable<InitializeResult> {
+  private initialize(connection: IConnection): Promise<InitializeResult> {
     this.refreshTrace(connection, false)
     this._clientOptions.invalidate()
     let initOption = this._clientOptions.value().initializationOptions
@@ -3601,101 +3542,117 @@ export abstract class BaseLanguageClient {
       capabilities: this.computeClientCapabilities(),
       initializationOptions: Is.func(initOption) ? initOption() : initOption,
       trace: Trace.toString(this._trace),
+      workspaceFolders: null
     }
     this.fillInitializeParams(initParams)
-    return connection
-      .initialize(initParams)
-      .then(result => {
-        this._resolvedConnection = connection
-        this._initializeResult = result
-        this.state = ClientState.Running
+    this._clientOptions.value().progressOnInitialization
+    if (this._clientOptions.value().progressOnInitialization) {
+      const token: ProgressToken = UUID.generateUuid()
+      const part: ProgressPart = new ProgressPart(connection, token)
+      initParams.workDoneToken = token
+      return this.doInitialize(connection, initParams).then((result) => {
+        part.done()
+        return result;
+      }, (error) => {
+        part.cancel();
+        throw error;
+      });
+    } else {
+      return this.doInitialize(connection, initParams)
+    }
+  }
 
-        let textDocumentSyncOptions:
-          | TextDocumentSyncOptions
-          | undefined = undefined
-        if (Is.number(result.capabilities.textDocumentSync)) {
-          if (result.capabilities.textDocumentSync === TextDocumentSyncKind.None) {
-            textDocumentSyncOptions = {
-              openClose: false,
-              change: TextDocumentSyncKind.None,
-              save: undefined
-            }
-          } else {
-            textDocumentSyncOptions = {
-              openClose: true,
-              change: result.capabilities.textDocumentSync,
-              save: {
-                includeText: false
-              }
+  private doInitialize(connection: IConnection, initParams: InitializeParams): Promise<InitializeResult> {
+    return connection.initialize(initParams).then(result => {
+      this._resolvedConnection = connection
+      this._initializeResult = result
+      this.state = ClientState.Running
+
+      let textDocumentSyncOptions: TextDocumentSyncOptions | undefined = undefined
+      if (Is.number(result.capabilities.textDocumentSync)) {
+        if (result.capabilities.textDocumentSync === TextDocumentSyncKind.None) {
+          textDocumentSyncOptions = {
+            openClose: false,
+            change: TextDocumentSyncKind.None,
+            save: undefined
+          }
+        } else {
+          textDocumentSyncOptions = {
+            openClose: true,
+            change: result.capabilities.textDocumentSync,
+            save: {
+              includeText: false
             }
           }
-        } else if (result.capabilities.textDocumentSync != null) {
-          textDocumentSyncOptions = result.capabilities.textDocumentSync as TextDocumentSyncOptions
         }
-        this._capabilities = Object.assign({}, result.capabilities, {
-          resolvedTextDocumentSync: textDocumentSyncOptions
-        })
-        if (!this._clientOptions.value().disableDiagnostics) {
-          connection.onDiagnostics(params => this.handleDiagnostics(params))
+      } else if (result.capabilities.textDocumentSync != null) {
+        textDocumentSyncOptions = result.capabilities.textDocumentSync as TextDocumentSyncOptions
+      }
+      this._capabilities = Object.assign({}, result.capabilities, {
+        resolvedTextDocumentSync: textDocumentSyncOptions
+      })
+      if (!this._clientOptions.value().disableDiagnostics) {
+        connection.onDiagnostics(params => this.handleDiagnostics(params))
+      }
+      connection.onRequest(RegistrationRequest.type, params =>
+        this.handleRegistrationRequest(params)
+      )
+      // See https://github.com/Microsoft/vscode-languageserver-node/issues/199
+      connection.onRequest('client/registerFeature', params =>
+        this.handleRegistrationRequest(params)
+      )
+      connection.onRequest(UnregistrationRequest.type, params =>
+        this.handleUnregistrationRequest(params)
+      )
+      // See https://github.com/Microsoft/vscode-languageserver-node/issues/199
+      connection.onRequest('client/unregisterFeature', params =>
+        this.handleUnregistrationRequest(params)
+      )
+      connection.onRequest(ApplyWorkspaceEditRequest.type, params =>
+        this.handleApplyWorkspaceEdit(params)
+      )
+
+      connection.sendNotification(InitializedNotification.type, {})
+
+      this.hookFileEvents(connection)
+      this.hookConfigurationChanged(connection)
+      this.initializeFeatures(connection)
+      this._onReadyCallbacks.resolve()
+      return result
+    }).then<InitializeResult>(undefined, error => {
+      if (this._clientOptions.value().initializationFailedHandler) {
+        if (this._clientOptions.value().initializationFailedHandler(error)) {
+          this.initialize(connection)
+        } else {
+          this.stop()
+          this._onReadyCallbacks.reject(error)
         }
-        connection.onRequest(RegistrationRequest.type, params =>
-          this.handleRegistrationRequest(params)
-        )
-        // See https://github.com/Microsoft/vscode-languageserver-node/issues/199
-        connection.onRequest('client/registerFeature', params =>
-          this.handleRegistrationRequest(params)
-        )
-        connection.onRequest(UnregistrationRequest.type, params =>
-          this.handleUnregistrationRequest(params)
-        )
-        // See https://github.com/Microsoft/vscode-languageserver-node/issues/199
-        connection.onRequest('client/unregisterFeature', params =>
-          this.handleUnregistrationRequest(params)
-        )
-        connection.onRequest(ApplyWorkspaceEditRequest.type, params =>
-          this.handleApplyWorkspaceEdit(params)
-        )
-
-        connection.sendNotification(InitializedNotification.type, {})
-
-        this.hookFileEvents(connection)
-        this.hookConfigurationChanged(connection)
-        this.initializeFeatures(connection)
-        this._onReadyCallbacks.resolve()
-        return result
-      }).then<InitializeResult>(undefined, error => {
-        if (this._clientOptions.value().initializationFailedHandler) {
-          if (this._clientOptions.value().initializationFailedHandler(error)) {
+      } else if (
+        error instanceof ResponseError &&
+        error.data &&
+        error.data.retry
+      ) {
+        workspace.showPrompt(error.message + ' Retry?').then(confirmed => {
+          if (confirmed) {
             this.initialize(connection)
           } else {
             this.stop()
             this._onReadyCallbacks.reject(error)
           }
-        } else if (
-          error instanceof ResponseError &&
-          error.data &&
-          error.data.retry
-        ) {
-          workspace.showPrompt(error.message + ' Retry?').then(confirmed => {
-            if (confirmed) {
-              this.initialize(connection)
-            } else {
-              this.stop()
-              this._onReadyCallbacks.reject(error)
-            }
-          })
-        } else {
-          if (error && error.message) {
-            workspace.showMessage(error.message, 'error')
-          }
-          this.error('Server initialization failed.', error)
-          this.stop()
-          this._onReadyCallbacks.reject(error)
+        })
+      } else {
+        if (error && error.message) {
+          workspace.showMessage(error.message, 'error')
         }
-      })
+        this.error('Server initialization failed.', error)
+        this.stop()
+        this._onReadyCallbacks.reject(error)
+      }
+      throw error
+    })
   }
 
-  public stop(): Thenable<void> {
+  public stop(): Promise<void> {
     this._initializeResult = undefined
     if (!this._connectionPromise) {
       this.state = ClientState.Stopped
@@ -3712,6 +3669,7 @@ export abstract class BaseLanguageClient {
         connection.exit()
         connection.dispose()
         this.state = ClientState.Stopped
+        this.cleanUpChannel()
         this._onStop = undefined
         this._connectionPromise = undefined
         this._resolvedConnection = undefined
@@ -3734,9 +3692,8 @@ export abstract class BaseLanguageClient {
     for (let handler of this._dynamicFeatures.values()) {
       handler.dispose()
     }
-    if (channel && this._outputChannel && this._disposeOutputChannel) {
-      this._outputChannel.dispose()
-      this._outputChannel = undefined
+    if (channel) {
+      this.cleanUpChannel()
     }
     if (diagnostics && this._diagnostics) {
       this._diagnostics.dispose()
@@ -3744,23 +3701,33 @@ export abstract class BaseLanguageClient {
     }
   }
 
+  private cleanUpChannel(): void {
+    if (this._outputChannel && this._disposeOutputChannel) {
+      this._outputChannel.dispose()
+      this._outputChannel = undefined
+    }
+  }
+
   private notifyFileEvent(event: FileEvent): void {
-    this._fileEvents.push(event)
-    this._fileEventDelayer.trigger(() => {
-      this.onReady().then(
-        () => {
-          this.resolveConnection().then(connection => {
-            if (this.isConnectionActive()) {
-              connection.didChangeWatchedFiles({ changes: this._fileEvents })
+    const client = this
+    function didChangeWatchedFile(this: void, event: FileEvent) {
+      client._fileEvents.push(event)
+      client._fileEventDelayer.trigger(() => {
+        client.onReady().then(() => {
+          client.resolveConnection().then(connection => {
+            if (client.isConnectionActive()) {
+              client.forceDocumentSync()
+              connection.didChangeWatchedFiles({ changes: client._fileEvents })
             }
-            this._fileEvents = []
+            client._fileEvents = []
           })
-        },
-        error => {
-          this.error(`Notify file events failed.`, error)
-        }
-      )
-    })
+        }, (error) => {
+          client.error(`Notify file events failed.`, error)
+        })
+      })
+    }
+    const workSpaceMiddleware = this.clientOptions.middleware?.workspace;
+    workSpaceMiddleware?.didChangeWatchedFile ? workSpaceMiddleware.didChangeWatchedFile(event, didChangeWatchedFile) : didChangeWatchedFile(event)
   }
 
   private forceDocumentSync(): void {
@@ -3792,9 +3759,9 @@ export abstract class BaseLanguageClient {
 
   protected abstract createMessageTransports(
     encoding: string
-  ): Thenable<MessageTransports | null>
+  ): Promise<MessageTransports | null>
 
-  private createConnection(): Thenable<IConnection> {
+  private createConnection(): Promise<IConnection> {
     let errorHandler = (error: Error, message: Message, count: number) => {
       logger.error('connection error:', error, message)
       this.handleConnectionError(error, message, count)
@@ -3948,6 +3915,36 @@ export abstract class BaseLanguageClient {
     }
   }
 
+  public getFeature(request: typeof DidOpenTextDocumentNotification.method): DynamicFeature<TextDocumentRegistrationOptions> & NotificationFeature<(textDocument: TextDocument) => void>
+  public getFeature(request: typeof DidChangeTextDocumentNotification.method): DynamicFeature<TextDocumentRegistrationOptions> & NotificationFeature<(textDocument: TextDocument) => void>
+  public getFeature(request: typeof WillSaveTextDocumentNotification.method): DynamicFeature<TextDocumentRegistrationOptions> & NotificationFeature<(textDocument: TextDocument) => void>
+  public getFeature(request: typeof WillSaveTextDocumentWaitUntilRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & NotificationFeature<(textDocument: TextDocument) => ProviderResult<TextEdit[]>>
+  public getFeature(request: typeof DidSaveTextDocumentNotification.method): DynamicFeature<TextDocumentRegistrationOptions> & NotificationFeature<(textDocument: TextDocument) => void>
+  public getFeature(request: typeof DidCloseTextDocumentNotification.method): DynamicFeature<TextDocumentRegistrationOptions> & NotificationFeature<(textDocument: TextDocument) => void>
+  public getFeature(request: typeof CompletionRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<CompletionItemProvider>
+  public getFeature(request: typeof HoverRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<HoverProvider>
+  public getFeature(request: typeof SignatureHelpRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<SignatureHelpProvider>
+  public getFeature(request: typeof DefinitionRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<DefinitionProvider>
+  public getFeature(request: typeof ReferencesRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<ReferenceProvider>
+  public getFeature(request: typeof DocumentHighlightRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<DocumentHighlightProvider>
+  public getFeature(request: typeof CodeActionRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<CodeActionProvider>
+  public getFeature(request: typeof DocumentFormattingRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<DocumentFormattingEditProvider>
+  public getFeature(request: typeof DocumentRangeFormattingRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<DocumentRangeFormattingEditProvider>
+  public getFeature(request: typeof DocumentOnTypeFormattingRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<OnTypeFormattingEditProvider>
+  public getFeature(request: typeof RenameRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<RenameProvider>
+  public getFeature(request: typeof DocumentLinkRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<DocumentLinkProvider>
+  public getFeature(request: typeof DocumentColorRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<DocumentColorProvider>
+  public getFeature(request: typeof DeclarationRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<DeclarationProvider>
+  public getFeature(request: typeof FoldingRangeRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<FoldingRangeProvider>
+  public getFeature(request: typeof ImplementationRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<ImplementationProvider>
+  public getFeature(request: typeof SelectionRangeRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<SelectionRangeProvider>
+  public getFeature(request: typeof TypeDefinitionRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<TypeDefinitionProvider>
+  public getFeature(request: typeof Proposed.CallHierarchyPrepareRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<TypeDefinitionProvider>
+  public getFeature(request: typeof WorkspaceSymbolRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & WorkspaceProviderFeature<WorkspaceSymbolProvider>
+  public getFeature(request: string): DynamicFeature<any> | undefined {
+    return this._dynamicFeatures.get(request)
+  }
+
   protected registerBuiltinFeatures() {
     this.registerFeature(new ConfigurationFeature(this))
     this.registerFeature(new DidOpenTextDocumentFeature(this, this._syncedDocuments))
@@ -3992,7 +3989,10 @@ export abstract class BaseLanguageClient {
     workspaceEdit.documentChanges = true
     workspaceEdit.resourceOperations = [ResourceOperationKind.Create, ResourceOperationKind.Rename, ResourceOperationKind.Delete]
     workspaceEdit.failureHandling = FailureHandlingKind.TextOnlyTransactional
-    ensure(ensure(result, 'textDocument')!, 'publishDiagnostics')!.relatedInformation = true
+    const diagnostics = ensure(ensure(result, 'textDocument')!, 'publishDiagnostics')!
+    diagnostics.relatedInformation = true
+    diagnostics.versionSupport = false
+    diagnostics.tagSupport = { valueSet: [DiagnosticTag.Unnecessary, DiagnosticTag.Deprecated] } // TODO
     for (let feature of this._features) {
       feature.fillClientCapabilities(result)
     }
@@ -4008,7 +4008,7 @@ export abstract class BaseLanguageClient {
 
   private handleRegistrationRequest(
     params: RegistrationParams
-  ): Thenable<void> {
+  ): Promise<void> {
     if (this.clientOptions.disableDynamicRegister) return Promise.resolve()
     return new Promise<void>((resolve, reject) => {
       for (let registration of params.registrations) {
@@ -4036,7 +4036,7 @@ export abstract class BaseLanguageClient {
 
   private handleUnregistrationRequest(
     params: UnregistrationParams
-  ): Thenable<void> {
+  ): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       for (let unregistration of params.unregisterations) {
         const feature = this._dynamicFeatures.get(unregistration.method)
@@ -4056,11 +4056,30 @@ export abstract class BaseLanguageClient {
 
   private handleApplyWorkspaceEdit(
     params: ApplyWorkspaceEditParams
-  ): Thenable<ApplyWorkspaceEditResponse> {
+  ): Promise<ApplyWorkspaceEditResponse> {
+    // This is some sort of workaround since the version check should be done by VS Code in the Workspace.applyEdit.
+    // However doing it here adds some safety since the server can lag more behind then an extension.
+    let workspaceEdit: WorkspaceEdit = params.edit;
+    let openTextDocuments: Map<string, TextDocument> = new Map<string, TextDocument>();
+    workspace.textDocuments.forEach((document) => openTextDocuments.set(document.uri.toString(), document));
+    let versionMismatch = false;
+    if (workspaceEdit.documentChanges) {
+      for (const change of workspaceEdit.documentChanges) {
+        if (TextDocumentEdit.is(change) && change.textDocument.version && change.textDocument.version >= 0) {
+          let textDocument = openTextDocuments.get(change.textDocument.uri);
+          if (textDocument && textDocument.version !== change.textDocument.version) {
+            versionMismatch = true;
+            break;
+          }
+        }
+      }
+    }
+    if (versionMismatch) {
+      return Promise.resolve({ applied: false });
+    }
     return workspace.applyEdit(params.edit).then(value => {
       return { applied: value }
-    }
-    )
+    })
   }
 
   public logFailedRequest(type: RPCMessageType, error: any): void {

--- a/src/language-client/client.ts
+++ b/src/language-client/client.ts
@@ -2189,7 +2189,7 @@ class DocumentSymbolFeature extends TextDocumentFeature<
     symbolCapabilities.symbolKind = {
       valueSet: SupportedSymbolKinds
     }
-    symbolCapabilities.hierarchicalDocumentSymbolSupport // TODO
+    symbolCapabilities.hierarchicalDocumentSymbolSupport = true
   }
 
   public initialize(
@@ -3991,7 +3991,7 @@ export abstract class BaseLanguageClient {
     const diagnostics = ensure(ensure(result, 'textDocument')!, 'publishDiagnostics')!
     diagnostics.relatedInformation = true
     diagnostics.versionSupport = false
-    diagnostics.tagSupport = { valueSet: [DiagnosticTag.Unnecessary, DiagnosticTag.Deprecated] } // TODO
+    diagnostics.tagSupport = { valueSet: [DiagnosticTag.Unnecessary, DiagnosticTag.Deprecated] }
     for (let feature of this._features) {
       feature.fillClientCapabilities(result)
     }

--- a/src/language-client/implementation.ts
+++ b/src/language-client/implementation.ts
@@ -32,7 +32,7 @@ export class ImplementationFeature extends TextDocumentFeature<boolean | Impleme
   public fillClientCapabilities(capabilites: ClientCapabilities): void {
     const implementationSupport = ensure(ensure(capabilites, 'textDocument')!, 'implementation')!
     implementationSupport.dynamicRegistration = true
-    implementationSupport.linkSupport = true
+    // implementationSupport.linkSupport = true
   }
 
   public initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {

--- a/src/language-client/implementation.ts
+++ b/src/language-client/implementation.ts
@@ -2,12 +2,10 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { CancellationToken, ClientCapabilities, Definition, Disposable, DocumentSelector, ImplementationRequest, Position, ServerCapabilities, TextDocument, TextDocumentRegistrationOptions } from 'vscode-languageserver-protocol'
+import { CancellationToken, ClientCapabilities, Definition, Disposable, DocumentSelector, ImplementationOptions, ImplementationRegistrationOptions, ImplementationRequest, Position, ServerCapabilities, TextDocument } from 'vscode-languageserver-protocol'
 import languages from '../languages'
-import { ProviderResult } from '../provider'
-import * as Is from '../util/is'
+import { ImplementationProvider, ProviderResult } from '../provider'
 import { BaseLanguageClient, TextDocumentFeature } from './client'
-import * as UUID from './utils/uuid'
 import * as cv from './utils/converter'
 
 function ensure<T, K extends keyof T>(target: T, key: K): T[K] {
@@ -18,66 +16,52 @@ function ensure<T, K extends keyof T>(target: T, key: K): T[K] {
 }
 
 export interface ProvideImplementationSignature {
-  (document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Definition> // tslint:disable-line
+  (this: void, document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Definition> // tslint:disable-line
 }
 
 export interface ImplementationMiddleware {
   provideImplementation?: (this: void, document: TextDocument, position: Position, token: CancellationToken, next: ProvideImplementationSignature) => ProviderResult<Definition>
 }
 
-export class ImplementationFeature extends TextDocumentFeature<TextDocumentRegistrationOptions> {
+export class ImplementationFeature extends TextDocumentFeature<boolean | ImplementationOptions, ImplementationRegistrationOptions, ImplementationProvider> {
 
   constructor(client: BaseLanguageClient) {
     super(client, ImplementationRequest.type)
   }
 
   public fillClientCapabilities(capabilites: ClientCapabilities): void {
-    ensure(ensure(capabilites, 'textDocument')!, 'implementation')!.dynamicRegistration = true
+    const implementationSupport = ensure(ensure(capabilites, 'textDocument')!, 'implementation')!
+    implementationSupport.dynamicRegistration = true
+    implementationSupport.linkSupport = true
   }
 
   public initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {
-    if (!capabilities.implementationProvider) {
+    const [id, options] = this.getRegistration(documentSelector, capabilities.implementationProvider)
+    if (!id || !options) {
       return
     }
-    if (capabilities.implementationProvider === true) {
-      if (!documentSelector) {
-        return
-      }
-      this.register(this.messages, {
-        id: UUID.generateUuid(),
-        registerOptions: Object.assign({}, { documentSelector })
-      })
-    } else {
-      const implCapabilities = capabilities.implementationProvider
-      const id = Is.string(implCapabilities.id) && implCapabilities.id.length > 0 ? implCapabilities.id : UUID.generateUuid()
-      const selector = implCapabilities.documentSelector || documentSelector
-      if (selector) {
-        this.register(this.messages, {
-          id,
-          registerOptions: Object.assign({}, { documentSelector: selector })
-        })
-      }
-    }
+    this.register(this.messages, { id, registerOptions: options })
   }
 
-  protected registerLanguageProvider(options: TextDocumentRegistrationOptions): Disposable {
-    let client = this._client
-    let provideImplementation: ProvideImplementationSignature = (document, position, token) => {
-      return client.sendRequest(ImplementationRequest.type, cv.asTextDocumentPositionParams(document, position), token)
-        .then(res => res, error => {
-          client.logFailedRequest(ImplementationRequest.type, error)
-          return Promise.resolve(null)
+  protected registerLanguageProvider(options: ImplementationRegistrationOptions): [Disposable, ImplementationProvider] {
+    const provider: ImplementationProvider = {
+      provideImplementation: (document, position, token) => {
+        const client = this._client
+        const provideImplementation: ProvideImplementationSignature = (document, position, token) => {
+          return client.sendRequest(ImplementationRequest.type, cv.asTextDocumentPositionParams(document, position), token).then(
+            res => res, error => {
+              client.logFailedRequest(ImplementationRequest.type, error)
+              return Promise.resolve(null)
+            }
+          )
         }
-        )
+        const middleware = client.clientOptions.middleware!
+        return middleware.provideImplementation
+          ? middleware.provideImplementation(document, position, token, provideImplementation)
+          : provideImplementation(document, position, token)
+      }
     }
-    let middleware = client.clientOptions.middleware!
-    return languages.registerImplementationProvider(
-      options.documentSelector, {
-        provideImplementation: (document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Definition> => {
-          return middleware.provideImplementation
-            ? middleware.provideImplementation(document, position, token, provideImplementation)
-            : provideImplementation(document, position, token)
-        }
-      })
+
+    return [languages.registerImplementationProvider(options.documentSelector, provider), provider]
   }
 }

--- a/src/language-client/index.ts
+++ b/src/language-client/index.ts
@@ -7,22 +7,24 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import { createClientPipeTransport, createClientSocketTransport, Disposable, generateRandomPipeName, IPCMessageReader, IPCMessageWriter, StreamMessageReader, StreamMessageWriter } from 'vscode-languageserver-protocol'
+import which from 'which'
 import { ServiceStat } from '../types'
 import { disposeAll } from '../util'
 import * as Is from '../util/is'
 import { terminate } from '../util/processes'
+import { resolveVariables } from '../util/string'
 import workspace from '../workspace'
-import which from 'which'
 import { BaseLanguageClient, ClientState, DynamicFeature, LanguageClientOptions, MessageTransports, StaticFeature } from './client'
 import { ColorProviderFeature } from './colorProvider'
 import { ConfigurationFeature as PullConfigurationFeature } from './configuration'
 import { DeclarationFeature } from './declaration'
 import { FoldingRangeFeature } from './foldingRange'
 import { ImplementationFeature } from './implementation'
+import { ProgressFeature } from './progress'
 import { TypeDefinitionFeature } from './typeDefinition'
 import { WorkspaceFoldersFeature } from './workspaceFolders'
+import { SelectionRangeFeature } from './selectionRange'
 import ChildProcess = cp.ChildProcess
-import { resolveVariables } from '../util/string'
 
 const logger = require('../util/logger')('language-client-index')
 
@@ -192,7 +194,7 @@ export class LanguageClient extends BaseLanguageClient {
         // 3rd signature
         options = (arg3 as DeferredLanguageClientServerOptions).deferredOptions
         forceDebug = !!arg4
-      }else {
+      } else {
         // 2nd signature
         options = () => [arg4 as LanguageClientOptions, arg3 as ServerOptions]
         forceDebug = !!arg5
@@ -483,9 +485,8 @@ export class LanguageClient extends BaseLanguageClient {
     this.registerFeature(new DeclarationFeature(this))
     this.registerFeature(new ColorProviderFeature(this))
     this.registerFeature(new FoldingRangeFeature(this))
-    // TODO
-    // this.registerFeature(new SelectionRangeFeature(this))
-    // this.registerFeature(new ProgressFeature(this))
+    this.registerFeature(new SelectionRangeFeature(this))
+    this.registerFeature(new ProgressFeature(this))
     if (!this.clientOptions.disableWorkspaceFolders) {
       this.registerFeature(new WorkspaceFoldersFeature(this))
     }
@@ -537,7 +538,7 @@ export class SettingMonitor {
       dispose: () => {
         disposeAll(this._listeners)
         if (this._client.needsStop()) {
-          this._client.stop()
+          void this._client.stop()
         }
       }
     }
@@ -553,7 +554,7 @@ export class SettingMonitor {
     if (enabled && this._client.needsStart()) {
       this._client.start()
     } else if (!enabled && this._client.needsStop()) {
-      this._client.stop()
+      void this._client.stop()
     }
   }
 }

--- a/src/language-client/index.ts
+++ b/src/language-client/index.ts
@@ -30,10 +30,17 @@ export * from './client'
 
 declare var v8debug: any
 
+export interface ExecutableOptions {
+  cwd?: string
+  env?: any
+  detached?: boolean
+  shell?: boolean
+}
+
 export interface Executable {
   command: string
   args?: string[]
-  options?: SpawnOptions
+  options?: ExecutableOptions
 }
 
 namespace Executable {
@@ -476,6 +483,9 @@ export class LanguageClient extends BaseLanguageClient {
     this.registerFeature(new DeclarationFeature(this))
     this.registerFeature(new ColorProviderFeature(this))
     this.registerFeature(new FoldingRangeFeature(this))
+    // TODO
+    // this.registerFeature(new SelectionRangeFeature(this))
+    // this.registerFeature(new ProgressFeature(this))
     if (!this.clientOptions.disableWorkspaceFolders) {
       this.registerFeature(new WorkspaceFoldersFeature(this))
     }
@@ -551,7 +561,11 @@ export class SettingMonitor {
 // Exporting proposed protocol.
 export namespace ProposedFeatures {
   export function createAll(_client: BaseLanguageClient): (StaticFeature | DynamicFeature<any>)[] {
-    let result: (StaticFeature | DynamicFeature<any>)[] = []
+    let result: (StaticFeature | DynamicFeature<any>)[] = [
+      // TODO
+      // new CallHierarchyFeature(client),
+      // new SemanticTokensFeature(client)
+    ]
     return result
   }
 }

--- a/src/language-client/index.ts
+++ b/src/language-client/index.ts
@@ -143,7 +143,7 @@ export type ServerOptions =
   | { run: Executable; debug: Executable }
   | { run: NodeModule; debug: NodeModule }
   | NodeModule
-  | (() => Thenable<ChildProcess | StreamInfo | MessageTransports | ChildProcessInfo>)
+  | (() => Promise<ChildProcess | StreamInfo | MessageTransports | ChildProcessInfo>)
 
 export interface DeferredLanguageClientServerOptions {
   deferredOptions: () => [LanguageClientOptions, ServerOptions]
@@ -213,7 +213,7 @@ export class LanguageClient extends BaseLanguageClient {
     this.registerProposedFeatures()
   }
 
-  public stop(): Thenable<void> {
+  public stop(): Promise<void> {
     return super.stop().then(() => {
       if (this._serverProcess) {
         let toCheck = this._serverProcess

--- a/src/language-client/progress.ts
+++ b/src/language-client/progress.ts
@@ -1,0 +1,33 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict'
+
+import { ClientCapabilities, WorkDoneProgressCreateParams, WorkDoneProgressCreateRequest } from 'vscode-languageserver-protocol'
+import { BaseLanguageClient, StaticFeature } from './client'
+import { ProgressPart } from './progressPart'
+
+function ensure<T, K extends keyof T>(target: T, key: K): T[K] {
+	if (target[key] === void 0) {
+		target[key] = Object.create(null) as any
+	}
+	return target[key]
+}
+
+export class ProgressFeature implements StaticFeature {
+	constructor(private _client: BaseLanguageClient) { }
+
+	public fillClientCapabilities(capabilities: ClientCapabilities): void {
+		ensure(capabilities, 'window')!.workDoneProgress = true
+	}
+
+	public initialize(): void {
+		let client = this._client
+
+		let createHandler = (params: WorkDoneProgressCreateParams) => {
+			new ProgressPart(this._client, params.token)
+		}
+		client.onRequest(WorkDoneProgressCreateRequest.type, createHandler)
+	}
+}

--- a/src/language-client/progressPart.ts
+++ b/src/language-client/progressPart.ts
@@ -4,8 +4,9 @@
  * ------------------------------------------------------------------------------------------ */
 'use strict'
 
-import { CancellationToken, Disposable, NotificationHandler, NotificationType, ProgressToken, ProgressType, WorkDoneProgress, WorkDoneProgressBegin, WorkDoneProgressCancelNotification, WorkDoneProgressReport } from 'vscode-languageserver-protocol'
-import * as Is from '../util/is'
+import { Disposable, NotificationHandler, NotificationType, ProgressToken, ProgressType, WorkDoneProgress, WorkDoneProgressBegin, WorkDoneProgressReport } from 'vscode-languageserver-protocol'
+import { StatusBarItem } from '../types'
+import workspace from '../workspace'
 
 export interface ProgressContext {
 	onProgress<P>(type: ProgressType<P>, token: string | number, handler: NotificationHandler<P>): Disposable
@@ -13,20 +14,14 @@ export interface ProgressContext {
 }
 
 export class ProgressPart {
-
-	private _infinite: boolean
-	private _reported: number
-	// TODO
-	// private _progress: Progress<{ message?: string, increment?: number }>
-	private _progress: any
-	private _cancellationToken: CancellationToken
 	private _disposable: Disposable | undefined
-
-	private _resolve: (() => void) | undefined
-	private _reject: ((reason?: any) => void) | undefined
+	private _workDoneStatus: StatusBarItem
+	private _title: string
+	private _message: string
+	private _percentage: string
 
 	public constructor(private _client: ProgressContext, private _token: ProgressToken) {
-		this._reported = 0
+		this._workDoneStatus = workspace.createStatusBarItem(99, { progress: true })
 		this._disposable = this._client.onProgress(WorkDoneProgress.type, this._token, value => {
 			switch (value.kind) {
 				case 'begin':
@@ -43,56 +38,41 @@ export class ProgressPart {
 	}
 
 	private begin(params: WorkDoneProgressBegin): void {
-		// TODO
-		console.error(`progressPart begin: ${params}`) // tslint:disable-line
-		// let location: ProgressLocation = params.cancellable ? ProgressLocation.Notification : ProgressLocation.Window
-		// Window.withProgress<void>({ location, cancellable: params.cancellable, title: params.title }, async (progress, cancellationToken) => {
-		// 	this._progress = progress;
-		// 	this._infinite = params.percentage === undefined;
-		// 	this._cancellationToken = cancellationToken;
-		// 	this._cancellationToken.onCancellationRequested(() => {
-		// 		this._client.sendNotification(WorkDoneProgressCancelNotification.type, { token: this._token });
-		// 	});
-		// 	this.report(params);
-		// 	return new Promise<void>((resolve, reject) => {
-		// 		this._resolve = resolve;
-		// 		this._reject = reject;
-		// 	});
-		// });
+		// TODO: WorkDoneProgressCancelNotification
+		this._title = params.title
+
+		this.report(params)
 	}
 
 	private report(params: WorkDoneProgressReport | WorkDoneProgressBegin): void {
-		if (this._infinite && Is.string(params.message)) {
-			this._progress.report({ message: params.message })
-		} else if (Is.number(params.percentage)) {
-			let percentage = Math.max(0, Math.min(params.percentage, 100))
-			let delta = Math.max(0, percentage - this._reported)
-			this._progress.report({ message: params.message, increment: delta })
-			this._reported += delta
-		}
+		this._message = params.message ? params.message : ''
+		this._percentage = params.percentage ? params.percentage + '%' : ''
+
+		this._workDoneStatus.text = `${this._title} ${this._message} ${this._percentage}`
+		this._workDoneStatus.show()
 	}
 
 	public cancel(): void {
+		if (this._workDoneStatus) {
+			this._workDoneStatus.hide()
+			this._workDoneStatus.dispose()
+			this._workDoneStatus = undefined
+		}
 		if (this._disposable) {
 			this._disposable.dispose()
 			this._disposable = undefined
-		}
-		if (this._reject) {
-			this._reject()
-			this._resolve = undefined
-			this._reject = undefined
 		}
 	}
 
 	public done(): void {
+		if (this._workDoneStatus) {
+			this._workDoneStatus.hide()
+			this._workDoneStatus.dispose()
+			this._workDoneStatus = undefined
+		}
 		if (this._disposable) {
 			this._disposable.dispose()
 			this._disposable = undefined
-		}
-		if (this._resolve) {
-			this._resolve()
-			this._resolve = undefined
-			this._reject = undefined
 		}
 	}
 }

--- a/src/language-client/progressPart.ts
+++ b/src/language-client/progressPart.ts
@@ -1,0 +1,98 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict'
+
+import { CancellationToken, Disposable, NotificationHandler, NotificationType, ProgressToken, ProgressType, WorkDoneProgress, WorkDoneProgressBegin, WorkDoneProgressCancelNotification, WorkDoneProgressReport } from 'vscode-languageserver-protocol'
+import * as Is from '../util/is'
+
+export interface ProgressContext {
+	onProgress<P>(type: ProgressType<P>, token: string | number, handler: NotificationHandler<P>): Disposable
+	sendNotification<P, RO>(type: NotificationType<P, RO>, params?: P): void
+}
+
+export class ProgressPart {
+
+	private _infinite: boolean
+	private _reported: number
+	// TODO
+	// private _progress: Progress<{ message?: string, increment?: number }>
+	private _progress: any
+	private _cancellationToken: CancellationToken
+	private _disposable: Disposable | undefined
+
+	private _resolve: (() => void) | undefined
+	private _reject: ((reason?: any) => void) | undefined
+
+	public constructor(private _client: ProgressContext, private _token: ProgressToken) {
+		this._reported = 0
+		this._disposable = this._client.onProgress(WorkDoneProgress.type, this._token, value => {
+			switch (value.kind) {
+				case 'begin':
+					this.begin(value)
+					break
+				case 'report':
+					this.report(value)
+					break
+				case 'end':
+					this.done()
+					break
+			}
+		})
+	}
+
+	private begin(params: WorkDoneProgressBegin): void {
+		// TODO
+		console.error(`progressPart begin: ${params}`) // tslint:disable-line
+		// let location: ProgressLocation = params.cancellable ? ProgressLocation.Notification : ProgressLocation.Window
+		// Window.withProgress<void>({ location, cancellable: params.cancellable, title: params.title }, async (progress, cancellationToken) => {
+		// 	this._progress = progress;
+		// 	this._infinite = params.percentage === undefined;
+		// 	this._cancellationToken = cancellationToken;
+		// 	this._cancellationToken.onCancellationRequested(() => {
+		// 		this._client.sendNotification(WorkDoneProgressCancelNotification.type, { token: this._token });
+		// 	});
+		// 	this.report(params);
+		// 	return new Promise<void>((resolve, reject) => {
+		// 		this._resolve = resolve;
+		// 		this._reject = reject;
+		// 	});
+		// });
+	}
+
+	private report(params: WorkDoneProgressReport | WorkDoneProgressBegin): void {
+		if (this._infinite && Is.string(params.message)) {
+			this._progress.report({ message: params.message })
+		} else if (Is.number(params.percentage)) {
+			let percentage = Math.max(0, Math.min(params.percentage, 100))
+			let delta = Math.max(0, percentage - this._reported)
+			this._progress.report({ message: params.message, increment: delta })
+			this._reported += delta
+		}
+	}
+
+	public cancel(): void {
+		if (this._disposable) {
+			this._disposable.dispose()
+			this._disposable = undefined
+		}
+		if (this._reject) {
+			this._reject()
+			this._resolve = undefined
+			this._reject = undefined
+		}
+	}
+
+	public done(): void {
+		if (this._disposable) {
+			this._disposable.dispose()
+			this._disposable = undefined
+		}
+		if (this._resolve) {
+			this._resolve()
+			this._resolve = undefined
+			this._reject = undefined
+		}
+	}
+}

--- a/src/language-client/typeDefinition.ts
+++ b/src/language-client/typeDefinition.ts
@@ -42,7 +42,7 @@ export class TypeDefinitionFeature extends TextDocumentFeature<boolean | TypeDef
   public fillClientCapabilities(capabilites: ClientCapabilities): void {
     const typeDefinitionSupport = ensure(ensure(capabilites, 'textDocument')!, 'typeDefinition')!
     typeDefinitionSupport.dynamicRegistration = true
-    typeDefinitionSupport.linkSupport = true
+    // typeDefinitionSupport.linkSupport = true
   }
 
   public initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {

--- a/src/language-client/utils/converter.ts
+++ b/src/language-client/utils/converter.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { CodeLensParams, CompletionContext, CompletionParams, DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidSaveTextDocumentParams, DocumentSelector, DocumentSymbolParams, Position, ReferenceParams, TextDocument, TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams, VersionedTextDocumentIdentifier, WillSaveTextDocumentParams } from 'vscode-languageserver-protocol'
+import { CodeLensParams, CompletionContext, CompletionParams, DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidSaveTextDocumentParams, DocumentSelector, DocumentSymbol, DocumentSymbolParams, Position, ReferenceParams, TextDocument, TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams, VersionedTextDocumentIdentifier, WillSaveTextDocumentParams } from 'vscode-languageserver-protocol'
 import { URI } from 'vscode-uri'
 import { TextDocumentWillSaveEvent } from '../../types'
 import { omit } from '../../util/lodash'

--- a/src/services.ts
+++ b/src/services.ts
@@ -276,7 +276,7 @@ export class ServiceManager extends EventEmitter implements Disposable {
         })
       },
       dispose: () => {
-        client.stop()
+        void client.stop()
         onDidServiceReady.dispose()
         disposeAll(disposables)
       },

--- a/src/snippets/session.ts
+++ b/src/snippets/session.ts
@@ -120,6 +120,7 @@ export class SnippetSession {
 
   public async synchronizeUpdatedPlaceholders(change: TextDocumentContentChangeEvent): Promise<void> {
     if (!this.isActive || !this.document || this.document.version - this.version == 1) return
+    if (!('range' in change)) return
     let edit: TextEdit = { range: change.range, newText: change.text }
     let { snippet } = this
     // change outside range

--- a/src/types.ts
+++ b/src/types.ts
@@ -348,6 +348,7 @@ export interface LanguageServerConfig {
   rootPatterns?: string[]
   ignoredRootPaths?: string[]
   initializationOptions?: any
+  progressOnInitialization?: boolean
   revealOutputChannelOn?: string
   configSection?: string
   stdioEncoding?: string

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,7 @@
   "rules": {
     "no-invalid-template-strings": false,
     "no-unused-expression": false,
+    "deprecation": false,
     "no-console": true
   },
   "linterOptions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3903,23 +3903,10 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vscode-jsonrpc@^4.1.0-next.2:
-  version "4.1.0-next.2"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.1.0-next.2.tgz#3bd318910a48e631742b290975386e3dae685be3"
-  integrity sha512-GsBLjP9DxQ42yl1mW9GEIlnSc0+R8mfzhaebwmmTPEJjezD5SPoAo3DFrIAFZha9yvQ1nzZfZlhtVpGQmgxtXg==
-
 vscode-jsonrpc@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz#9bab9c330d89f43fc8c1e8702b5c36e058a01794"
   integrity sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==
-
-vscode-languageserver-protocol@^3.15.0-next.6:
-  version "3.15.0-next.6"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.0-next.6.tgz#a8aeb7e7dd65da8216b386db59494cdfd3215d92"
-  integrity sha512-/yDpYlWyNs26mM23mT73xmOFsh1iRfgZfBdHmfAxwDKwpQKLoOSqVidtYfxlK/pD3IEKGcAVnT4WXTsguxxAMQ==
-  dependencies:
-    vscode-jsonrpc "^4.1.0-next.2"
-    vscode-languageserver-types "^3.15.0-next.2"
 
 vscode-languageserver-protocol@^3.15.3:
   version "3.15.3"
@@ -3934,29 +3921,12 @@ vscode-languageserver-types@3.15.1, vscode-languageserver-types@^3.15.1:
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz#17be71d78d2f6236d414f0001ce1ef4d23e6b6de"
   integrity sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==
 
-vscode-languageserver-types@^3.15.0-next.2:
-  version "3.15.0-next.2"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0-next.2.tgz#a0601332cdaafac21931f497bb080cfb8d73f254"
-  integrity sha512-2JkrMWWUi2rlVLSo9OFR2PIGUzdiowEM8NgNYiwLKnXTjpwpjjIrJbNNxDik7Rv4oo9KtikcFQZKXbrKilL/MQ==
-
-vscode-languageserver@5.3.0-next.8:
-  version "5.3.0-next.8"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-5.3.0-next.8.tgz#12a4adf60374dbb93e153e08bdca5525f9b2029f"
-  integrity sha512-6vUb96wsRfrFqndril3gct/FBCSc24OxFZ2iz7kuEuXvLaIcEVOcSZIqQK8oFN7PdbAIaa9nnIpKSy4Yd15cIw==
+vscode-languageserver@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-6.1.1.tgz#d76afc68172c27d4327ee74332b468fbc740d762"
+  integrity sha512-DueEpkUAkD5XTR4MLYNr6bQIp/UFR0/IPApgXU3YfCBCB08u2sm9hRCs6DxYZELkk++STPjpcjksR2H8qI3cDQ==
   dependencies:
-    vscode-languageserver-protocol "^3.15.0-next.6"
-    vscode-textbuffer "^1.0.0"
-    vscode-uri "^1.0.6"
-
-vscode-textbuffer@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-textbuffer/-/vscode-textbuffer-1.0.0.tgz#1faee638c8e0e4131c8d5c353993a1874acda086"
-  integrity sha512-zPaHo4urgpwsm+PrJWfNakolRpryNja18SUip/qIIsfhuEqEIPEXMxHOlFPjvDC4JgTaimkncNW7UMXRJTY6ow==
-
-vscode-uri@^1.0.6:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.8.tgz#9769aaececae4026fb6e22359cb38946580ded59"
-  integrity sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ==
+    vscode-languageserver-protocol "^3.15.3"
 
 vscode-uri@^2.0.3:
   version "2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3810,10 +3810,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.6.2:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.2.tgz#105b0f1934119dde543ac8eb71af3a91009efe54"
-  integrity sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==
+typescript@^3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.2.tgz#91d6868aaead7da74f493c553aeff76c0c0b1d5a"
+  integrity sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==
 
 uglify-js@^3.1.4:
   version "3.6.0"
@@ -3908,7 +3908,12 @@ vscode-jsonrpc@^4.1.0-next.2:
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.1.0-next.2.tgz#3bd318910a48e631742b290975386e3dae685be3"
   integrity sha512-GsBLjP9DxQ42yl1mW9GEIlnSc0+R8mfzhaebwmmTPEJjezD5SPoAo3DFrIAFZha9yvQ1nzZfZlhtVpGQmgxtXg==
 
-vscode-languageserver-protocol@3.15.0-next.6, vscode-languageserver-protocol@^3.15.0-next.6:
+vscode-jsonrpc@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz#9bab9c330d89f43fc8c1e8702b5c36e058a01794"
+  integrity sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==
+
+vscode-languageserver-protocol@^3.15.0-next.6:
   version "3.15.0-next.6"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.0-next.6.tgz#a8aeb7e7dd65da8216b386db59494cdfd3215d92"
   integrity sha512-/yDpYlWyNs26mM23mT73xmOFsh1iRfgZfBdHmfAxwDKwpQKLoOSqVidtYfxlK/pD3IEKGcAVnT4WXTsguxxAMQ==
@@ -3916,7 +3921,20 @@ vscode-languageserver-protocol@3.15.0-next.6, vscode-languageserver-protocol@^3.
     vscode-jsonrpc "^4.1.0-next.2"
     vscode-languageserver-types "^3.15.0-next.2"
 
-vscode-languageserver-types@3.15.0-next.2, vscode-languageserver-types@^3.15.0-next.2:
+vscode-languageserver-protocol@^3.15.3:
+  version "3.15.3"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz#3fa9a0702d742cf7883cb6182a6212fcd0a1d8bb"
+  integrity sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==
+  dependencies:
+    vscode-jsonrpc "^5.0.1"
+    vscode-languageserver-types "3.15.1"
+
+vscode-languageserver-types@3.15.1, vscode-languageserver-types@^3.15.1:
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz#17be71d78d2f6236d414f0001ce1ef4d23e6b6de"
+  integrity sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==
+
+vscode-languageserver-types@^3.15.0-next.2:
   version "3.15.0-next.2"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0-next.2.tgz#a0601332cdaafac21931f497bb080cfb8d73f254"
   integrity sha512-2JkrMWWUi2rlVLSo9OFR2PIGUzdiowEM8NgNYiwLKnXTjpwpjjIrJbNNxDik7Rv4oo9KtikcFQZKXbrKilL/MQ==


### PR DESCRIPTION
This PR will upgrade `vscode-languageserver-protocol` to 3.15, and port `vscode-languageclient` 6.1.1 to language-client.

I've tested with gopls/rust-analyzer by `languageserver`, and coc-tsserver/coc-json/coc-rust-analyzer/coc-clangd extensions, everything works as expect. More tests from extensions are needed, @iamcco @weirongxu @voldikss @oblitum @yatli and everyone else, hope you guys can help.

~TODO: progress support is done in language-client, but not on coc side, WIP.~ Done, basic progress just shows on status line. I'll open another PR to add custom progress report support.