### PR TITLE
feat: Added contributes.languages support

### DIFF
--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -28,6 +28,7 @@ import workspace from './workspace'
 const createLogger = require('./util/logger')
 const logger = createLogger('extensions')
 
+logger.debug('test')('hi')
 export type API = { [index: string]: any } | void | null | undefined
 
 export interface PropertyScheme {
@@ -126,6 +127,7 @@ export class Extensions {
     if (global.hasOwnProperty('__TEST__')) return
     for (let item of this.list) {
       let { id, packageJSON } = item.extension
+      this.setupCustomLanguages(packageJSON)
       this.setupActiveEvents(id, packageJSON)
     }
     // check extensions need watch & install
@@ -562,6 +564,7 @@ export class Extensions {
       }
     }
     this._onDidLoadExtension.fire(extension)
+    this.setupCustomLanguages(packageJSON)
     this.setupActiveEvents(id, packageJSON)
   }
 
@@ -673,6 +676,18 @@ export class Extensions {
   public addSchemeProperty(key: string, def: PropertyScheme): void {
     this._additionalSchemes[key] = def
     workspace.configurations.extendsDefaults({ [key]: def.default })
+  }
+
+  private setupCustomLanguages(packageJSON: any): void {
+    let { contributes } = packageJSON
+    if (!contributes)
+      return
+    let { languages }  = contributes
+    if (!languages || Array.isArray(languages))
+      return
+    for (let lang of languages) {
+      workspace.addLanguage(lang)
+    }
   }
 
   private setupActiveEvents(id: string, packageJSON: any): void {
@@ -845,6 +860,7 @@ export class Extensions {
     }
     this._onDidLoadExtension.fire(extension)
     if (this.activated) {
+      this.setupCustomLanguages(packageJSON)
       this.setupActiveEvents(id, packageJSON)
     }
   }

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -682,7 +682,7 @@ export class Extensions {
     if (!contributes)
       return
     let { languages }  = contributes
-    if (!languages || Array.isArray(languages))
+    if (!languages || !Array.isArray(languages))
       return
     for (let lang of languages) {
       workspace.addLanguage(lang)

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -28,7 +28,6 @@ import workspace from './workspace'
 const createLogger = require('./util/logger')
 const logger = createLogger('extensions')
 
-logger.debug('test')('hi')
 export type API = { [index: string]: any } | void | null | undefined
 
 export interface PropertyScheme {

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -34,6 +34,7 @@ export default class Document {
   // real current lines
   private lines: string[] = []
   private _filetype: string
+  private _extension: string
   private _uri: string
   private _changedtick: number
   private _words: string[] = []
@@ -79,6 +80,13 @@ export default class Document {
    */
   public get words(): string[] {
     return this._words
+  }
+
+  /**
+   * Return extension of document
+   */
+  public getFileExtension(fullpath: string): string {
+    return fullpath.split('.').pop()
   }
 
   /**
@@ -144,6 +152,7 @@ export default class Document {
       return false
     }
     this._filetype = this.convertFiletype(opts.filetype)
+    this._extension = this.getFileExtension(opts.fullpath)
     this.textDocument = TextDocument.create(uri, this.filetype, 1, this.getDocumentContent())
     this.setIskeyword(opts.iskeyword)
     this.gitCheck()
@@ -274,6 +283,10 @@ export default class Document {
    */
   public get filetype(): string {
     return this._filetype
+  }
+
+  public get extension(): string {
+    return this._extension
   }
 
   public get uri(): string {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -191,7 +191,7 @@ export default class Plugin extends EventEmitter {
           this.addCommand(cmd)
         }
       }
-      logger.info(`coc ${this.version} initialized with node: ${process.version} hi`)
+      logger.info(`coc ${this.version} initialized with node: ${process.version}`)
       this.emit('ready')
     } catch (e) {
       this._ready = false

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -191,7 +191,7 @@ export default class Plugin extends EventEmitter {
           this.addCommand(cmd)
         }
       }
-      logger.info(`coc ${this.version} initialized with node: ${process.version}`)
+      logger.info(`coc ${this.version} initialized with node: ${process.version} hi`)
       this.emit('ready')
     } catch (e) {
       this._ready = false

--- a/src/types.ts
+++ b/src/types.ts
@@ -1233,6 +1233,15 @@ export interface ExtensionContext {
   logger: log4js.Logger
 }
 
+export type Language = {
+  id: string
+  extensions?: string[]
+  aliases?: string[]
+  filenames?: string[]
+  firstLine?: string
+  configuration: string
+}
+
 export interface IWorkspace {
   readonly nvim: Neovim
   readonly cwd: string
@@ -1288,4 +1297,5 @@ export interface IWorkspace {
   runTerminalCommand(cmd: string, cwd?: string, keepfocus?: boolean): Promise<TerminalResult>
   createStatusBarItem(priority?: number): StatusBarItem
   dispose(): void
+  addLanguage(lang: Language): void
 }

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1710,6 +1710,8 @@ augroup end`
   }
 
   public addLanguage(lang: Language): void {
+    logger.info('custom language detected')
+    logger.info(JSON.stringify(lang))
     this._languages.push(lang)
   }
 


### PR DESCRIPTION
# Feature Request

vscode provides [a handy method](https://code.visualstudio.com/api/references/contribution-points#contributes.languages) for plugins to work with a wide variety of languages.
The key of this method is to allow plugins to define the languages they want to cope with and the corresponding completion rules declaratively. This feature is not yet implemented in coc.

2 sub-features are required in order to implement this feature in coc.

1. auto-activation of extensions based on file extensions.
2. setup grammar rules declaratively like [this](https://code.visualstudio.com/api/language-extensions/language-configuration-guide)

# Background

Based on the reply from @chemzqm  in [this](https://gitter.im/neoclide/coc-cn?at=5e7870905a64806d5ee48d04), `contributes.languages` has yet been supported and no plan to add it has been made.

# Change

This PR only implements the first subfeature, which is to activate the extension based on the declaration of `contributes.languages` of the extension itself.

# Known Problems

Currently, only file extensions are included. However, according to [the definition](https://code.visualstudio.com/api/references/contribution-points#contributes.languages), filenames and firstLine should also be supported.

I haven't dived into the second subfeature yet as it can be way more complex than the first one.

# Roadmap

1. make sure that this feature is desired and the way to implement it is acceptable
2. add filenames and firstLine support
3. implement the second subfeature