### PR TITLE
fix(extensions): fix can not load extensions if uri is null

### DIFF
--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -557,7 +557,7 @@ export class Extensions {
         }
         let version = obj ? obj.version || '' : ''
         let description = obj ? obj.description || '' : ''
-        let uri = isuri.isValid(val) ? val : null
+        let uri = isuri.isValid(val) ? val : ''
         resolve({
           id: key,
           isLocal: false,


### PR DESCRIPTION
if `uri` is `null`, all my coc extensions won't be loaded. 

Firstly mentioned by @willfish here https://github.com/neoclide/coc.nvim/commit/d7b30843755d6040f46d9d7d2fbc8f49fc366e1c#r39264105