### PR TITLE
Add option for list minimum height.

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -706,6 +706,11 @@
       "default": 10,
       "description": "Maximum height of list window."
     },
+    "list.minHeight": {
+      "type": "number",
+      "default": 1,
+      "description": "Minimum height of list window."
+    },
     "list.signOffset": {
       "type": "number",
       "default": 900,

--- a/src/list/ui.ts
+++ b/src/list/ui.ts
@@ -311,7 +311,7 @@ export default class ListUI {
   public async drawItems(items: ListItem[], name: string, listOptions: ListOptions, reload = false): Promise<void> {
     let { bufnr, config, nvim } = this
     this.newTab = listOptions.position == 'tab'
-    let height = this.calculateListHeight(items);
+    let height = this.calculateListHeight(items)
     let limitLines = config.get<number>('limitLines', 30000)
     let curr = this.items[this.index]
     this.items = items.slice(0, limitLines)
@@ -371,7 +371,7 @@ export default class ListUI {
       nvim.call('clearmatches', [], true)
     }
     if (resize) {
-      let height = this.calculateListHeight(this.items);
+      let height = this.calculateListHeight(this.items)
       nvim.call('coc#list#set_height', [height], true)
     }
     if (!append) {

--- a/src/list/ui.ts
+++ b/src/list/ui.ts
@@ -311,9 +311,7 @@ export default class ListUI {
   public async drawItems(items: ListItem[], name: string, listOptions: ListOptions, reload = false): Promise<void> {
     let { bufnr, config, nvim } = this
     this.newTab = listOptions.position == 'tab'
-    let maxHeight = config.get<number>('maxHeight', 10)
-    let minHeight = config.get<number>('minHeight', 1)
-    let height = Math.min(Math.max(minHeight, items.length), maxHeight)
+    let height = this.calculateListHeight(items);
     let limitLines = config.get<number>('limitLines', 30000)
     let curr = this.items[this.index]
     this.items = items.slice(0, limitLines)
@@ -352,6 +350,16 @@ export default class ListUI {
     await this.setLines(append.map(item => item.label), curr > 0, this.currIndex)
   }
 
+  private calculateListHeight(items: ListItem[]): number {
+    let { config } = this
+    let maxHeight = config.get<number>('maxHeight', 10)
+    let minHeight = config.get<number>('minHeight', 1)
+    let height = Math.min(Math.max(minHeight, items.length), maxHeight)
+    this.height = Math.max(1, height)
+
+    return this.height
+  }
+
   private async setLines(lines: string[], append = false, index: number): Promise<void> {
     let { nvim, bufnr, window, config } = this
     if (!bufnr || !window) return
@@ -363,10 +371,7 @@ export default class ListUI {
       nvim.call('clearmatches', [], true)
     }
     if (resize) {
-      let maxHeight = config.get<number>('maxHeight', 10)
-      let minHeight = config.get<number>('minHeight', 1)
-      let height = Math.min(Math.max(minHeight, this.items.length), maxHeight)
-      this.height = height
+      let height = this.calculateListHeight(this.items);
       nvim.call('coc#list#set_height', [height], true)
     }
     if (!append) {

--- a/src/list/ui.ts
+++ b/src/list/ui.ts
@@ -311,8 +311,9 @@ export default class ListUI {
   public async drawItems(items: ListItem[], name: string, listOptions: ListOptions, reload = false): Promise<void> {
     let { bufnr, config, nvim } = this
     this.newTab = listOptions.position == 'tab'
-    let maxHeight = config.get<number>('maxHeight', 12)
-    let height = Math.max(1, Math.min(items.length, maxHeight))
+    let maxHeight = config.get<number>('maxHeight', 10)
+    let minHeight = config.get<number>('minHeight', 1)
+    let height = Math.min(Math.max(minHeight, items.length), maxHeight)
     let limitLines = config.get<number>('limitLines', 30000)
     let curr = this.items[this.index]
     this.items = items.slice(0, limitLines)
@@ -362,8 +363,9 @@ export default class ListUI {
       nvim.call('clearmatches', [], true)
     }
     if (resize) {
-      let maxHeight = config.get<number>('maxHeight', 12)
-      let height = Math.max(1, Math.min(this.items.length, maxHeight))
+      let maxHeight = config.get<number>('maxHeight', 10)
+      let minHeight = config.get<number>('minHeight', 1)
+      let height = Math.min(Math.max(minHeight, this.items.length), maxHeight)
       this.height = height
       nvim.call('coc#list#set_height', [height], true)
     }


### PR DESCRIPTION
This adds a function called calculate height to the list ui.
It adds a config option in schema.json for minimum height.
It changes the default value, if not in config, for maxHeight to match default given in schema.json

I did not see any tests on the UI portion, but if I missed that and you want tests for this, I will add them.