### PR TITLE
zN<CR> only if preview window is a horizontal split

### DIFF
--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -236,7 +236,7 @@ export default class Handler {
         nvim.command('setlocal conceallevel=2 nospell nofoldenable wrap', true)
         nvim.command('setlocal bufhidden=wipe nobuflisted', true)
         nvim.command('setfiletype markdown', true)
-        nvim.command(`exe "normal! z${Math.min(this.documentLines.length, this.preferences.previewMaxHeight)}\\<cr>"`, true)
+        nvim.command(`if winnr('j') != winnr('k') | exe "normal! z${Math.min(this.documentLines.length, this.preferences.previewMaxHeight)}\\<cr> | endif"`, true)
         await nvim.resumeNotification()
         return this.documentLines.join('\n')
       }


### PR DESCRIPTION
When using "coc.preferences.hoverTarget": "preview", coc sets the preview window height with `zN<CR>`. The problem is that it reduces the height of the window even if there is no window adjacent to the top/bottom current window, which is undesirable. Therefore, it first need to check that there is a adjacent window.

For example this is what you'll get if you move the preview window to the right size and then do hover.
![image](https://user-images.githubusercontent.com/19489738/92277675-704f4a00-ef2e-11ea-9e7e-5b2eb032d648.png)

