### PR TITLE
feat(file): resolve environment variables in filename completion

### DIFF
--- a/src/source/file.ts
+++ b/src/source/file.ts
@@ -26,9 +26,22 @@ export default class File extends Source {
     })
   }
 
+  private resolveEnvVariables(str: string) {
+    let replaced = str
+    // windows
+    replaced = replaced.replace(/%([^%]+)%/g, (_, n) => process.env[n])
+    // linux and mac
+    replaced = replaced.replace(
+      /\$([A-Z_]+[A-Z0-9_]*)|\${([A-Z0-9_]*)}/gi,
+      (_, a, b) => process.env[a || b]
+    )
+    return replaced
+  }
+
   private getPathOption(opt: CompleteOption): PathOption | null {
     let { line, colnr } = opt
     let part = byteSlice(line, 0, colnr - 1)
+    part = this.resolveEnvVariables(part)
     if (!part || part.slice(-2) == '//') return null
     let ms = part.match(pathRe)
     if (ms && ms.length) {


### PR DESCRIPTION
Often in my work day, I use paths which feature an env variables like: `$REPO_ROOT/foo/bar`
Until now, the filename completion was not working as env variables were not resolved.

This PR implement env variables resolution for filename both on Windows and Linux/Mac.
I tested it on my end and it seems to be working fine.

What do you think?

Thanks,
Antoine 