### PR TITLE
Add virtualtext highlight links according to documentation

### DIFF
--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -268,6 +268,12 @@ endif
 if has('nvim-0.5.0')
   hi default CocCursorTransparent gui=strikethrough blend=100
 endif
+if has('nvim')
+  hi default link CocErrorVirtualText   CocErrorSign
+  hi default link CocWarningVirtualText CocWarningSign
+  hi default link CocInfoVirtualText    CocInfoSign
+  hi default link CocHintVirtualText    CocHintSign
+endif
 
 hi default link CocHoverRange     Search
 hi default link CocCursorRange    Search


### PR DESCRIPTION
I noticed that the settings described in the documentation aren't actually there, so I added them.
https://github.com/neoclide/coc.nvim/blob/b47c4a8738bcb11c693534a523185baf2c0f9a65/doc/coc.txt#L1885