### PR TITLE
workspace: handle version=0 in rename validation

### DIFF
--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1453,7 +1453,7 @@ augroup end`
         if (!newUris.has(uri)) {
           uris.add(uri)
         }
-        if (version != null) {
+        if (version != null && version > 0) {
           let doc = this.getDocument(uri)
           if (!doc) {
             throw new Error(`${uri} not loaded`)


### PR DESCRIPTION
Looks like a regression to #225, re-introduced in
7eb2d4c00599a7f82e1e50c62ec5767be8e9605c?

I noticed the issue while using ocaml-lsp locally.