### PR TITLE
fix(handler): do not create swap file for preview window

### DIFF
--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -1132,7 +1132,7 @@ export default class Handler {
           p.push('```')
           return p
         }, [])
-        await this.nvim.command(`pedit coc://document`)
+        await this.nvim.command(`noswapfile pedit coc://document`)
       }
     }
     return true
@@ -1361,7 +1361,7 @@ export default class Handler {
     } else if (target == 'float') {
     } else {
       this.documentLines = lines
-      await this.nvim.command(`pedit coc://document`)
+      await this.nvim.command(`noswapfile pedit coc://document`)
     }
   }
 


### PR DESCRIPTION
When `"coc.preferences.hoverTarget": "preview"`, coc opens hover info in a preview window named `coc://document`.
However, that creates `document.swp` file in somewhere `&directory` indicates (typically in tmp directory), so when another instance of Vim opens hover info, the second Vim raises an error of "swap file already exists".
This fix prevents that by using `:noswapfile` when opening a preview window.