### PR TITLE
added mdx filetype identifier

### DIFF
--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -550,7 +550,7 @@ export class Extensions {
     this.list.push({ id, extension, deactivate, isLocal: true })
     let { contributes } = packageJSON
     if (contributes) {
-      let { configuration } = contributes
+      let { configuration, languages } = contributes
       if (configuration && configuration.properties) {
         let { properties } = configuration
         let props = {}
@@ -559,6 +559,8 @@ export class Extensions {
           if (val != null) props[key] = val
         }
         workspace.configurations.extendsDefaults(props)
+      }
+      if (languages && Array.isArray(languages)) {
       }
     }
     this._onDidLoadExtension.fire(extension)

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -550,7 +550,7 @@ export class Extensions {
     this.list.push({ id, extension, deactivate, isLocal: true })
     let { contributes } = packageJSON
     if (contributes) {
-      let { configuration, languages } = contributes
+      let { configuration } = contributes
       if (configuration && configuration.properties) {
         let { properties } = configuration
         let props = {}
@@ -559,8 +559,6 @@ export class Extensions {
           if (val != null) props[key] = val
         }
         workspace.configurations.extendsDefaults(props)
-      }
-      if (languages && Array.isArray(languages)) {
       }
     }
     this._onDidLoadExtension.fire(extension)

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -91,6 +91,7 @@ export default class Document {
     }
     if (filetype == 'javascript.jsx') return 'javascriptreact'
     if (filetype == 'typescript.jsx' || filetype == 'typescript.tsx') return 'typescriptreact'
+    if (filetype == 'markdown.mdx') return 'mdx'
     return map[filetype] || filetype
   }
 


### PR DESCRIPTION
# Problem

As I tried to transplant a [vscode plugin](https://github.com/mdx-js/vscode-mdx), activationEvents does not trigger on opening mdx files.

# Cause

mdx is not a built-in filetype of vscode language server at the moment.

The [contributes.languages](https://code.visualstudio.com/api/references/contribution-points#contributes.languages) feature of allows vscode extensions to define their own filetype, i.e. extensions mapped to language identifier. Therefore vscode-mdx works fine without the official support of mdx filetype from vscode.

However coc.nvim is lack of this feature at the moment.

# Fix

I will eventually try to implement this feature. But I wish to focus on the original problem, which is to transplant vscode-mdx to coc. So a dirty and temporary workaround is made.

The change has been kept minimal. Please check if anything will be broken by this PR.