### PR TITLE
fix single option completion

### DIFF
--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -882,15 +882,15 @@ Example key-mappings:~
 
 Map <tab> to trigger completion and navigate to the next item: >
 
-    function! s:check_back_space() abort
-      let col = col('.') - 1
-      return !col || getline('.')[col - 1]  =~ '\s'
-    endfunction
+	function! s:check_back_space() abort
+	  let col = col('.') - 1
+	  return !col || getline('.')[col - 1]  =~ '\s'
+	endfunction
 
-    inoremap <silent><expr> <TAB>
-		  \ pumvisible() ? "\<C-n>" :
-		  \ <SID>check_back_space() ? "\<TAB>" :
-		  \ coc#refresh()
+	inoremap <silent><expr> <TAB>
+	  \ pumvisible() ? "\<C-n>" :
+	  \ <SID>check_back_space() ? "\<TAB>" :
+	  \ coc#refresh()
 
 
 Map <c-space> to trigger completion: >
@@ -899,18 +899,21 @@ Map <c-space> to trigger completion: >
 <
 <CR> to confirm completion, use: >
 
-	inoremap <expr> <cr> pumvisible() ? "\<C-y>" : "\<CR>"
+	inoremap <expr> <CR> pumvisible() ? "\<C-y>" : "\<CR>"
 <
 To make <CR> auto-select the first completion item and notify coc.nvim to
 format on enter, use: >
 
-	inoremap <silent><expr> <cr> pumvisible() ? coc#_select_confirm()
-				\: "\<C-g>u\<CR>\<c-r>=coc#on_enter()\<CR>"
+	inoremap <silent><expr> <CR>
+	  \ len(complete_info()["items"]) == 1 ? "\<C-y>" :
+	  \ pumvisible() ? coc#_select_confirm() :
+	  \ "\<C-g>u\<CR>\<c-r>=coc#on_enter()\<CR>"
 
 Map <tab> for trigger completion, completion confirm, snippet expand and jump
 like VSCode. >
 
 	inoremap <silent><expr> <TAB>
+	  \ len(complete_info()["items"]) == 1 ? "\<C-y>" :
 	  \ pumvisible() ? coc#_select_confirm() :
 	  \ coc#expandableOrJumpable() ?
 	  \ "\<C-r>=coc#rpc#request('doKeymap', ['snippets-expand-jump',''])\<CR>" :


### PR DESCRIPTION
When using the mappings from [line 907](https://github.com/neoclide/coc.nvim/blob/f176d09dc9d9430efd550a440f623c1a064fc80e/doc/coc.txt#L907) and [line 913](https://github.com/neoclide/coc.nvim/blob/f176d09dc9d9430efd550a440f623c1a064fc80e/doc/coc.txt#L913) in  [docs/coc.txt](https://github.com/neoclide/coc.nvim/blob/master/doc/coc.txt),
pressing `TAB` and `ENTER` did not confirm completion whenever there was only one completion option.
Adding 
```vim
\ len(complete_info()["items"]) == 1 ? "\<C-y>" :
```
to each mapping fixes this problem in both vim and neovim.

This pull request only fixes the two mappings on [line 907](https://github.com/neoclide/coc.nvim/blob/f176d09dc9d9430efd550a440f623c1a064fc80e/doc/coc.txt#L907) and [line 913](https://github.com/neoclide/coc.nvim/blob/f176d09dc9d9430efd550a440f623c1a064fc80e/doc/coc.txt#L913) in  [docs/coc.txt](https://github.com/neoclide/coc.nvim/blob/master/doc/coc.txt), but it might be a good idea to change the behavior of `coc#_select_confirm()` if this problem is not specific to these two mappings. 

<details><summary>Click here to see the <code>TAB</code> and <code>ENTER</code> mappings I am currently using.</summary>

```vim
inoremap <silent><expr> <TAB>
  \ len(complete_info()["items"]) == 1 ? "\<C-y>" :
  \ pumvisible() ? coc#_select_confirm() :
  \ coc#expandableOrJumpable() ? "\<C-r>=coc#rpc#request('doKeymap', ['snippets-expand-jump',''])\<CR>" :
  \ <SID>check_back_space() ? "\<TAB>" :
  \ coc#refresh()

inoremap <silent><expr> <CR>
  \ len(complete_info()["items"]) == 1 ? "\<C-y>" :
  \ pumvisible() ? coc#_select_confirm() :
  \ coc#expandableOrJumpable() ? "\<C-r>=coc#rpc#request('doKeymap', ['snippets-expand-jump',''])\<CR>" :
  \ <SID>check_back_space() ? "\<CR>" :
  \ "\<CR>"

function! s:check_back_space() abort
  let col = col('.') - 1
  return !col || getline('.')[col - 1]  =~# '\s'
endfunction
```
</details>