### PR TITLE
fix(plugin): fix copy log filepath

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -112,7 +112,7 @@ export default class Plugin extends EventEmitter {
       try {
         await clipboardy.write(file)
       } catch (e) {
-        await nvim.command(`let @*='${file.replace(/'/g, "''")}'`)
+        await nvim.call('setreg', ['"', file])
       }
       let level = process.env.NVIM_COC_LOG_LEVEL || 'info'
       workspace.showMessage(`Copied filepath to clipboard, current log level: ${level}`, 'more')


### PR DESCRIPTION
Registers `"*` and `"+` not working when without X11, and `setreg('*', ...)` always return 0, so we have no way to use unnamed register as a fallback plan for `"*`.

```viml
let @*='test'
```
![image](https://user-images.githubusercontent.com/1709861/88390081-4a407100-cdea-11ea-936f-f8422cc7aa96.png)

```viml
echo setreg('*', 'test')
```
![image](https://user-images.githubusercontent.com/1709861/88390144-63e1b880-cdea-11ea-88dc-2953343fcbdf.png)
