### PR TITLE
feat(util): support getting size for unnamed buffers

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -462,7 +462,7 @@ function! coc#util#get_bufoptions(bufnr) abort
   endif
   return {
         \ 'bufname': bufname,
-        \ 'size': buftype ==# '' ? getfsize(bufname) : -1,
+        \ 'size': buftype ==# '' ? (bufname != '' ? getfsize(bufname) : line2byte(line("$") + 1)) : -1,
         \ 'eol': getbufvar(a:bufnr, '&eol'),
         \ 'buftype': buftype,
         \ 'winid': winid,


### PR DESCRIPTION
With this patch, large unnamed buffers no longer hangs if
`maxFileSize` is correctly configured.

Inspired by https://coderwall.com/p/ussjrg/vim-get-buffer-byte-size