### PR TITLE
Fix the discrepancy between maxDetailLength's documented and actual value

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -298,12 +298,12 @@
     "suggest.labelMaxLength": {
       "type": "number",
       "description": "Max length of abbr that shown as label of complete item.",
-      "default": 200
+      "default": 50
     },
     "suggest.detailMaxLength": {
       "type": "number",
       "description": "Max length of detail that should be shown in popup menu.",
-      "default": 100
+      "default": 50
     },
     "suggest.detailField": {
       "type": "string",

--- a/data/schema.json
+++ b/data/schema.json
@@ -298,7 +298,7 @@
     "suggest.labelMaxLength": {
       "type": "number",
       "description": "Max length of abbr that shown as label of complete item.",
-      "default": 50
+      "default": 200
     },
     "suggest.detailMaxLength": {
       "type": "number",

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -135,7 +135,7 @@ Built in configurations:~
 
 "suggest.labelMaxLength":~
 
-	Maximum length of label shown in 'pum', default: `50`
+	Maximum length of label shown in 'pum', default: `200`
 
 "suggest.enablePreview":~
 

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -135,7 +135,7 @@ Built in configurations:~
 
 "suggest.labelMaxLength":~
 
-	Maximum length of label shown in 'pum', default: `200`
+	Maximum length of label shown in 'pum', default: `50`
 
 "suggest.enablePreview":~
 
@@ -147,7 +147,7 @@ Built in configurations:~
 
 "suggest.detailMaxLength":~
 
-	Max length of detail that will be shown in popup menu, default: `100`
+	Max length of detail that will be shown in popup menu, default: `50`
 
 "suggest.detailField":~
 

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -132,7 +132,7 @@ export class Completion implements Disposable {
       enablePreview: getConfig<boolean>('enablePreview', false),
       enablePreselect: getConfig<boolean>('enablePreselect', false),
       maxPreviewWidth: getConfig<number>('maxPreviewWidth', 80),
-      labelMaxLength: getConfig<number>('labelMaxLength', 200),
+      labelMaxLength: getConfig<number>('labelMaxLength', 50),
       triggerAfterInsertEnter: getConfig<boolean>('triggerAfterInsertEnter', false),
       noselect: getConfig<boolean>('noselect', true),
       numberSelect: getConfig<boolean>('numberSelect', false),

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -132,7 +132,7 @@ export class Completion implements Disposable {
       enablePreview: getConfig<boolean>('enablePreview', false),
       enablePreselect: getConfig<boolean>('enablePreselect', false),
       maxPreviewWidth: getConfig<number>('maxPreviewWidth', 80),
-      labelMaxLength: getConfig<number>('labelMaxLength', 50),
+      labelMaxLength: getConfig<number>('labelMaxLength', 200),
       triggerAfterInsertEnter: getConfig<boolean>('triggerAfterInsertEnter', false),
       noselect: getConfig<boolean>('noselect', true),
       numberSelect: getConfig<boolean>('numberSelect', false),


### PR DESCRIPTION
maxDetailLength is documented to be 100 by default but in the
code it appears to be 50. Documentation is updated to reflect current
behaviour.