### PR TITLE
fix(float): stop floats from getting too small on the RHS of the screen.

### DIFF
--- a/src/model/floatFactory.ts
+++ b/src/model/floatFactory.ts
@@ -138,11 +138,13 @@ export default class FloatFactory implements Disposable {
     if (alignTop) docs.reverse()
     await this.floatBuffer.setDocuments(docs, maxWidth)
     let { width } = this.floatBuffer
-    if (offsetX) {
-      offsetX = Math.min(col - 1, offsetX)
-      if (col - offsetX + width > columns) {
-        offsetX = col - offsetX + width - columns
-      }
+    // Ensure the floating window isn't tiny if the cursor is on the right:
+    // increase the offset to accommodate some minimum width.
+    // If we have offsetX, precise positioning is intended, force exact width.
+    let minWidth = offsetX ? width : Math.min(width, 50, maxWidth)
+    offsetX = Math.min(col - 1, offsetX)
+    if (col - offsetX + minWidth > columns) {
+      offsetX = col - offsetX + minWidth - columns
     }
     this.alignTop = alignTop
     return {
@@ -216,7 +218,7 @@ export default class FloatFactory implements Disposable {
         minwidth: config.width - 2,
         minheight: config.height,
         maxwidth: config.width - 2,
-        maxheight: config.height,
+        maxheight: this.maxHeight,
         firstline: alignTop ? -1 : 1
       })
       this.floatBuffer.setLines()


### PR DESCRIPTION
Currently if a float for diagnostics always triggers to the right
of the cursor. This is fine when the cursor is near column 0, but the right edge
of the window limits the size, so if the cursor is at say 70/80, there
are only 10 columns available and the content wraps *a lot*.

Compounding this, maxheight is set to number of lines of content, but
isn't increased if the content has to wrap. So when the content
wraps, it's truncated. (Scrollable, but this is awkward)

Current:
![old_000](https://user-images.githubusercontent.com/548993/75839811-ff39a900-5dc9-11ea-8977-12522f4bb20c.png)

Patched:
![new_004](https://user-images.githubusercontent.com/548993/75839854-18425a00-5dca-11ea-9508-6ff065915409.png)

Looking at the history, it seems there's been some tension between
wrapping and fixing widths. 77cbc92ca5c38e1be moved the window to the
left if there wasn't enough room (so it wouldn't wrap), but then
46e0f4d8e5d90ed42 made it conditional on offsetX != 0, which meant
everything except signature help wraps again.

So the proposal here is:
 - on the LHS things stay as they are
 - as the cursor moves to the right, the popup eventually hits the right
   edge, it starts to shrink+wrap
 - once it reaches a minimum width (50 cols, could be a setting), it
   stops shrinking and is no longer locked to the cursor position,
   rather to the RHS of the window.
 - the popup is allowed to grow vertically to accommodate the content
   when it wraps, up to the global maxheight.
 - popups with offsetX set (signature help) are fixed-width: minimum width is their content width

Graphically, where the cursor is `X`:

```
  X[------------------]          |
       X[------------------]     |
            X[------------------]|
                 X[-------------]|
                  [----X--------]|
                  [--------X----]|
                  [------------X]|
```