### PR TITLE
perf(autocmd): remove calls to get() for 15% faster autcmd

### DIFF
--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -47,6 +47,7 @@ endfunction
 call s:checkVersion()
 
 let g:did_coc_loaded = 1
+let g:coc_workspace_initialized = 0
 let g:coc_service_initialized = 0
 let s:is_win = has('win32') || has('win64')
 let s:root = expand('<sfile>:h:h')
@@ -210,17 +211,17 @@ function! s:Disable() abort
 endfunction
 
 function! s:Autocmd(...) abort
-  if !get(g:,'coc_workspace_initialized', 0)
+  if !g:coc_workspace_initialized
     return
   endif
   call coc#rpc#notify('CocAutocmd', a:000)
 endfunction
 
 function! s:SyncAutocmd(...)
-  if !get(g:,'coc_workspace_initialized', 0)
+  if !g:coc_workspace_initialized
     return
   endif
-  if get(g:, 'coc_service_initialized', 0)
+  if g:coc_service_initialized
     call coc#rpc#request('CocAutocmd', a:000)
   else
     call coc#rpc#notify('CocAutocmd', a:000)


### PR DESCRIPTION
It shows on CursorMoved autocmd especially, here are profiling results:
- 1295   0.918150   0.122849  <SNR>40_Autocmd() (before)
- 1289   0.821687   0.092443  <SNR>40_Autocmd() (after)

It aint much, but it's honest work.