### PR TITLE
Fix drawing horizontal line on CJK

### DIFF
--- a/src/model/floatBuffer.ts
+++ b/src/model/floatBuffer.ts
@@ -168,7 +168,7 @@ export default class FloatBuffer {
       let filtered = doc.filetype == 'markdown' ? lines.filter(s => !/^\s*```/.test(s)) : lines
       newLines.push(...filtered)
       if (idx != docs.length - 1) {
-        newLines.push('\u2500'.repeat(width - 2))
+        newLines.push('—'.repeat(width - 2))
         currLine = newLines.length
       }
       idx = idx + 1


### PR DESCRIPTION
This reverts commit 915af62ce70cef1dffe04dc63a44763d9706fec7.

On environments that East-Asian `Ambiguous characters are double-width`[1],
`\u2500` is treated as a double width character, and 
horizontal line in popup will be drawn bad like below screenshot.
(Screenshot on iTerm2, macOS)

![double-width](https://user-images.githubusercontent.com/1623176/83983601-a8181700-a96a-11ea-96d2-65d4198712f1.png)

`-` is treated as a single width character anytime, so it will be drawn good.
![pull-req](https://user-images.githubusercontent.com/1623176/83983890-ea425800-a96c-11ea-83ff-8f812289485d.png)


[1] UAX # 11: East Asian Width http://www.unicode.org/reports/tr11/tr11-38.html