### PR TITLE
feat(diagnostic): allow disabling the navigation hint for related diagnostics

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -624,6 +624,11 @@
       "default": false,
       "description": "Separate related information as diagnostics"
     },
+    "diagnostic.showRelatedInformationNavigationHint": {
+      "type": "boolean",
+      "default": true,
+      "description": "Show a navigation hint in diagnostics with related information"
+    },
     "signature.enable": {
       "type": "boolean",
       "description": "Enable signature help when trigger character typed, require restart service on change.",

--- a/src/language-client/client.ts
+++ b/src/language-client/client.ts
@@ -3767,14 +3767,23 @@ export abstract class BaseLanguageClient {
       return
     }
 
-    const separate = workspace.getConfiguration('diagnostic').get('separateRelatedInformationAsDiagnostics') as boolean
+    const config = workspace.getConfiguration('diagnostic')
+    const separate = config.get('separateRelatedInformationAsDiagnostics') as boolean
+    const showNavigationHint = config.get('showRelatedInformationNavigationHint') as boolean
     if (separate) {
       const entries: Map<string, Diagnostic[]> = new Map()
       entries.set(uri, diagnostics)
 
       for (const diagnostic of diagnostics) {
         if (diagnostic.relatedInformation) {
-          let message = `${diagnostic.message}\n\nRelated diagnostics: (Run \`:CocCommand workspace.diagnosticRelated\` to jump)\n`
+          let navigationHint;
+          if (showNavigationHint) {
+            navigationHint = " (Run \`:CocCommand workspace.diagnosticRelated\` to jump)";
+          } else {
+            navigationHint = "";
+          }
+
+          let message = `${diagnostic.message}\n\nRelated diagnostics:${navigationHint}\n`
           for (const info of diagnostic.relatedInformation) {
             const basename = path.basename(URI.parse(info.location.uri).fsPath)
             const ln = info.location.range.start.line


### PR DESCRIPTION
This PR adds an additional setting to coc.nvim that makes it possible to disable the command hint that is displayed for related diagnostics, since experienced users might like a cleaner diagnostic popup.