### PR TITLE
feat(env): allow nodejs path to be set by the environment

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -325,7 +325,7 @@ function! coc#util#job_command()
   if (has_key(g:, 'coc_node_path'))
     let node = expand(g:coc_node_path)
   else
-    let node = 'node'
+    let node = $COC_NODE_PATH == '' ? 'node' : $COC_NODE_PATH
   endif
   if !executable(node)
     echohl Error | echom '[coc.nvim] "'.node.'" is not executable, checkout https://nodejs.org/en/download/' | echohl None

--- a/autoload/health/coc.vim
+++ b/autoload/health/coc.vim
@@ -6,7 +6,7 @@ function! s:checkEnvironment() abort
     let valid = 0
     call health#report_error('Neovim version not satisfied, 0.3.0 and above required')
   endif
-  let node = get(g:, 'coc_node_path', 'node')
+  let node = get(g:, 'coc_node_path', $COC_NODE_PATH == '' ? 'node' : $COC_NODE_PATH)
   if !executable(node)
     let valid = 0
     call health#report_error('Executable node.js not found, install node.js from http://nodejs.org/')

--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -360,7 +360,7 @@ function! s:ShowInfo()
   else
     let lines = []
     echomsg 'coc.nvim service not started, checking environment...'
-    let node = get(g:, 'coc_node_path', 'node')
+    let node = get(g:, 'coc_node_path', $COC_NODE_PATH == '' ? 'node' : $COC_NODE_PATH)
     if !executable(node)
       call add(lines, 'Error: '.node.' is not executable!')
     else


### PR DESCRIPTION
Pretty straight forward amendment here to allow node's path to be set via an environment variable.  One use case, of many, is when it is desirable to spin up a new work environment with neovim + coc.  coc's node path dependency can now be preconfigured without parsing / writing configuration files.  This code change allows one to still override the env variable with `g:coc_node_path` and as a last fallback still use `node`.