### PR TITLE
fix: foldlevel doesn't work after processing fold

### DIFF
--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -766,12 +766,12 @@ export default class Handler {
     if (kind) ranges = ranges.filter(o => o.kind == kind)
     if (ranges.length) {
       this.nvim.pauseNotification()
-      win.setOption('foldenable', true, true)
       for (let range of ranges.reverse()) {
         let { startLine, endLine } = range
         let cmd = `${startLine + 1}, ${endLine + 1}fold`
         this.nvim.command(cmd, true)
       }
+      this.nvim.command('normal! zx', true)
       await this.nvim.resumeNotification()
       return true
     }


### PR DESCRIPTION
Use manual fold such as '<,'>fold will close this fold at first time,
although the current foldlevel is 99, we should use `zx` to re-apply
fold to make fold obey foldlevel.

BTW, zx seems that enable fold automatically, foldenable is unnecessary.