### PR TITLE
fix: cwd DirChanged on vim

### DIFF
--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -251,7 +251,7 @@ function! s:Enable(initialize)
     endif
     if s:is_vim
       if exists('##DirChanged')
-        autocmd DirChanged        * call s:Autocmd('DirChanged', expand('<afile>'))
+        autocmd DirChanged        * call s:Autocmd('DirChanged', getcwd())
       endif
       if exists('##TerminalOpen')
         autocmd TerminalOpen      * call s:Autocmd('TermOpen', +expand('<abuf>'))


### PR DESCRIPTION
<afile> in DidChanged is not always correct.

fix weirongxu/coc-explorer#267

1. vimrc:
```vim
set nocompatible

autocmd DirChanged * echom expand('<afile>')
autocmd VimEnter * chdir /home/raidou

filetype plugin indent on
syntax on
set hidden
```

2. Open vim from `/` root directory:
```
cd /
vim -u path/to/vimrc
```

3. cd to subdirectory inside the `/home/raidou`
```vim
:cd repos/
```

Vim will print `repos/`
