### PR TITLE
关于 readme 中 language server 的说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,14 @@ nnoremap <silent> <space>k  :<C-u>CocPrev<CR>
 nnoremap <silent> <space>p  :<C-u>CocListResume<CR>
 ```
 
+## Language server configurating
+
+You also need to configure language to make command like `gd` work.
+
+Run `:CocConfig`, and refer [here](https://github.com/neoclide/coc.nvim/wiki/Language-servers) for details.
+
+Also, you may need to install needed language server for specific language if you haven't.
+
 ## Articles
 
 - [coc.nvim 插件体系介绍](https://zhuanlan.zhihu.com/p/65524706)


### PR DESCRIPTION
readme 里面并没有说清楚需要进行 language server 的配置(也可能是因为我没有仔细看)
我对 README 进行了一些简单的修改, 提示新手需要配置 languager server