### PR TITLE
<nomodeline> for User autocmds

### DIFF
--- a/autoload/coc/terminal.vim
+++ b/autoload/coc/terminal.vim
@@ -14,7 +14,7 @@ function! coc#terminal#start(cmd, cwd, env) abort
   setl nonumber
   setl bufhidden=hide
   if exists('#User#CocTerminalOpen')
-    exe 'doautocmd User CocTerminalOpen'
+    exe 'doautocmd <nomodeline> User CocTerminalOpen'
   endif
   let bufnr = bufnr('%')
   let env = {}

--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -978,7 +978,7 @@ endfunction
 
 function! coc#util#do_autocmd(name) abort
   if exists('#User#'.a:name)
-    exe 'doautocmd User '.a:name
+    exe 'doautocmd <nomodeline> User '.a:name
   endif
 endfunction
 

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -719,7 +719,7 @@ export class Workspace implements IWorkspace {
       if (this.env.locationlist) {
         nvim.command('CocList --normal --auto-preview location', true)
       } else {
-        nvim.command('doautocmd User CocLocationsChange', true)
+        nvim.command('doautocmd <nomodeline> User CocLocationsChange', true)
       }
     }
   }


### PR DESCRIPTION
Whenever Coc does `doautocmd` vim triggers processing of modelines. This might be quite annoying if the modeline includes something like `foldlevel=0`. I believe most of Coc's user autocmds do not need to trigger modelines processing. In such cases, [`:h <nomodeline>`](https://neovim.io/doc/user/autocmd.html#%3Cnomodeline%3E) can be used.

I left out this one since it is probably correct to process modelines in this case.
https://github.com/neoclide/coc.nvim/blob/c8d43d990593e2184da1dcb55870faa19082415e/autoload/coc/util.vim#L1180

ref #452