### PR TITLE
Create pluggable mappings for classes: <Plug>(coc-classobj-*)

### DIFF
--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -1,8 +1,8 @@
 if exists('g:did_coc_loaded') || v:version < 800
   finish
 endif
-if has('nvim') && !has('nvim-0.3.0') 
-  finish 
+if has('nvim') && !has('nvim-0.3.0')
+  finish
 endif
 let g:did_coc_loaded = 1
 let g:coc_service_initialized = 0

--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -381,3 +381,7 @@ vnoremap <silent> <Plug>(coc-funcobj-i)        :<C-U>call coc#rpc#request('selec
 vnoremap <silent> <Plug>(coc-funcobj-a)        :<C-U>call coc#rpc#request('selectFunction', [v:false, visualmode()])<CR>
 onoremap <silent> <Plug>(coc-funcobj-i)        :<C-U>call coc#rpc#request('selectFunction', [v:true, ''])<CR>
 onoremap <silent> <Plug>(coc-funcobj-a)        :<C-U>call coc#rpc#request('selectFunction', [v:false, ''])<CR>
+vnoremap <silent> <Plug>(coc-classobj-i)        :<C-U>call coc#rpc#request('selectClass', [v:true, visualmode()])<CR>
+vnoremap <silent> <Plug>(coc-classobj-a)        :<C-U>call coc#rpc#request('selectClass', [v:false, visualmode()])<CR>
+onoremap <silent> <Plug>(coc-classobj-i)        :<C-U>call coc#rpc#request('selectClass', [v:true, ''])<CR>
+onoremap <silent> <Plug>(coc-classobj-a)        :<C-U>call coc#rpc#request('selectClass', [v:false, ''])<CR>

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -773,7 +773,15 @@ export default class Handler {
     return res
   }
 
+  public async selectClass(inner: boolean, visualmode: string): Promise<void> {
+    await this.selectSymbols(inner, visualmode, ['Interface', 'Struct', 'Class'])
+  }
+
   public async selectFunction(inner: boolean, visualmode: string): Promise<void> {
+    await this.selectSymbols(inner, visualmode, ['Method', 'Function'])
+  }
+
+  private async selectSymbols(inner: boolean, visualmode: string, supportedSymbols: string[]): Promise<void> {
     let { nvim } = this
     let bufnr = await nvim.eval('bufnr("%")') as number
     let doc = workspace.getDocument(bufnr)
@@ -791,10 +799,7 @@ export default class Handler {
       return
     }
     let properties = symbols.filter(s => s.kind == 'Property')
-    symbols = symbols.filter(s => [
-      'Method',
-      'Function',
-    ].includes(s.kind))
+    symbols = symbols.filter(s => supportedSymbols.includes(s.kind))
     let selectRange: Range
     for (let sym of symbols.reverse()) {
       if (sym.range && !equals(sym.range, range) && rangeInRange(range, sym.range)) {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -85,6 +85,9 @@ export default class Plugin extends EventEmitter {
     this.addMethod('selectFunction', async (inner: boolean, visualmode: string) => {
       return await this.handler.selectFunction(inner, visualmode)
     })
+    this.addMethod('selectClass', async (inner: boolean, visualmode: string) => {
+      return await this.handler.selectClass(inner, visualmode)
+    })
     this.addMethod('listResume', () => {
       return listManager.resume()
     })


### PR DESCRIPTION
Creates pluggable mappings for class text objects. Also, generalizes the function code to make it generally applicable to any DocumentSymbol range.

Topic for discussion: should we consider `['Interface', 'Struct', 'Class']` as all part of a "class" text object? I think about them similarly across languages, so I'm inclined to say yes.

I'll update the English docs if you generally approve of this PR / once we agree on the implementation.

