### PR TITLE
increase max timeout to 15000

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -376,7 +376,7 @@
       "type": "integer",
       "default": 5000,
       "minimum": 500,
-      "maximum": 5000,
+      "maximum": 15000,
       "description": "Timeout for completion, in miliseconds."
     },
     "suggest.minTriggerInputLength": {

--- a/src/completion/complete.ts
+++ b/src/completion/complete.ts
@@ -64,7 +64,7 @@ export default class Complete {
     // new option for each source
     let opt = Object.assign({}, this.option)
     let timeout = this.config.timeout
-    timeout = Math.max(Math.min(timeout, 5000), 1000)
+    timeout = Math.max(Math.min(timeout, 15000), 500)
     try {
       if (typeof source.shouldComplete === 'function') {
         let shouldRun = await Promise.resolve(source.shouldComplete(opt))


### PR DESCRIPTION
I've currently experienced some issues with `rust-analyzer` taking longer than default 5s, and I seem to not be the only one. Reference below,
https://gitter.im/neoclide/coc.nvim?at=5e0acd6c833c373f4d84eae4

PR increases the max timeout to 15s without touching default. PR also sets the correct minimum value.