### PR TITLE
fix(workspace): no loadfile after create file

### DIFF
--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -939,7 +939,6 @@ export class Workspace implements IWorkspace {
         if (doc) return
         let encoding = await this.getFileEncoding()
         fs.writeFileSync(filepath, '', encoding || '')
-        await this.loadFile(uri)
       }
     }
   }


### PR DESCRIPTION
I don't think it's need to load file after create file.

1. `applyEdit` with `createFile` change
2. do `createFile` works, it's OK
3. `loadFile` after `createFile`, this will change current `workspace.bufnr` to new file bufnr, it's not correct
4. do `jumpTo` failed, because workspace.bufnr changed