### PR TITLE
fix(diagnostic): don't miss updating the diagnostic list if diagnostics empty

### DIFF
--- a/src/language-client/client.ts
+++ b/src/language-client/client.ts
@@ -3768,7 +3768,7 @@ export abstract class BaseLanguageClient {
     }
 
     const separate = workspace.getConfiguration('diagnostic').get('separateRelatedInformationAsDiagnostics') as boolean
-    if (separate) {
+    if (separate && diagnostics.length > 0) {
       const entries: Map<string, Diagnostic[]> = new Map()
       entries.set(uri, diagnostics)
 


### PR DESCRIPTION
If separateRelatedInformationAsDiagnostics is enabled, coc.nvim doesn't
update the diagnostics when the list of diagnostics is empty.

This PR fixes this bug.