### PR TITLE
add suggest.maxPreviewHeight

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -277,10 +277,15 @@
       "description": "Enable preselect feature, only works on neovim",
       "default": false
     },
+    "suggest.maxPreviewHeight": {
+      "type": "number",
+      "default": 40,
+      "description": "Maximum height of floating window or preview window."
+    },
     "suggest.maxPreviewWidth": {
       "type": "number",
       "default": 80,
-      "description": "Maximum width of floating preview window."
+      "description": "Maximum width of floating window."
     },
     "suggest.enablePreview": {
       "type": "boolean",

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -133,9 +133,13 @@ Built-in configurations:~
 
 	Enable preselect feature on Neovim, default: `true`
 
+"suggest.maxPreviewHeight":~
+
+	Maximum height of floating window or preview window, default: `40`
+
 "suggest.maxPreviewWidth":~
 
-	Maximum width of floating preview window, default: `80`
+	Maximum width of floating window, default: `80`
 
 "suggest.labelMaxLength":~
 

--- a/src/completion/floating.ts
+++ b/src/completion/floating.ts
@@ -14,6 +14,7 @@ interface Bounding {
 
 export interface FloatingConfig {
   srcId: number
+  maxPreviewHeight: number
   maxPreviewWidth: number
   enable: boolean
 }
@@ -34,6 +35,7 @@ export default class Floating {
     }
     this.config = {
       srcId: workspace.createNameSpace('coc-pum-float'),
+      maxPreviewHeight: configuration.get<number>('maxPreviewHeight', 40),
       maxPreviewWidth: configuration.get<number>('maxPreviewWidth', 80),
       enable: enableFloat
     }
@@ -84,7 +86,7 @@ export default class Floating {
   private calculateBounding(docs: Documentation[], bounding: PumBounding): Bounding {
     let { config } = this
     let { columns, lines } = workspace.env
-    let { maxPreviewWidth } = config
+    let { maxPreviewHeight, maxPreviewWidth } = config
     let pumWidth = bounding.width + (bounding.scrollbar ? 1 : 0)
     let showRight = true
     let paddingRight = columns - bounding.col - pumWidth
@@ -92,6 +94,7 @@ export default class Floating {
     let maxWidth = showRight ? paddingRight - 1 : bounding.col - 1
     maxWidth = Math.min(maxPreviewWidth, maxWidth)
     let maxHeight = lines - bounding.row - workspace.env.cmdheight - 1
+    maxHeight = Math.min(maxPreviewHeight, maxHeight)
     let { width, height } = FloatBuffer.getDimension(docs, maxWidth, maxHeight)
     if (width == 0 || height == 0) return null
     return {

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -151,6 +151,7 @@ export class Completion implements Disposable {
       previewIsKeyword: getConfig<string>('previewIsKeyword', '@,48-57,_192-255'),
       enablePreview: getConfig<boolean>('enablePreview', false),
       enablePreselect: getConfig<boolean>('enablePreselect', false),
+      maxPreviewHeight: getConfig<number>('maxPreviewHeight', 40),
       maxPreviewWidth: getConfig<number>('maxPreviewWidth', 80),
       labelMaxLength: getConfig<number>('labelMaxLength', 200),
       triggerAfterInsertEnter: getConfig<boolean>('triggerAfterInsertEnter', false),

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -67,6 +67,7 @@ interface Preferences {
   formatOnTypeFiletypes: string[]
   formatOnInsertLeave: boolean
   hoverTarget: string
+  maxPreviewHeight: number
   previewAutoClose: boolean
   bracketEnterImprove: boolean
   currentFunctionSymbolAutoUpdate: boolean
@@ -235,7 +236,7 @@ export default class Handler {
         nvim.command('setlocal conceallevel=2 nospell nofoldenable wrap', true)
         nvim.command('setlocal bufhidden=wipe nobuflisted', true)
         nvim.command('setfiletype markdown', true)
-        nvim.command(`exe "normal! z${this.documentLines.length}\\<cr>"`, true)
+        nvim.command(`exe "normal! z${Math.min(this.documentLines.length, this.preferences.maxPreviewHeight)}\\<cr>"`, true)
         await nvim.resumeNotification()
         return this.documentLines.join('\n')
       }
@@ -1223,7 +1224,8 @@ export default class Handler {
     if (signatureHelpTarget == 'float' && !workspace.floatSupported) {
       signatureHelpTarget = 'echo'
     }
-    this.labels = workspace.getConfiguration('suggest').get<any>('completionItemKindLabels', {})
+    let suggest = workspace.getConfiguration('suggest')
+    this.labels = suggest.get<any>('completionItemKindLabels', {})
     this.preferences = {
       hoverTarget,
       signatureHelpTarget,
@@ -1237,6 +1239,7 @@ export default class Handler {
       formatOnTypeFiletypes: config.get('formatOnTypeFiletypes', []),
       formatOnInsertLeave: config.get<boolean>('formatOnInsertLeave', false),
       bracketEnterImprove: config.get<boolean>('bracketEnterImprove', true),
+      maxPreviewHeight: suggest.get<number>('maxPreviewHeight', 40),
       previewAutoClose: config.get<boolean>('previewAutoClose', false),
       currentFunctionSymbolAutoUpdate: config.get<boolean>('currentFunctionSymbolAutoUpdate', false),
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -595,6 +595,7 @@ export interface CompleteConfig {
   enablePreview: boolean
   enablePreselect: boolean
   labelMaxLength: number
+  maxPreviewHeight: number
   maxPreviewWidth: number
   autoTrigger: string
   previewIsKeyword: string


### PR DESCRIPTION
This is a configuration to limit the max height of floating windows AND
preview windows. This is especially useful when hoverTarget is preview
and previewAutoClose is false.  The Main advantage of such configuration
is that the documentation text remains intact while editing/navigating.
However, if the documentation is very long, the preview window would
occupy the entire page:
```
// in provideTextDocumentContent
nvim.command(`exe "normal! z${this.documentLines.length}\\<cr>"`, true)
```
Users can prevent such cases by setting maxPreviewHeight to a value
small enough (e.g. 20).

The name of option doesn't look good because there is another option
with the exactly same name (list.maxPreviewHeight).  Something like
suggest.hoverMaxHeight and suggest.hoverMaxWidth would be better.

**TODO**:
It turns out that this actually doesn't limit the max height of floating
window and I couldn't figure out why. 