### PR TITLE
don't force edit in snippet

### DIFF
--- a/src/languages.ts
+++ b/src/languages.ts
@@ -677,7 +677,7 @@ class Languages {
       await doc.applyEdits(nvim, [{
         range: Range.create(linenr - 1, 0, linenr, 0),
         newText: `${start}${end}\n`
-      }])
+      }], false)
       // can't select, since additionalTextEdits would break selection
       let pos = Position.create(linenr - 1, range.start.character)
       return await snippetManager.insertSnippet(newText, false, Range.create(pos, pos))


### PR DESCRIPTION
If forced, the edit will trigger the snippet update logic, and the range check will fail, resulting in snippet session getting cancelled

fixes #1601 