### PR TITLE
Bugfix strengthen is document edit type guard

### DIFF
--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -8,7 +8,7 @@ import { BufferOption, ChangeInfo, DidChangeTextDocumentParams, Env } from '../t
 import { distinct, group } from '../util/array'
 import { diffLines, getChange } from '../util/diff'
 import { isGitIgnored } from '../util/fs'
-import { disposeAll, getUri } from '../util/index'
+import { disposeAll, getUri, isTextEdit } from '../util/index'
 import { comparePosition } from '../util/position'
 import { byteIndex, byteLength, byteSlice } from '../util/string'
 import { Chars } from './chars'
@@ -295,6 +295,7 @@ export default class Document {
       edits = arguments[1]
     }
     if (edits.length == 0) return
+    edits = edits.filter(isTextEdit)
     edits.forEach(edit => {
       edit.newText = edit.newText.replace(/\r/g, '')
     })

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -3,7 +3,7 @@ import debounce from 'debounce'
 import fs from 'fs'
 import isuri from 'isuri'
 import path from 'path'
-import { Disposable, TextDocumentIdentifier } from 'vscode-languageserver-protocol'
+import { Disposable, TextEdit, TextDocumentIdentifier, TextDocumentEdit, Range, Position } from 'vscode-languageserver-protocol'
 import { URI } from 'vscode-uri'
 import which from 'which'
 import { MapMode } from '../types'
@@ -115,10 +115,31 @@ export function getKeymapModifier(mode: MapMode): string {
 }
 
 // consider textDocument without version to be valid
-export function isDocumentEdit(edit: any): boolean {
+export function isDocumentEdit(edit: any): edit is TextDocumentEdit {
   if (edit == null) return false
   if (!TextDocumentIdentifier.is(edit.textDocument)) return false
   if (!Array.isArray(edit.edits)) return false
+  if (edit.edits.some(edit => !isTextEdit(edit))) return false
+  return true
+}
+
+export function isTextEdit(edit: any): edit is TextEdit {
+  if (typeof edit !== 'object' || edit === null) return false
+  if (typeof edit.newText !== 'string') return false
+  if (!isRange(edit.range)) return false
+  return true
+}
+
+export function isRange(range: any): range is Range {
+  if (typeof range !== 'object') return false
+  if (!isPosition(range.start) || !isPosition(range.end)) return false
+  return true
+}
+
+export function isPosition(position: any): position is Position {
+  if (typeof position !== 'object') return false
+  if (typeof position.line !== 'number') return false
+  if (typeof position.character !== 'number') return false
   return true
 }
 

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -519,7 +519,7 @@ export class Workspace implements IWorkspace {
         let changedMap: Map<string, string> = new Map()
         for (let change of documentChanges) {
           if (isDocumentEdit(change)) {
-            let { textDocument, edits } = change as TextDocumentEdit
+            let { textDocument, edits } = change
             if (URI.parse(textDocument.uri).toString() == uri) currEdits = edits
             let doc = await this.loadFile(textDocument.uri)
             await doc.applyEdits(edits)
@@ -1492,7 +1492,7 @@ augroup end`
     let newUris: Set<string> = new Set()
     for (let change of documentChanges) {
       if (isDocumentEdit(change)) {
-        let { textDocument } = change as TextDocumentEdit
+        let { textDocument } = change
         let { uri, version } = textDocument
         if (!newUris.has(uri)) {
           uris.add(uri)


### PR DESCRIPTION
### Disclaimer

- I'm not aware of the performance impacts this could have. This is just an exploratory PR to fix a bug.
- Some tests fail locally with or without my changes, so I refrained from editing the test suite. I need some guidance on this.

### Context

I was trying to run my binding on a Svelte file:

`command! -nargs=0 Prettier :call CocAction('runCommand', 'prettier.formatFile')`

And I was getting this `Cannot find name 'replace' of undefined` error. After setting up the runtime path to my local coc.nvim installation, I found out it's because of a naïve check from `isDocumentEdit`. The `TextEdit`s inside it are asserted by `as TextDocumentEdit` as all having a `.newText` string field, but some were `undefined`.

This pull request does three things:

- Strenghtens `isDocumentEdit` checks by checking nested fields
- Removes unnecessary `as TextDocumentEdit` assertions
- Fix applying edits with `TextEdit`s that were missing `.newText`

After these commits, the message from coc.nvim became `[coc.nvim] svelte not supported by prettier`. It's better than `Cannot find name 'replace' of undefined`.

Thanks for the awesome software, it's changed my vim productivity for the better!
