### PR TITLE
throw error when extension doesn't containe main file in package.json

### DIFF
--- a/src/util/factory.ts
+++ b/src/util/factory.ts
@@ -154,7 +154,7 @@ function createSandbox(filename: string, logger: Logger): ISandbox {
 export function createExtension(id: string, filename: string): ExtensionExport {
   if (!fs.existsSync(filename)) {
     // tslint:disable-next-line:no-empty
-    return { activate: () => { }, deactivate: null }
+    throw new Error(`Cannot find main file ${filename} specified by package.json`)
   }
   const sandbox = createSandbox(filename, createLogger(`extension-${id}`))
 


### PR DESCRIPTION
This is a response to [this issue](https://github.com/neoclide/coc-tsserver/issues/124) according to this [problem](https://github.com/neoclide/coc-tsserver/issues/126). 

Currently when the main file in package.json doesn't exist extension module will only create an `ExtensionExport` with empty `activate` function. But when you download extensions from npm the package itself might have a problem, and if that happened there is no explicit error message.

### Current `createExtension` in `src/utl/factory.ts`
![2020-03-08-055316_1078x144_scrot](https://user-images.githubusercontent.com/12954634/76163918-b0f91280-6107-11ea-9a26-7f3c2f571875.png)

### Exception threw there will be caught here.
![2020-03-08-055139_1134x187_scrot](https://user-images.githubusercontent.com/12954634/76163881-637ca580-6107-11ea-8ed6-d2616392f544.png)

The pull request throws an exception instead of returning a dummy `ExtensionExport`, so I could provide a direct error message when the problem happens. It is quite bizarre to download an extension that misses the main entrance.