### PR TITLE
popup: escape markdown syntax

### DIFF
--- a/autoload/coc.vim
+++ b/autoload/coc.vim
@@ -11,6 +11,40 @@ let s:warning_sign = get(g:, 'coc_status_warning_sign', has('mac') ? '⚠️ ' :
 let s:select_api = exists('*nvim_select_popupmenu_item')
 let s:callbacks = {}
 
+autocmd User doHover call coc#conceal() <cr>
+
+function! coc#conceal() abort
+  let popup_id = g:coc_last_float_win
+  let bufnr = winbufnr(popup_id)
+  let escapes = []
+
+  let lines = getbufline(bufnr, 1, '$')
+
+  let lineN = 1
+  for line in lines
+    let chars = split(line, '\zs')
+    let n = len(chars)
+    let column = 0
+
+    while column < n
+      if chars[column] == '\'
+        let posColumn = column + 1
+        let tuple = [lineN, posColumn, 1]
+        let escapes = add(escapes, tuple)
+      endif
+      let column += 1
+    endwhile
+
+    let lineN += 1
+  endfor
+
+  if len(escapes) > 0
+    for escape in escapes
+      call win_execute(popup_id, 'call matchaddpos("Conceal", [escape], 10, -1, {"conceal": ""})')
+    endfor
+  endif
+endfunction
+
 function! coc#expandable() abort
   return coc#rpc#request('snippetCheck', [1, 0])
 endfunction

--- a/autoload/coc/rpc.vim
+++ b/autoload/coc/rpc.vim
@@ -89,7 +89,9 @@ function! coc#rpc#request(method, args) abort
   if !coc#rpc#ready()
     return ''
   endif
-  return s:client['request'](a:method, a:args)
+  let m = s:client['request'](a:method, a:args)
+  call coc#util#do_autocmd(a:method)
+  return m
 endfunction
 
 function! coc#rpc#notify(method, args) abort


### PR DESCRIPTION
this commit removes the escapes from markdown returned from a lsp on
hover.

the timing of CocFloatOpen will not work. Instead I tie an autocmd to
the action and call it when the rpc returns.

this pr opens up the use of registering autocmd(s) named after a
CoCAction and having those autocmd fire when the rpc request actually
returns to (n)vim.