### PR TITLE
fix(workspace): don't change documentChanges order

### DIFF
--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1661,7 +1661,7 @@ augroup end`
         res.push(change)
       }
     }
-    res.push(...documentEdits)
+    res.unshift(...documentEdits)
     return res
   }
 


### PR DESCRIPTION
`TextDocumentEdit` changes should be in first order. @ckipp01 can you test this PR with #1767 ?

close #1767 