### PR TITLE
fix(float): fix wrong relative position between floatwin and border

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -311,15 +311,9 @@ function! coc#util#create_float_win(winid, bufnr, config) abort
     let config = coc#util#omit(a:config, ['title', 'border', 'cursorline'])
     let border = has_key(a:config, 'border')
     if border
-      if config['relative'] ==# 'cursor' && config['row'] < 0
-        " move top
-        let config['row'] = config['row'] - 1
-      else
-        " move down
-        let config['row'] = config['row'] + 1
-      endif
-      let config['width'] = config['width'] - 2
-      let config['col'] = config['col'] + 1
+      let config['row'] += 1
+      let config['width'] -= 2
+      let config['col'] += 1
       " create border window
     endif
     let bufnr = coc#util#create_float_buf(a:bufnr)


### PR DESCRIPTION
Because `anchor` field is not used in window config, the `row` of inner window should be always be larger than that of the outer window

This PR fixes the wrong relative position between those two windows when cursor is at the bottom of the editor screen. 
![image](https://user-images.githubusercontent.com/20282795/96218004-589bc480-0fb6-11eb-9bb0-e23e39178fc1.png)
and
![image](https://user-images.githubusercontent.com/20282795/96218246-f099ae00-0fb6-11eb-9deb-b28ae5b17f45.png)

