### PR TITLE
fix(util): suppress 'press ENTER' in echo_messages()

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -270,9 +270,12 @@ function! coc#util#echo_messages(hl, msgs)
   endif
   execute 'echohl '.a:hl
   let msgs = filter(copy(a:msgs), '!empty(v:val)')
+  " :echomsg can't print multiple lines without 'press ENTER' interruptions.
+  " Send the lines to messages first, then display them with :echo.
   for msg in msgs
-    echom msg
+    echom msg | redraw
   endfor
+  echo join(msgs, "\n")
   echohl None
 endfunction
 


### PR DESCRIPTION
This is used for workspace/showMessage, when it contains multiple lines.
Using `echomsg` in a loop means that each line after the second prompts
before displaying.

The downside of this change is if there are multiple consecutive calls
to `echo_messages()`, only the last one is shown. (All will appear in :messages)

Motivating use: clangd has "dump AST" code action behind the
-hidden-features flag. This action calls showMessage with a payload like:
```
FunctionDecl 0x14387ee101e8 </home/sammccall/test.cc:1:1, line:3:1> line:1:6 foo 'void ()'
`-CompoundStmt 0x14387ee10380 <col:11, line:3:1>
  `-DeclStmt 0x14387ee10368 <line:2:3, col:10>
      `-VarDecl 0x14387ee10300 <col:3, col:7> col:7 bar 'int'
```