### PR TITLE
add document.jumpToPrevSymbol command

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -235,6 +235,30 @@ export class CommandManager implements Disposable {
         await workspace.moveTo(ranges[0].start)
       }
     }, false, 'Jump to next symbol highlight position.')
+    this.register({
+      id: 'document.jumpToPrevSymbol',
+      execute: async () => {
+        let doc = await workspace.document
+        if (!doc) return
+        let ranges = await plugin.cocAction('symbolRanges') as Range[]
+        if (!ranges) return
+        let { textDocument } = doc
+        let offset = await workspace.getOffset()
+        ranges.sort((a, b) => {
+          if (a.start.line != b.start.line) {
+            return a.start.line - b.start.line
+          }
+          return a.start.character - b.start.character
+        })
+        for (let i = ranges.length - 1; i >= 0; i--) {
+          if (textDocument.offsetAt(ranges[i].end) < offset) {
+            await workspace.moveTo(ranges[i].start)
+            return
+          }
+        }
+        await workspace.moveTo(ranges[ranges.length - 1].start)
+      }
+    }, false, 'Jump to previous symbol highlight position.')
   }
 
   public get commandList(): CommandItem[] {


### PR DESCRIPTION
This command would be the equivalent of  Shift+F7 in VSCode.
And the opposite of document.jumpToNextSymbol.
Please see #1290