### PR TITLE
Filter the items added to the list history

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -764,6 +764,11 @@
       "default": {},
       "description": "Custom keymappings on insert mode."
     },
+    "list.historyAddOnClose": {
+      "type": "boolean",
+      "default": true,
+      "description": "If set to false, an item will be added to the prompt history only when an action is actually executed"
+    },
     "list.source.outline.ctagsFilestypes": {
       "type": "array",
       "default": [],

--- a/src/list/source/outline.ts
+++ b/src/list/source/outline.ts
@@ -18,7 +18,6 @@ function getFilterText(s: DocumentSymbol | SymbolInformation, args: {[key: strin
     if (args.kind) {
         result += ` ${kind}`
     }
-
     return result
 }
 


### PR DESCRIPTION
Normally, when closing a list without selecting an item, I would like for the item to not be added to the history. I should be able to add an item to the history only if an action has been performed on the item. 

For this purpose I added the option `historyAddOnClose`, which is default `true`. This means that it's perfectly backwards compatible. Nothing changes unless this option is set to `false`. If this option is false, then an item will be added to the lists history only if an action has been performed. 