### PR TITLE
feat(extensions): add extensionUpdateBuffer config

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -851,6 +851,11 @@
       "description": "Interval for check extension update, could be daily, weekly, never",
       "enum": ["daily", "weekly", "never"]
     },
+    "coc.preferences.extensionUpdateBuffer": {
+      "type": "boolean",
+      "default": true,
+      "description": "Split a buffer to show extensions update messages"
+    },
     "coc.preferences.snippetStatusText": {
       "type": "string",
       "default": "SNIP",

--- a/data/schema.json
+++ b/data/schema.json
@@ -854,7 +854,7 @@
     "coc.preferences.extensionUpdateBuffer": {
       "type": "boolean",
       "default": true,
-      "description": "Split a buffer to show extensions update messages"
+      "description": "Split a buffer to show extensions update logs, otherwise using messages"
     },
     "coc.preferences.snippetStatusText": {
       "type": "string",


### PR DESCRIPTION
~Prefer to use `messages`, not status line, we can use `:messages` to view full logs.~

Statusline shows progress message, `messages` shows error/updated result.

close #2171