### PR TITLE
fix(languages): check textEdit null

### DIFF
--- a/src/languages.ts
+++ b/src/languages.ts
@@ -763,7 +763,7 @@ class Languages {
       kind: complete.completionKindString(item.kind, this.completionItemKindMap, this.completeConfig.defaultKindText),
       sortText: item.sortText || null,
       sourceScore: item['score'] || null,
-      filterText: startcol != null ? item.textEdit.newText : item.filterText || label,
+      filterText: (startcol != null && item.textEdit) ? item.textEdit.newText : item.filterText || label,
       isSnippet,
       dup: item.data && item.data.dup == 0 ? 0 : 1
     }


### PR DESCRIPTION
getStartColumn only checks first 10 items, others maybe contain empty
textEdit.

close https://github.com/fannheyward/coc-texlab/issues/143