### PR TITLE
fix(services): missing client

### DIFF
--- a/src/services.ts
+++ b/src/services.ts
@@ -251,6 +251,7 @@ export class ServiceManager extends EventEmitter implements Disposable {
     let created = false
     let service: IServiceProvider = {
       id,
+      client,
       name: typeof name === 'string' ? name : name.name,
       selector: typeof name === 'string' ? getDocumentSelector(config.filetypes, config.additionalSchemes) : name.clientOptions.documentSelector,
       state: ServiceStat.Initial,


### PR DESCRIPTION
`client` is missing with `services.registLanguageClient(client)`, then will failed on `registNotification` at https://github.com/neoclide/coc.nvim/blob/master/src/services.ts#L201