### PR TITLE
fix(plugin): keepjumps for CocTagFunc

### DIFF
--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -541,7 +541,7 @@ export default class Handler {
       const filename = URI.parse(location.uri).fsPath
       return {
         name: word,
-        cmd: `${location.range.start.line + 1} | normal ${location.range.start.character + 1}|`,
+        cmd: `keepjumps ${location.range.start.line + 1} | normal ${location.range.start.character + 1}|`,
         filename,
       }
     })


### PR DESCRIPTION
do not add `line 1` of destination file to the jumplist