### PR TITLE
feat: add CocAction('listLoadItems', 'list_name')

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -37,6 +37,7 @@ export default class Plugin extends EventEmitter {
     this.addAction('hasSelected', () => completion.hasSelected())
     this.addAction('listNames', () => listManager.names)
     this.addAction('listDescriptions', () => listManager.descriptions)
+    this.addAction('listLoadItems', async (name: string) => await listManager.loadItems(name))
     this.addAction('search', (...args: string[]) => this.handler.search(args))
     this.addAction('cursorsSelect', (bufnr: number, kind: string, mode: string) => this.cursors.select(bufnr, kind, mode))
     this.addAction('codeActionRange', (start, end, only) => this.handler.codeActionRange(start, end, only))


### PR DESCRIPTION
Retrieve list info to process it using FZF for instance.
Avoids having 1 CocAction per list (e.g.: commandList, diagnosticList etc)

This is a POC, please let me know if anything needs to be changed.
This would help me support way more lists in coc-fzf :smiley: 