### PR TITLE
fix: when insertText is empty

### DIFF
--- a/src/languages.ts
+++ b/src/languages.ts
@@ -617,7 +617,7 @@ class Languages {
         let item = completeItems[vimItem.index]
         if (!item) return
         let line = opt.linenr - 1
-        if (item.insertText && !item.textEdit) {
+        if (item.insertText !== undefined && !item.textEdit) {
           item.textEdit = {
             range: Range.create(line, opt.col, line, opt.colnr - 1),
             newText: item.insertText


### PR DESCRIPTION
Coc should remove the candidate when insertText is empty.

https://github.com/fannheyward/coc-docthis/blob/ecadbce31ec5ea673e5627df7ef07ac2178ad4ce/src/index.ts#L41