### PR TITLE
show error message when extension's main file doesn't exist.

### DIFF
--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -764,18 +764,21 @@ export class Extensions {
         }
         isActive = true
         if (!ext) {
+          // check if activate is empty function like () => {}
+          // keep the implementation of createExtension
+          const stringifyFunction = f => f
+            .toString()
+            .split('')
+            .filter(e => e !== ' ')
+            .join('')
+          const emptyFunction = stringifyFunction(() => { })
+
           try {
             ext = createExtension(id, filename)
-
-            // check if activate is empty function like () => {}
-            const stringifyFunction = f => f
-              .toString()
-              .split('')
-              .filter(e => e !== ' ')
-              .join('')
-
-            if (stringifyFunction(ext.activate) === stringifyFunction(() => {})) {
-              workspace.showMessage(`extension doesn't contain main file ${filename}.`, 'error')
+            if (stringifyFunction(ext.activate) === emptyFunction) {
+              const e = `extension doesn't contain main file ${filename}.`;
+              workspace.showMessage(e, 'error')
+              logger.error(e)
             }
           } catch (e) {
             workspace.showMessage(`Error on load extension ${id} from ${filename}: ${e}`, 'error')

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -766,6 +766,17 @@ export class Extensions {
         if (!ext) {
           try {
             ext = createExtension(id, filename)
+
+            // check if activate is empty function like () => {}
+            const stringifyFunction = f => f
+              .toString()
+              .split('')
+              .filter(e => e !== ' ')
+              .join('')
+
+            if (stringifyFunction(ext.activate) === stringifyFunction(() => {})) {
+              workspace.showMessage(`extension doesn't contain main file ${filename}.`, 'error')
+            }
           } catch (e) {
             workspace.showMessage(`Error on load extension ${id} from ${filename}: ${e}`, 'error')
             logger.error(e)

--- a/src/util/factory.ts
+++ b/src/util/factory.ts
@@ -154,7 +154,7 @@ function createSandbox(filename: string, logger: Logger): ISandbox {
 export function createExtension(id: string, filename: string): ExtensionExport {
   if (!fs.existsSync(filename)) {
     // tslint:disable-next-line:no-empty
-    return { activate: () => { }, deactivate: null }
+    throw new Error(`Cannot find main file ${filename} specified by package.json`)
   }
   const sandbox = createSandbox(filename, createLogger(`extension-${id}`))
 

--- a/src/util/factory.ts
+++ b/src/util/factory.ts
@@ -154,7 +154,7 @@ function createSandbox(filename: string, logger: Logger): ISandbox {
 export function createExtension(id: string, filename: string): ExtensionExport {
   if (!fs.existsSync(filename)) {
     // tslint:disable-next-line:no-empty
-    throw new Error(`Cannot find main file ${filename} specified by package.json`)
+    return { activate: () => { }, deactivate: null }
   }
   const sandbox = createSandbox(filename, createLogger(`extension-${id}`))
 


### PR DESCRIPTION
This is a response to this [issue](https://github.com/neoclide/coc-tsserver/issues/125) according to this [problem](https://github.com/neoclide/coc-tsserver/issues/126).

Currently when the main file in package.json doesn't exist extension module will only create an ExtensionExport with empty activate function. But when you download extensions from npm the package itself might have a problem, and if that happened there is no explicit error message.

#### Current createExtension will return a `ExtensionExport` without showing any messages.
![2020-03-08-055139_1134x187_scrot](https://user-images.githubusercontent.com/12954634/76165537-07208280-6115-11ea-9485-7a6af36cc6f4.png)

![2020-03-08-055316_1078x144_scrot](https://user-images.githubusercontent.com/12954634/76165539-0b4ca000-6115-11ea-9617-3ba336ab92ad.png)

The pull request shows an error message for this purpose without change the original implementation of `createExtension`
