### PR TITLE
modified show_documentation function to do the default action of vim on pressing K when coc is not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,10 @@ nnoremap <silent> K :call <SID>show_documentation()<CR>
 function! s:show_documentation()
   if (index(['vim','help'], &filetype) >= 0)
     execute 'h '.expand('<cword>')
-  else
+  elseif (coc#rpc#ready())
     call CocActionAsync('doHover')
+  else
+    execute '!' . &keywordprg . " " . expand('<cword>')
   endif
 endfunction
 


### PR DESCRIPTION
modified show_documentation function so the default behaviour of K would not get overridden when coc#rpc is not available.

In the example vimrc configs in README.md, the default behaviour of K was overriden. This commit, first looks if the coc LSP process is started, if so, it does `call CocActionAsync('doHover')` as before but if no coc process is found, it does the default action of vim on pressing K button (which is normally opening up man page for the word under the cursor).
