### PR TITLE
Allow structs when filtering current function symbol

### DIFF
--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -276,6 +276,7 @@ export default class Handler {
       'Class',
       'Method',
       'Function',
+      'Struct',
     ].includes(s.kind))
     let functionName = ''
     for (let sym of symbols.reverse()) {


### PR DESCRIPTION
Closes #2266.

Simply adds the kind 'Struct' to the list of kinds to filter by when obtaining the current function symbol. Structs are the same thing as classes in C++, so they should be recognized here along with the 'Class' kind.