### PR TITLE
add coc.preferences.previewMaxHeight

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -849,6 +849,11 @@
       "description": "Auto close preview window on cursor move.",
       "default": true
     },
+    "coc.preferences.previewMaxHeight": {
+      "type": "number",
+      "default": 12,
+      "description": "Max height of preview window for hover."
+    },
     "coc.preferences.currentFunctionSymbolAutoUpdate": {
       "type": "boolean",
       "description": "Automatically update the value of b:coc_current_function on CursorHold event",

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -633,6 +633,10 @@ Built-in configurations:~
 
 	Auto close preview window of hover upon cursor move, default: `true`
 
+"coc.preferences.previewMaxHeight":~
+
+	Max height of preview window for hover, default: `12`
+
 "coc.preferences.colorSupport":~
 
 	Enable color highlight if Language Server support it, default: `true`

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -68,6 +68,7 @@ interface Preferences {
   formatOnInsertLeave: boolean
   hoverTarget: string
   previewAutoClose: boolean
+  previewMaxHeight: number
   bracketEnterImprove: boolean
   currentFunctionSymbolAutoUpdate: boolean
 }
@@ -235,7 +236,7 @@ export default class Handler {
         nvim.command('setlocal conceallevel=2 nospell nofoldenable wrap', true)
         nvim.command('setlocal bufhidden=wipe nobuflisted', true)
         nvim.command('setfiletype markdown', true)
-        nvim.command(`exe "normal! z${this.documentLines.length}\\<cr>"`, true)
+        nvim.command(`exe "normal! z${Math.min(this.documentLines.length, this.preferences.previewMaxHeight)}\\<cr>"`, true)
         await nvim.resumeNotification()
         return this.documentLines.join('\n')
       }
@@ -1228,6 +1229,7 @@ export default class Handler {
       formatOnTypeFiletypes: config.get('formatOnTypeFiletypes', []),
       formatOnInsertLeave: config.get<boolean>('formatOnInsertLeave', false),
       bracketEnterImprove: config.get<boolean>('bracketEnterImprove', true),
+      previewMaxHeight: config.get<number>('previewMaxHeight', 12),
       previewAutoClose: config.get<boolean>('previewAutoClose', false),
       currentFunctionSymbolAutoUpdate: config.get<boolean>('currentFunctionSymbolAutoUpdate', false),
     }


### PR DESCRIPTION
This is the fixed version of #1946. Apparently I mixed up the "preview" window and the hover/popup window used for completion "preview".

This is a configuration to limit the max height of a preview window used for hover. Only valid when `coc.preferences.hoverTarget` is `"preview"`.