### PR TITLE
FIX(completion): Add language ids to client name 

### DIFF
--- a/src/language-client/client.ts
+++ b/src/language-client/client.ts
@@ -1882,7 +1882,7 @@ class CompletionItemFeature extends TextDocumentFeature<CompletionOptions, Compl
 
     const languageIds = cv.asLanguageIds(options.documentSelector!)
     const disposable = languages.registerCompletionItemProvider(
-      this._client.id,
+      this._client.id + `(${languageIds})`,
       'LS',
       languageIds,
       provider,


### PR DESCRIPTION
to prevent sources with the same name being created when a server registers more than one completion source.

closes #2138
closes vshaxe/vshaxe#447
closes vantreeseba/coc-haxe#5