### PR TITLE
feat(completion): Allow languageserver level settings for 'suggest'

### DIFF
--- a/src/configuration/index.ts
+++ b/src/configuration/index.ts
@@ -64,6 +64,20 @@ export default class Configurations {
       this._errorItems.push(...errors)
     })
     this._onError.fire(this._errorItems)
+
+    const suggest = res.contents['suggest']
+    const langservers = res.contents['languageserver']
+    if (!langservers) {
+      return res
+    }
+
+    Object.keys(langservers).forEach(key => {
+      const ls = langservers[key]
+      if (suggest && ls.suggest) {
+        ls.filetypes.forEach(ft => suggest[ft] = ls.suggest)
+      }
+    })
+
     return res
   }
 

--- a/src/configuration/util.ts
+++ b/src/configuration/util.ts
@@ -55,7 +55,7 @@ export function parseConfiguration(content: string): [ParseError[], any] {
         let first = parts.shift()
         addProperty(dest, first, parts, obj[key])
       } else {
-        dest[key] = convert(obj[key])
+        dest[key] = convert(obj[key], split)
       }
     }
     return dest


### PR DESCRIPTION
Close #1800 

- Set listeners for `BufEnter` and `FileType` to update the current `getConfig` function
- Transform the config read from the file from this:

```jsonc
{                                       
   "suggest.autoTrigger": "always",
   "languageserver": {
     "golang": {
       "suggest.autoTrigger": "none", 
        // ...
      }
   }
}
```
into this
```jsonc
{                                       
   "suggest": {
     "autoTrigger": "always"
     "go": {
        "autoTrigger": "none"
     }
   }
   "languageserver": { 
     "golang": {     
       "suggest.autoTrigger": "none", 
       // ...      
      }                
   }               
}
```

@chemzqm need help with:
1. Doesn't take effect when we open with `nvim main.go` for example. Haven't figured out which event gets triggered in this case, do you know?
2. Notice there's a test in `configurations.test.ts`
```
 describe('parse configuration', () => {
    it('should only split top level dot keys', () => { ... }}) 
```

Does something else break if we split all dotted keys? It would be useful to reuse this to break the keys inside:
```jsonc
{                                       
   "suggest.autoTrigger": "always",      
   "languageserver": { 
     "golang": {
       "suggest.autoTrigger": "none", 
        // ...      
      }                
   }               
}
```

I can move the code to specifically split the "suggest" configs inside each `langserver` but its more generic to reuse what already exists, thoughts?

Still need to check if docs need updating and commit the updated tests. But would like feedback on points 1. and 2. above first