### PR TITLE
Fix example language server config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,12 @@ Or configure language server in `coc-settings.json` opened by
 ```json
 {
   "languageserver": {
-    "command": "gopls",
-    "rootPatterns": ["go.mod"],
-    "trace.server": "verbose",
-    "filetypes": ["go"]
+    "go": {
+      "command": "gopls",
+      "rootPatterns": ["go.mod"],
+      "trace.server": "verbose",
+      "filetypes": ["go"]
+    }
   }
 }
 ```


### PR DESCRIPTION
This snippet does not work as is, and is missing the top level key for the language.