### PR TITLE
doc: Fix a simple typo in file coc.cnx

### DIFF
--- a/doc/coc.cnx
+++ b/doc/coc.cnx
@@ -106,7 +106,7 @@ coc.nvim 使用 coc-settings.json 文件进行配置，该文件格式与工作�
 
 	"suggest.autoTrigger": "none",
 <
-进入插入模块即触发自动补全： >
+进入插入模式即触发自动补全： >
 
 	"suggest.triggerAfterInsertEnter": true,
 


### PR DESCRIPTION
Replace "模块" with "模式".

Signed-off-by: Ding Tao <i@dingtao.org>