### PR TITLE
fix(completion): preserve duplicate items for textEdit

### DIFF
--- a/src/completion/complete.ts
+++ b/src/completion/complete.ts
@@ -193,7 +193,7 @@ export default class Complete {
           continue
         }
         if ((!item.dup || source == 'tabnine') && words.has(word)) continue
-        if (removeDuplicateItems && !item.isSnippet && words.has(word)) continue
+        if (removeDuplicateItems && !item.isSnippet && words.has(word) && item.line == undefined) continue
         let filterText = item.filterText || item.word
         item.filterText = filterText
         if (filterText.length < input.length) continue


### PR DESCRIPTION
# Problem

With `"suggest.removeDuplicateItems"` set to `false`, I can get both `#include <` and `#include "` when I use ccls for cpp completion.

After setting that option to `true`, I only got `#include "` and `#include <` was removed.

# Opinion

That is unreasonable. Though these two items share the same label(`'include'`), but they apply different `textEdit`(`'include <' v.s. 'include \"'`). Therefor the second one should be preserved.

# Solution

According to the code comment [here](https://github.com/neoclide/coc.nvim/blob/master/src/types.ts#L497),  we can check if the item will apply a textEdit before removing it.