### PR TITLE
Add subseparator between codelenses in virtual text

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -668,6 +668,11 @@
       "description": "Separator text for codeLens in virtual text",
       "default": "‣"
     },
+    "codeLens.subseparator": {
+      "type": "string",
+      "description": "Subseparator between codeLenses in virtual text",
+      "default": " "
+    },
     "refactor.openCommand": {
       "type": "string",
       "description": "Open command for refactor window.",

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -513,6 +513,10 @@ Built-in configurations:~
 
 	Separator text for `codeLens` in virtual text, default: `"‣"`
 
+"codeLens.subseparator":~
+
+	Subseparator text for multiple `codeLens`es in virtual text, default: `" "`
+
 "workspace.ignoredFiletypes":~
 
 	Filetypes to ignore for workspace folder resolution,

--- a/src/handler/codelens.ts
+++ b/src/handler/codelens.ts
@@ -17,6 +17,7 @@ export interface CodeLensInfo {
 
 export default class CodeLensManager {
   private separator: string
+  private subseparator: string
   private srcId: number
   private enabled: boolean
   private fetching: Set<number> = new Set()
@@ -108,6 +109,7 @@ export default class CodeLensManager {
       config = workspace.getConfiguration('codeLens')
     }
     this.separator = config.get<string>('separator', '‣')
+    this.subseparator = config.get<string>('subseparator', ' ')
     this.enabled = nvim.hasFunction('nvim_buf_set_virtual_text') && config.get<boolean>('enable', true)
   }
 
@@ -154,7 +156,15 @@ export default class CodeLensManager {
       let codeLenses = list.get(lnum)
       let commands = codeLenses.map(codeLens => codeLens.command)
       commands = commands.filter(c => c && c.title)
-      let chunks = commands.map(c => [c.title + ' ', 'CocCodeLens'] as [string, string])
+      let chunks = []
+      let n_commands = commands.length
+      for (let i = 0; i < n_commands; i++) {
+        let c = commands[i]
+        chunks.push([c.title, 'CocCodeLens'] as [string, string])
+        if (i != n_commands - 1) {
+          chunks.push([this.subseparator, 'CocCodeLens'] as [string, string])
+        }
+      }
       chunks.unshift([`${this.separator} `, 'CocCodeLens'])
       await buffer.setVirtualText(this.srcId, lnum, chunks)
     }


### PR DESCRIPTION
Added sub-separator between codelenses in virtual text in case there are multiple codelenses at one line.

The motivation is that [`rust-analyzer`](https://github.com/rust-analyzer/rust-analyzer) returns CodeLens item whose title includes space character like `Run Bench`. If it appears with other CodeLenses, virtual text becomes confusing.

![Screenshot from 2020-05-14 00-47-50](https://user-images.githubusercontent.com/4624806/81837342-b186ad00-957f-11ea-9e0a-759bef403735.png)

So I added `codeLens.subseparator` option. 
If `codeLens.subseparator: " | "`, virtual text in same case as above is displayed as below:

![Screenshot from 2020-05-14 00-48-24](https://user-images.githubusercontent.com/4624806/81837940-720c9080-9580-11ea-97c0-f9aa131e7aea.png)

(If `codeLens.subseparator: " "`, behaves as before)