### PR TITLE
fix(list): avoid `relativenumber`

### DIFF
--- a/autoload/coc/list.vim
+++ b/autoload/coc/list.vim
@@ -224,9 +224,11 @@ function! coc#list#create(position, height, name, numberSelect)
     execute 'resize '.a:height
   endif
   if a:numberSelect
+    setl norelativenumber
     setl number
   else
     setl nonumber
+    setl norelativenumber
     setl signcolumn=yes
   endif
   return [bufnr('%'), win_getid()]


### PR DESCRIPTION
When `relativenumber` is set in vimrc.

Execute `:Coclist --number-select`:
![image](https://user-images.githubusercontent.com/20282795/96102076-ae199800-0f08-11eb-9094-0f884b7a4a24.png)
Should be 
![image](https://user-images.githubusercontent.com/20282795/96102249-e4571780-0f08-11eb-84d0-078ddfb7997a.png)


Execute `:Coclist`:
![image](https://user-images.githubusercontent.com/20282795/96101976-95a97d80-0f08-11eb-8323-11dec5bcfe97.png)
Should be:
![image](https://user-images.githubusercontent.com/20282795/96102220-d99c8280-0f08-11eb-9bfb-a70805d6ea82.png)

