### PR TITLE
services: fix config check in process start

### DIFF
--- a/src/services.ts
+++ b/src/services.ts
@@ -272,7 +272,8 @@ export class ServiceManager extends EventEmitter implements Disposable {
         if (!created) {
           if (typeof name == 'string' && !client) {
             let config: LanguageServerConfig = workspace.getConfiguration().get<{ key: LanguageServerConfig }>('languageserver', {} as any)[name]
-            if (!config || !config.enable) return
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-boolean-literal-compare
+            if (!config || config.enable === false) return
             let opts = getLanguageServerOptions(id, name, config)
             if (!opts) return
             client = new LanguageClient(id, name, opts[1], opts[0])

--- a/src/types.ts
+++ b/src/types.ts
@@ -342,7 +342,7 @@ export interface LanguageServerConfig {
   disableDiagnostics?: boolean
   filetypes: string[]
   additionalSchemes: string[]
-  enable: boolean
+  enable?: boolean
   args?: string[]
   cwd?: string
   env?: any


### PR DESCRIPTION
LanguageServerConfig.enable was mistyped and the linter got it wrong.
There's a chance this is happening in other places, I'd recommend
reviewing all changes from `!== false` or `=== false` to simple truthy
checks. Avoiding boolean values that default to true would make the
code easier to reason about too.

Related to #1878 and #1881.