### PR TITLE
docs: Fixing wrong word for hint in docs

### DIFF
--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -429,7 +429,7 @@ Built-in configurations:~
 
 "diagnostic.hintSign":~
 
-	Sign of info diagnostics shown in the 'signcolumn', default: `">>"`
+	Sign of hint diagnostics shown in the 'signcolumn', default: `">>"`
 
 "diagnostic.maxWindowHeight":~
 


### PR DESCRIPTION
Should say `hint diagnostics` instead of `info diagnostics`. Fairly small fix.