### PR TITLE
fix(outputChannel): don't wrap in log files

### DIFF
--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -178,7 +178,7 @@ export class Workspace implements IWorkspace {
         let channel = this.outputChannels.get(uri.path.slice(1))
         if (!channel) return ''
         nvim.pauseNotification()
-        nvim.command('setlocal nospell nofoldenable wrap noswapfile', true)
+        nvim.command('setlocal nospell nofoldenable nowrap noswapfile', true)
         nvim.command('setlocal buftype=nofile bufhidden=hide', true)
         nvim.command('setfiletype log', true)
         await nvim.resumeNotification()


### PR DESCRIPTION
Not sure whether PRs for settings like this are appreciated, but this is driving me a little nuts, I don't think it's the right default.

Output windows open in a vsplit (so often narrow) and having logs wrap is annoying:
 - it hides the typical repetetive structure that makes logs easy to
   visually scan
 - in the presence of very long lines (which are reasonably common) you
   often see only a couple of log entries, and half the screen is blank

Current:
![wrap](https://user-images.githubusercontent.com/548993/75835313-d1029c00-5dbe-11ea-96da-e674b9027e04.png)
(Note half the window is displaying nothing, though there are more logs, because the next line is very long)

Patched:
![nowrap](https://user-images.githubusercontent.com/548993/75835309-cf38d880-5dbe-11ea-8863-675fccdd4b17.png)

