### PR TITLE
fix(workspace): Auto jump to first location

### DIFF
--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -705,6 +705,7 @@ export class Workspace implements IWorkspace {
     if (preferences.get<boolean>('useQuickfixForLocations', false)) {
       await nvim.call('setqflist', [items])
       nvim.command('copen', true)
+      nvim.command('cfirst', true)
     } else {
       await nvim.setVar('coc_jump_locations', items)
       if (this.env.locationlist) {


### PR DESCRIPTION
If there is only one result available then it's auto-jumping to location, but not when there are multiple ones. This fixes it.