### PR TITLE
fix(float): don't leak floating windows when created concurrently

### DIFF
--- a/src/__tests__/modules/decorator.test.ts
+++ b/src/__tests__/modules/decorator.test.ts
@@ -1,0 +1,27 @@
+import * as decorator from '../../util/decorator'
+
+class CallTest {
+  public count = 0
+
+  @decorator.combineConcurrent
+  public async combinedConcurrent() : Promise<number> { return ++this.count }
+}
+
+describe('combineConcurrent', () => {
+  test('overlapping', async () => {
+    const c = new CallTest()
+
+    const first = c.combinedConcurrent()
+    const second = c.combinedConcurrent()
+    expect(await first).toBe(1)
+    expect(await second).toBe(1)
+  })
+  test('nonoverlapping', async () => {
+    const c = new CallTest()
+
+    const first = c.combinedConcurrent()
+    expect(await first).toBe(1)
+    const second = c.combinedConcurrent()
+    expect(await second).toBe(2)
+  })
+})

--- a/src/model/floatFactory.ts
+++ b/src/model/floatFactory.ts
@@ -7,6 +7,7 @@ import { disposeAll } from '../util'
 import { equals } from '../util/object'
 import workspace from '../workspace'
 import FloatBuffer from './floatBuffer'
+import { combineConcurrent } from '../util/decorator'
 import debounce from 'debounce'
 import createPopup, { Popup } from './popup'
 import { distinct } from '../util/array'
@@ -77,6 +78,7 @@ export default class FloatFactory implements Disposable {
     }
   }
 
+  @combineConcurrent
   private async checkFloatBuffer(): Promise<void> {
     let { floatBuffer, nvim, window } = this
     if (this.env.textprop) {


### PR DESCRIPTION
Fixes #1816