### PR TITLE
feat(language-client): support config formatterPriority

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -40,6 +40,11 @@
           "default": false,
           "description": "Disable completion feature for this languageserver."
         },
+        "formatterPriority": {
+          "type": "number",
+          "default": 0,
+          "description": "Priority of this languageserver's fomatter."
+        },
         "env": {
           "type": "object",
           "default": null,
@@ -136,6 +141,7 @@
         "disableDynamicRegister": {},
         "disableDiagnostics": {},
         "disableCompletion": {},
+        "formatterPriority": {},
         "enable": {},
         "rootPatterns": {},
         "requireRootPattern": {},
@@ -200,6 +206,7 @@
         "disableSnippetCompletion": {},
         "disableDiagnostics": {},
         "disableCompletion": {},
+        "formatterPriority": {},
         "rootPatterns": {},
         "requireRootPattern": {},
         "ignoredRootPaths": {},
@@ -250,6 +257,7 @@
         "disableSnippetCompletion": {},
         "disableDiagnostics": {},
         "disableCompletion": {},
+        "formatterPriority": {},
         "rootPatterns": {},
         "requireRootPattern": {},
         "ignoredRootPaths": {},

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -790,6 +790,8 @@ Built-in configurations:~
 	- "disableCompletion": Disable completion feature for this
 	  languageserver.
 
+	- "formatterPriority": Priority of this languageserver's fomatter.
+
 	- "revealOutputChannelOn": Configure message level to show the output
 	  channel buffer.
 

--- a/src/language-client/client.ts
+++ b/src/language-client/client.ts
@@ -691,6 +691,7 @@ export interface LanguageClientOptions {
   disableSnippetCompletion?: boolean
   disableDiagnostics?: boolean
   disableCompletion?: boolean
+  formatterPriority?: number
   outputChannelName?: string
   outputChannel?: OutputChannel
   revealOutputChannelOn?: RevealOutputChannelOn
@@ -714,6 +715,7 @@ interface ResolvedClientOptions {
   disableDynamicRegister: boolean
   disableDiagnostics: boolean
   disableCompletion: boolean
+  formatterPriority: number
   documentSelector?: DocumentSelector
   synchronize: SynchronizeOptions
   diagnosticCollectionName?: string
@@ -2517,7 +2519,10 @@ class DocumentFormattingFeature extends TextDocumentFeature<
       }
     }
 
-    return [languages.registerDocumentFormatProvider(options.documentSelector!, provider), provider]
+    return [
+      languages.registerDocumentFormatProvider(options.documentSelector!, provider, this._client.clientOptions.formatterPriority),
+      provider
+    ]
   }
 }
 
@@ -3077,6 +3082,7 @@ export abstract class BaseLanguageClient {
       disableDynamicRegister: clientOptions.disableDynamicRegister,
       disableDiagnostics: clientOptions.disableDiagnostics,
       disableCompletion: clientOptions.disableCompletion,
+      formatterPriority: clientOptions.formatterPriority,
       ignoredRootPaths: clientOptions.ignoredRootPaths,
       documentSelector: clientOptions.documentSelector || [],
       synchronize: clientOptions.synchronize || {},

--- a/src/services.ts
+++ b/src/services.ts
@@ -401,6 +401,7 @@ export function getLanguageServerOptions(id: string, name: string, config: Langu
     disableDynamicRegister: !!config.disableDynamicRegister,
     disableCompletion: !!config.disableCompletion,
     disableDiagnostics: !!config.disableDiagnostics,
+    formatterPriority: config.formatterPriority || 0,
     documentSelector: getDocumentSelector(config.filetypes, config.additionalSchemes),
     revealOutputChannelOn: getRevealOutputChannelOn(config.revealOutputChannelOn),
     synchronize: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -367,6 +367,7 @@ export interface LanguageServerConfig {
   disableDynamicRegister?: boolean
   disableCompletion?: boolean
   disableDiagnostics?: boolean
+  formatterPriority?: number
   filetypes: string[]
   additionalSchemes: string[]
   enable?: boolean


### PR DESCRIPTION
Continue of #280

Motivation: I want my custom language server have higher format priority than the coc-tsserer