### PR TITLE
http.proxyCA support 

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -289,6 +289,11 @@
       "description": "The value to send as the `Proxy-Authorization` header for every network request.",
       "default": null
     },
+    "http.proxyCA": {
+      "type": "string",
+      "description": "CA (file) to use as Certificate Authority",
+      "default": null
+    },
     "npm.binPath": {
       "type": "string",
       "default": "npm",

--- a/src/model/fetch.ts
+++ b/src/model/fetch.ts
@@ -1,6 +1,7 @@
 import { http, https } from 'follow-redirects'
 import { Readable } from 'stream'
 import { parse, UrlWithStringQuery } from 'url'
+import fs from 'fs'
 import zlib from 'zlib'
 import { objectLiteral } from '../util/is'
 import workspace from '../workspace'

--- a/src/model/fetch.ts
+++ b/src/model/fetch.ts
@@ -18,6 +18,7 @@ export interface ProxyOptions {
   proxyUrl: string
   strictSSL?: boolean
   proxyAuthorization?: string | null
+  proxyCA?: string | null
 }
 
 function getSystemProxyURI(endpoint: UrlWithStringQuery): string {

--- a/src/model/fetch.ts
+++ b/src/model/fetch.ts
@@ -83,7 +83,8 @@ export function resolveRequestOptions(url: string, options: FetchOptions = {}): 
   let proxyOptions: ProxyOptions = {
     proxyUrl: config.get<string>('proxy', ''),
     strictSSL: config.get<boolean>('proxyStrictSSL', true),
-    proxyAuthorization: config.get<string | null>('proxyAuthorization', null)
+    proxyAuthorization: config.get<string | null>('proxyAuthorization', null),
+    proxyCA: config.get<string | null>('proxyCA', null)
   }
   if (options.query && !url.includes('?')) {
     url = `${url}?${stringify(options.query)}`
@@ -103,6 +104,9 @@ export function resolveRequestOptions(url: string, options: FetchOptions = {}): 
       'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64)',
       'Accept-Encoding': 'gzip, deflate'
     }, headers)
+  }
+  if (proxyOptions.proxyCA) {
+     opts.ca = fs.readFileSync(proxyOptions.proxyCA)
   }
   if (dataType == 'object') {
     opts.headers['Content-Type'] = 'application/json'


### PR DESCRIPTION
Hi, 

I see that if you are using COC through a SSL-inspection proxy your only choice is to disable SSL verification with `http.proxyStrictSSL = false`,

This PR adds the support to read a certificate authority file, with the option `http.proxyCA = "filename"`which you can use to trust the certificates signed by the proxy.

best regards,
    
    Fredrik