### PR TITLE
Fixed incorrect completion suggestions in TabNine

### DIFF
--- a/src/completion/complete.ts
+++ b/src/completion/complete.ts
@@ -191,7 +191,7 @@ export default class Complete {
         if (asciiCharactersOnly && !/^[\x00-\x7F]*$/.test(word)) {
           continue
         }
-        if ((!item.dup || source == 'tabnine') && words.has(word)) continue
+        if (source !== 'tabnine' && item.dup && words.has(word)) continue
         if (removeDuplicateItems && !item.isSnippet && words.has(word) && item.line == undefined) continue
         let filterText = item.filterText || item.word
         item.filterText = filterText


### PR DESCRIPTION
Fixed an issue where there were very few candidates for coc-tabnine completion.
A word in tabnine contains the same thing, so I think it's correct not to check dup if source is tabnine.
Is the existing implementation the intended one?

There are very few completion candidates for coc-tabnine, but with this change, the result is the same as VSCode.

VSCode:
![スクリーンショット 2020-10-20 17 43 03](https://user-images.githubusercontent.com/5423775/96572028-52378080-1307-11eb-95b1-06f0e0afbd0f.png)

Before:
![スクリーンショット 2020-10-20 17 42 51](https://user-images.githubusercontent.com/5423775/96572002-4b107280-1307-11eb-8ec0-fec41c32076f.png)

After:
![スクリーンショット 2020-10-20 17 53 17](https://user-images.githubusercontent.com/5423775/96572040-55327100-1307-11eb-9598-02c37e3680c7.png)
