### PR TITLE
Clarify funcobj and classobj: no default mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,18 +155,15 @@ nmap <leader>ac  <Plug>(coc-codeaction)
 " Apply AutoFix to problem on the current line.
 nmap <leader>qf  <Plug>(coc-fix-current)
 
-" Introduce function text object
+" Map function and class text objects
 " NOTE: Requires 'textDocument.documentSymbol' support from the language server.
 xmap if <Plug>(coc-funcobj-i)
-xmap af <Plug>(coc-funcobj-a)
 omap if <Plug>(coc-funcobj-i)
+xmap af <Plug>(coc-funcobj-a)
 omap af <Plug>(coc-funcobj-a)
-
-" Introduce class/struct/interface text object
-" NOTE: Requires 'textDocument.documentSymbol' support from the language server.
 xmap ic <Plug>(coc-classobj-i)
-xmap ac <Plug>(coc-classobj-a)
 omap ic <Plug>(coc-classobj-i)
+xmap ac <Plug>(coc-classobj-a)
 omap ac <Plug>(coc-classobj-a)
 
 " Use <TAB> for selections ranges.

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -805,22 +805,28 @@ normal mode, `v_` works for visual mode.
 
 <Plug>(coc-funcobj-i)			*n_coc-funcobj-i* *v_coc-funcobj-i*
 
-			Select inside function, mapped to `if` by default.
+			Select inside function. Recommend mapping:
+			  xmap if <Plug>(coc-funcobj-i)
+			  omap if <Plug>(coc-funcobj-i)
 
 			Note: Requires 'textDocument.documentSymbol' support
 			from the language server.
 
 <Plug>(coc-funcobj-a)			*n_coc-funcobj-a* *v_coc-funcobj-a*
 
-			Select current function, mapped to `af` by default.
+			Select around function. Recommended mapping:
+			  xmap af <Plug>(coc-funcobj-a)
+			  omap af <Plug>(coc-funcobj-a)
 
 			Note: Requires 'textDocument.documentSymbol' support
 			from the language server.
 
 <Plug>(coc-classobj-i)			*n_coc-classobj-i* *v_coc-classobj-i*
 
-			Select inside class/struct/interface, mapped to `ic`
-			by default.
+			Select inside class/struct/interface. Recommended
+			mapping:
+			  xmap ic <Plug>(coc-classobj-i)
+			  omap ic <Plug>(coc-classobj-i)
 
 			Note: Requires 'textDocument.documentSymbol' support
 			from the language server.
@@ -828,8 +834,10 @@ normal mode, `v_` works for visual mode.
 
 <Plug>(coc-classobj-a)			*n_coc-classobj-a* *v_coc-classobj-a*
 
-			Select current class/struct/interface, mapped to `ac`
-			by default.
+			Select around class/struct/interface. Recommended
+			mapping:
+			  xmap ac <Plug>(coc-classobj-a)
+			  omap ac <Plug>(coc-classobj-a)
 
 			Note: Requires 'textDocument.documentSymbol' support
 			from the language server.


### PR DESCRIPTION
There are no default mappings provided by either funcobj-* or
classobj-*. Instead, there are Coc-recommended keys / modes to which
these pluggable mappings should be mapped.

See here for reference: https://github.com/neoclide/coc.nvim/pull/1875#issuecomment-626221554