### PR TITLE
Show diagnostic message only if <Plug>(coc-diagnostic-next/prev) pressed

### DIFF
--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -162,7 +162,9 @@ export class DiagnosticManager implements Disposable {
     buf = new DiagnosticBuffer(bufnr, doc.uri, this.config)
     this.buffers.set(bufnr, buf)
     buf.onDidRefresh(() => {
-      if (this.config.enableMessage == 'never') return
+      if (['never', 'jump'].includes(this.config.enableMessage)) {
+        return;
+      }
       this.echoMessage(true).logError()
     })
   }

--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -163,7 +163,7 @@ export class DiagnosticManager implements Disposable {
     this.buffers.set(bufnr, buf)
     buf.onDidRefresh(() => {
       if (['never', 'jump'].includes(this.config.enableMessage)) {
-        return;
+        return
       }
       this.echoMessage(true).logError()
     })


### PR DESCRIPTION
Before this, diagnostic message will be popup after switching buffers even if I didn't press `<Plug>(coc-diagnostic-next/prev)`.