### PR TITLE
docs(configuration): Fix obsolete default value

### DIFF
--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -131,7 +131,7 @@ Built-in configurations:~
 							*coc-config-suggest*
 "suggest.enablePreselect":~
 
-	Enable preselect feature on Neovim, default: `true`
+	Enable preselect feature on Neovim, default: `false`
 
 "suggest.maxPreviewWidth":~
 


### PR DESCRIPTION
Documentation indicates a `"suggest.enablePreselect"` default value of `true`, whereas the code and the schema indicates `false`
This PR modifies the value in documentation in order to reflect the code