### PR TITLE
Add support for ignoring filetypes for buffer source. Fixes #1721.

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -951,6 +951,14 @@
       "default": true,
       "description": "Ignore git ignored files for buffer words"
     },
+    "coc.source.buffer.ignoredFiletypes": {
+      "type": "array",
+      "default": [],
+      "description": "Filetypes that should be ignored for buffer words.",
+      "items": {
+        "type": "string"
+      }
+    },
     "coc.source.buffer.disableSyntaxes": {
       "type": "array",
       "default": [],

--- a/src/source/buffer.ts
+++ b/src/source/buffer.ts
@@ -16,11 +16,16 @@ export default class Buffer extends Source {
     return this.getConfig('ignoreGitignore', true)
   }
 
+  public get ignoredFiletypes(): string[] {
+    return this.getConfig('ignoredFiletypes', [])
+  }
+
   private getWords(bufnr: number): string[] {
-    let { ignoreGitignore } = this
+    let { ignoreGitignore, ignoredFiletypes } = this
     let words: string[] = []
     workspace.documents.forEach(document => {
       if (document.bufnr == bufnr) return
+      if (ignoredFiletypes.indexOf(document.filetype) > -1) return
       if (ignoreGitignore && document.isIgnored) return
       for (let word of document.words) {
         if (words.indexOf(word) == -1) {


### PR DESCRIPTION
Since i wasn't able to find a way to ignore certain filetypes for buffer source (Details in issue #1721), I added an option for it. I tried `workspace.ignoredFiletypes` but it didn't work for me.