### PR TITLE
fix( getTagList): handle filename for urls with non-file schemes  

### DIFF
--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -538,7 +538,8 @@ export default class Handler {
     }
     let definitions = await languages.getDefinition(document.textDocument, position)
     return definitions.map(location => {
-      const filename = URI.parse(location.uri).fsPath
+      let parsedURI = URI.parse(location.uri)
+      const filename = parsedURI.scheme == 'file' ? parsedURI.fsPath : parsedURI.toString()
       return {
         name: word,
         cmd: `keepjumps ${location.range.start.line + 1} | normal ${location.range.start.character + 1}|`,


### PR DESCRIPTION
Fixes neoclide/coc-java#80

This fixes the handling of tagList filename for the cases where the scheme of the definition returned by the language server is not 'file' ( example : Libary functions of java which return definitions with 'jdt' scheme).  

While this seems to fix all of the cases I have encountered, a more robust method of sending final URI might be needed similar to what's done in coc#util#jump() for some cases. 

