### PR TITLE
Reversed autocomplete options list

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -425,6 +425,11 @@
       "description": "Remove completion items with duplicated word for all sources, snippet items are excluded.",
       "default": false
     },
+    "suggest.reverseList": {
+      "type": "boolean",
+      "description": "Reverse completion items.",
+      "default": false
+    },
     "suggest.defaultSortMethod": {
       "type": "string",
       "description": "Default sorting behavior for suggested completion items.",

--- a/src/__tests__/completion/basic.test.ts
+++ b/src/__tests__/completion/basic.test.ts
@@ -402,4 +402,27 @@ describe('completion', () => {
     }
     disposable.dispose()
   })
+
+  it('should reverse list of complete items', async () => {
+    helper.updateConfiguration('suggest.reverseList', true)
+    await helper.edit()
+    let source: ISource = {
+      name: 'high',
+      priority: 90,
+      enable: true,
+      sourceType: SourceType.Native,
+      triggerCharacters: ['.'],
+      doComplete: async (): Promise<CompleteResult> => Promise.resolve({
+          items: ['a', 'b', 'c', 'd'].map(key => ({ word: key }))
+        })
+    }
+    let disposable = sources.addSource(source)
+    await nvim.input('i')
+    await helper.wait(30)
+    await nvim.input('.')
+    await helper.waitPopup()
+    let items = await helper.getItems()
+    expect(items.map(item=>item.abbr)).toEqual(["d", "c", "b", "a"])
+    disposable.dispose()
+  })
 })

--- a/src/completion/complete.ts
+++ b/src/completion/complete.ts
@@ -261,7 +261,15 @@ export default class Complete {
           return a.filterText.length - b.filterText.length
       }
     })
-    return this.limitCompleteItems(arr.slice(0, this.config.maxItemCount))
+
+    let completeItems= this.limitCompleteItems(arr.slice(0, this.config.maxItemCount))
+
+    if (this.config.reverseList) {
+      completeItems = completeItems.reverse()
+    }
+    console.log(this.config.reverseList)
+
+    return completeItems
   }
 
   private limitCompleteItems(items: VimCompleteItem[]): VimCompleteItem[] {

--- a/src/completion/complete.ts
+++ b/src/completion/complete.ts
@@ -267,7 +267,6 @@ export default class Complete {
     if (this.config.reverseList) {
       completeItems = completeItems.reverse()
     }
-    console.log(this.config.reverseList)
 
     return completeItems
   }

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -146,7 +146,8 @@ export class Completion implements Disposable {
       localityBonus: getConfig<boolean>('localityBonus', true),
       highPrioritySourceLimit: getConfig<number>('highPrioritySourceLimit', null),
       lowPrioritySourceLimit: getConfig<number>('lowPrioritySourceLimit', null),
-      asciiCharactersOnly: getConfig<boolean>('asciiCharactersOnly', false)
+      asciiCharactersOnly: getConfig<boolean>('asciiCharactersOnly', false),
+      reverseList: getConfig<boolean>('reverseList', false)
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -607,6 +607,7 @@ export interface CompleteConfig {
   removeDuplicateItems: boolean
   defaultSortMethod: string
   asciiCharactersOnly: boolean
+  reverseList: boolean
 }
 
 export interface WorkspaceConfiguration {


### PR DESCRIPTION
Added `suggest.reverseList` setting to reverse the order of autocomplete options so most relevant ones show at the bottom instead of top.

Resolves https://github.com/neoclide/coc.nvim/issues/1008