### PR TITLE
Set WorkDoneProgressBegin.percentage precision to 2 decimal places

### DIFF
--- a/src/language-client/progressPart.ts
+++ b/src/language-client/progressPart.ts
@@ -46,7 +46,7 @@ export class ProgressPart {
 
 	private report(params: WorkDoneProgressReport | WorkDoneProgressBegin): void {
 		this._message = params.message ? params.message : ''
-		this._percentage = params.percentage ? params.percentage + '%' : ''
+		this._percentage = params.percentage ? params.percentage.toFixed(2) + '%' : ''
 
 		this._workDoneStatus.text = `${this._title} ${this._message} ${this._percentage}`
 		this._workDoneStatus.show()


### PR DESCRIPTION
When showing job progression in the text editors, it is hard to read
"precise" percentage numbers. This patch sets precision of
`WorkDoneProgressBegin.percentage` to 2 decimal places to improve
readability.