### PR TITLE
Add insert mode float scrolling function

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -103,6 +103,44 @@ function! coc#util#float_scroll(forward)
   return ""
 endfunction
 
+" scroll float without exiting insert mode (nvim only)
+function! coc#util#float_scroll_i(amount)
+  let float = coc#util#get_float()
+  if !float | return '' | endif
+  let buf = nvim_win_get_buf(float)
+  let buf_height = nvim_buf_line_count(buf)
+  let win_height = nvim_win_get_height(float)
+  if buf_height < win_height | return '' | endif
+  let pos = nvim_win_get_cursor(float)
+  try
+    let last_amount = nvim_win_get_var(float, 'coc_float_scroll_last_amount')
+  catch
+    let last_amount = 0
+  endtry
+  if a:amount > 0
+    if pos[0] == 1
+      let pos[0] += a:amount + win_height - 2
+    elseif last_amount > 0
+      let pos[0] += a:amount
+    else
+      let pos[0] += a:amount + win_height - 3
+    endif
+    let pos[0] = pos[0] < buf_height ? pos[0] : buf_height
+  elseif a:amount < 0
+    if pos[0] == buf_height
+      let pos[0] += a:amount - win_height + 2
+    elseif last_amount < 0
+      let pos[0] += a:amount
+    else
+      let pos[0] += a:amount - win_height + 3
+    endif
+    let pos[0] = pos[0] > 1 ? pos[0] : 1
+  endif
+  call nvim_win_set_var(float, 'coc_float_scroll_last_amount', a:amount)
+  call nvim_win_set_cursor(float, pos)
+  return ''
+endfunction
+
 " get cursor position
 function! coc#util#cursor()
   let pos = getcurpos()


### PR DESCRIPTION
`coc#util#float_scroll_i(amount)` allows scrolling floating windows in NeoVim
without exiting insert mode, by a given `amount` of lines.

Example usage:

```vim
let g:coc_snippet_next = '<c-l>'
let g:coc_snippet_prev = '<c-h>'
inoremap <silent><expr> <c-j> coc#util#has_float() ? coc#util#float_scroll_i( 1) : "\<c-j>"
inoremap <silent><expr> <c-k> coc#util#has_float() ? coc#util#float_scroll_i(-1) : "\<c-k>"
vnoremap <silent><expr> <c-j> coc#util#has_float() ? coc#util#float_scroll_i( 1) : "\<c-j>"
vnoremap <silent><expr> <c-k> coc#util#has_float() ? coc#util#float_scroll_i(-1) : "\<c-k>"
```

With this configuration one can scroll with `<c-j>`/`<c-k>` (vertical keys) and
jump snippet placeholders with `<c-l>`/`<c-h>` (horizontal keys).

Give it a try, it's quite useful! :)