### PR TITLE
select[Function,Class] changed to selectSymbolRange

### DIFF
--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -377,11 +377,13 @@ nnoremap <silent> <Plug>(coc-cursors-operator) :<C-u>set operatorfunc=<SID>Curso
 vnoremap <silent> <Plug>(coc-cursors-range)    :<C-u>call coc#rpc#request('cursorsSelect', [bufnr('%'), 'range', visualmode()])<CR>
 nnoremap <silent> <Plug>(coc-cursors-word)     :<C-u>call coc#rpc#request('cursorsSelect', [bufnr('%'), 'word', 'n'])<CR>
 nnoremap <silent> <Plug>(coc-cursors-position) :<C-u>call coc#rpc#request('cursorsSelect', [bufnr('%'), 'position', 'n'])<CR>
-vnoremap <silent> <Plug>(coc-funcobj-i)        :<C-U>call coc#rpc#request('selectFunction', [v:true, visualmode()])<CR>
-vnoremap <silent> <Plug>(coc-funcobj-a)        :<C-U>call coc#rpc#request('selectFunction', [v:false, visualmode()])<CR>
-onoremap <silent> <Plug>(coc-funcobj-i)        :<C-U>call coc#rpc#request('selectFunction', [v:true, ''])<CR>
-onoremap <silent> <Plug>(coc-funcobj-a)        :<C-U>call coc#rpc#request('selectFunction', [v:false, ''])<CR>
-vnoremap <silent> <Plug>(coc-classobj-i)        :<C-U>call coc#rpc#request('selectClass', [v:true, visualmode()])<CR>
-vnoremap <silent> <Plug>(coc-classobj-a)        :<C-U>call coc#rpc#request('selectClass', [v:false, visualmode()])<CR>
-onoremap <silent> <Plug>(coc-classobj-i)        :<C-U>call coc#rpc#request('selectClass', [v:true, ''])<CR>
-onoremap <silent> <Plug>(coc-classobj-a)        :<C-U>call coc#rpc#request('selectClass', [v:false, ''])<CR>
+
+vnoremap <silent> <Plug>(coc-funcobj-i)        :<C-U>call coc#rpc#request('selectSymbolRange', [v:true, visualmode(), ['Method', 'Function']])<CR>
+vnoremap <silent> <Plug>(coc-funcobj-a)        :<C-U>call coc#rpc#request('selectSymbolRange', [v:false, visualmode(), ['Method', 'Function']])<CR>
+onoremap <silent> <Plug>(coc-funcobj-i)        :<C-U>call coc#rpc#request('selectSymbolRange', [v:true, '', ['Method', 'Function']])<CR>
+onoremap <silent> <Plug>(coc-funcobj-a)        :<C-U>call coc#rpc#request('selectSymbolRange', [v:false, '', ['Method', 'Function']])<CR>
+
+vnoremap <silent> <Plug>(coc-classobj-i)       :<C-U>call coc#rpc#request('selectSymbolRange', [v:true, visualmode(), ['Interface', 'Struct', 'Class']])<CR>
+vnoremap <silent> <Plug>(coc-classobj-a)       :<C-U>call coc#rpc#request('selectSymbolRange', [v:false, visualmode(), ['Interface', 'Struct', 'Class']])<CR>
+onoremap <silent> <Plug>(coc-classobj-i)       :<C-U>call coc#rpc#request('selectSymbolRange', [v:true, '', ['Interface', 'Struct', 'Class']])<CR>
+onoremap <silent> <Plug>(coc-classobj-a)       :<C-U>call coc#rpc#request('selectSymbolRange', [v:false, '', ['Interface', 'Struct', 'Class']])<CR>

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -771,15 +771,10 @@ export default class Handler {
     return res
   }
 
-  public async selectClass(inner: boolean, visualmode: string): Promise<void> {
-    await this.selectSymbols(inner, visualmode, ['Interface', 'Struct', 'Class'])
-  }
-
-  public async selectFunction(inner: boolean, visualmode: string): Promise<void> {
-    await this.selectSymbols(inner, visualmode, ['Method', 'Function'])
-  }
-
-  private async selectSymbols(inner: boolean, visualmode: string, supportedSymbols: string[]): Promise<void> {
+  /*
+   * supportedSymbols must be string values of symbolKind
+   */
+  public async selectSymbolRange(inner: boolean, visualmode: string, supportedSymbols: string[]): Promise<void> {
     let { nvim } = this
     let bufnr = await nvim.eval('bufnr("%")') as number
     let doc = workspace.getDocument(bufnr)

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -66,8 +66,7 @@ export default class Plugin extends EventEmitter {
       await this.ready
       return await this.handler.runCommand(...args)
     })
-    this.addMethod('selectFunction', async (inner: boolean, visualmode: string) => await this.handler.selectFunction(inner, visualmode))
-    this.addMethod('selectClass', async (inner: boolean, visualmode: string) => await this.handler.selectClass(inner, visualmode))
+    this.addMethod('selectSymbolRange', async (inner: boolean, visualmode: string, supportedSymbols: string[]) => await this.handler.selectSymbolRange(inner, visualmode, supportedSymbols))
     this.addMethod('listResume', () => listManager.resume())
     this.addMethod('listPrev', () => listManager.previous())
     this.addMethod('listNext', () => listManager.next())


### PR DESCRIPTION
By exposing `selectSymbolRange` instead of `selectClass` and `selectFunction` (which I've removed), end users can write their own pluggable mappings while maintaining the same public interface in Vim / Neovim.

Ultimately, this PR gives the end user more configuration control while maintaining existing mappings / not changing any important public interfaces.