### PR TITLE
Add link to my detailed article on coc extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,8 +250,8 @@ nnoremap <silent><nowait> <space>p  :<C-u>CocListResume<CR>
 
 - [coc.nvim 插件体系介绍](https://zhuanlan.zhihu.com/p/65524706)
 - [CocList 入坑指南](https://zhuanlan.zhihu.com/p/71846145)
-- [Create coc.nvim extension to improve Vim
-  experience](https://medium.com/@chemzqm/create-coc-nvim-extension-to-improve-vim-experience-4461df269173)
+- [Create coc.nvim extension to improve Vim experience](https://medium.com/@chemzqm/create-coc-nvim-extension-to-improve-vim-experience-4461df269173)
+- [How to write a coc.nvim extension (and why)](https://samroeca.com/coc-plugin.html)
 
 ## Trouble shooting
 


### PR DESCRIPTION
I wrote this article because I struggled a bit writing my first coc
extension to wrap an executable language server. The article provides
both the reason and the method to write a coc.nvim extension.
Additionally, it goes over why coc.nvim is different from other nvim LSP
clients and how it relates to vscode. My hope is that it makes it easier
for other developers to write coc extensions so that we get more of
them.