### PR TITLE
fix: diagnostic sign doesn't disappear

### DIFF
--- a/src/__tests__/modules/diagnosticBuffer.test.ts
+++ b/src/__tests__/modules/diagnosticBuffer.test.ts
@@ -77,7 +77,7 @@ describe('diagnostic buffer', () => {
     let buf = await createDiagnosticBuffer()
     buf.addSigns(diagnostics)
     await helper.wait(30)
-    let content = await nvim.call('execute', [`sign place buffer=${buf.bufnr}`])
+    let content = await nvim.call('execute', [`sign place group=* buffer=${buf.bufnr}`])
     let lines: string[] = content.split('\n')
     let line = lines.find(s => s.includes('CocError'))
     expect(line).toBeDefined()


### PR DESCRIPTION
fixes #131

The issue #131 had been fixed before by calling checkSigns on write with commit b300aea2cca22a9c9271ab5569b85b435327b808
But this fix had been reverted after commit c83813f73007d00d5590495d8d6420ad3ded632d

This commit tries to fix the issue in a different way: using sign group.