### PR TITLE
fix: avoid height is NaN, fix #1934

### DIFF
--- a/src/model/floatFactory.ts
+++ b/src/model/floatFactory.ts
@@ -116,7 +116,7 @@ export default class FloatFactory extends EventEmitter implements Disposable {
   public async create(docs: Documentation[], allowSelection = false, offsetX = 0): Promise<void> {
     if (!workspace.floatSupported) return
     this.onCursorMoved.clear()
-    if (docs.length == 0) {
+    if (docs.length == 0 || docs.every(doc => doc.content.length == 0)) {
       this.close()
       return
     }


### PR DESCRIPTION
When document is empty height will get a `NaN`, 

`(w - 2) / (width - 2) = 0 / 0 = NaN`

https://github.com/neoclide/coc.nvim/blob/d3d460db324093fa3af674243538590708792ef1/src/model/floatBuffer.ts#L182