### PR TITLE
Stop modifying position of cursor on signatureHelp

### DIFF
--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -876,8 +876,6 @@ export default class Handler {
       this.signatureFactory.close()
       return
     }
-    let idx = Math.max(part.lastIndexOf(','), part.lastIndexOf('('))
-    if (idx != -1) position.character = idx + 1
     let tokenSource = this.signatureTokenSource = new CancellationTokenSource()
     let token = tokenSource.token
     let timer = setTimeout(() => {


### PR DESCRIPTION
It is a Language Server's job to correctly handle signatureHelp. coc.nvim should not attempt to fix buggy language servers on the client side because this will break non-buggy language servers.

Resolves https://github.com/neoclide/coc.nvim/issues/1467

Note: this resolves the issue by removing something some people may arguably consider a feature (I view it as a bug, but others may disagree with me). An alternative would be to keep this bug, add a documented option to disable it, and modify the code accordingly. I'm submitting this PR just in case you, like me, prefer to simply eliminate this bug-inducing code.