### PR TITLE
add hover action target argument

### DIFF
--- a/doc/coc.cnx
+++ b/doc/coc.cnx
@@ -789,7 +789,7 @@ CocActionAsync({action}, [...{args}, [{callback}]])
 
 	行为与 "jumpDefinition" 相同。
 
-"doHover" 					*coc-action-doHover*
+"doHover" [{hoverTarget}] 					*coc-action-doHover*
 
 	显示当前位置的悬浮信息。
 

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -1819,8 +1819,9 @@ Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 	Show documentation of the current word in a preview window.
 	Return `v:false` when hover not found.
 
-	{hoverTarget}: optional specification for where to show hover info, defaults to
-	`coc.preferences.hoverTarget` in `coc-settings.json`.
+	{hoverTarget}: optional specification for where to show hover info,
+	defaults to `coc.preferences.hoverTarget` in `coc-settings.json`.
+	Valid options: ["preview", "echo", "float"]
 
 	Note: the behavior would change in Neovim, where floating windows are
 	available.

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -1814,12 +1814,13 @@ Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 
 	same behavior as "jumpDefinition"
 
-"doHover"						*coc-action-doHover*
+"doHover" [{hoverTarget}]					*coc-action-doHover*
 
 	Show documentation of the current word in a preview window.
 	Return `v:false` when hover not found.
 
-	Use `coc.preferences.hoverTarget` to change hover behavior.
+	{hoverTarget}: optional specification for where to show hover info, defaults to
+	`coc.preferences.hoverTarget` in `coc-settings.json`.
 
 	Note: the behavior would change in Neovim, where floating windows are
 	available.

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -357,10 +357,10 @@ export default class Handler {
     return languages.hasProvider(id as any, doc.textDocument)
   }
 
-  public async onHover(): Promise<boolean> {
+  public async onHover(hoverTarget?: string): Promise<boolean> {
     let { doc, position, winid } = await this.getCurrentState()
     if (doc == null) return
-    let target = this.preferences.hoverTarget
+    let target = hoverTarget ?? this.preferences.hoverTarget
     if (target == 'float') {
       this.hoverFactory.close()
     } else if (target == 'preview') {
@@ -379,7 +379,7 @@ export default class Handler {
         if (workspace.isVim) this.nvim.command('redraw', true)
       }, 1000)
     }
-    await this.previewHover(hovers)
+    await this.previewHover(hovers, target)
     return true
   }
 
@@ -1318,8 +1318,7 @@ export default class Handler {
     search.run(args, workspace.cwd, refactor).logError()
   }
 
-  private async previewHover(hovers: Hover[]): Promise<void> {
-    let target = this.preferences.hoverTarget
+  private async previewHover(hovers: Hover[], target: string): Promise<void> {
     let docs: Documentation[] = []
     let isPreview = target === 'preview'
     for (let hover of hovers) {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -251,8 +251,8 @@ export default class Plugin extends EventEmitter {
     this.addAction('jumpUsed', openCommand => {
       return this.handler.gotoReferences(openCommand, false)
     })
-    this.addAction('doHover', () => {
-      return this.handler.onHover()
+    this.addAction('doHover', hoverTarget => {
+      return this.handler.onHover(hoverTarget)
     })
     this.addAction('getHover', () => {
       return this.handler.getHover()


### PR DESCRIPTION
The `doHover` action currently reads its target configuration directly from preferences. This PR changes it so that the target argument can optionally be provided as an argument (falling back to reading from preferences), following the style of the `jumpTo*` actions. This is useful because sometimes one wants to use different keybindings for a preview hover or floating hover, or to keep some hovered information open in the preview while using mostly using the float.

I updated the docs except for the Chinese text, because I don't know Chinese.