### PR TITLE
fix(extensions): fix coc_global_extensions error

### DIFF
--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -180,7 +180,7 @@ export class Extensions {
       let json = this.loadJson()
       if (json && json.dependencies) {
         let vals: string[] = Object.values(json.dependencies)
-        names = names.filter(s => /^https?:/.test(s) && vals.some(v => v.startsWith(s)))
+        names = names.filter(s => !vals.includes(s))
       }
       this.installExtensions(names).logError()
     }


### PR DESCRIPTION
close #1881

@chemzqm correct me if I'm wrong, what `checkExtensions` does is:

1. get globalExtensions and filter disabled
2. check if exists in node_modules
3. check json.dependencies, here I think it's only need to check whether exists
4. finally got non-exist extensions list, do install action