### PR TITLE
feat: enable extensions auto-update

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -848,7 +848,7 @@
     },
     "coc.preferences.extensionUpdateCheck": {
       "type": "string",
-      "default": "never",
+      "default": "daily",
       "description": "Interval for check extension update, could be daily, weekly, never",
       "enum": ["daily", "weekly", "never"]
     },


### PR DESCRIPTION
We now have `coc.preferences.silentAutoupdate`, it's better to enable extensions auto-update by default: 

https://github.com/neoclide/coc.nvim/blob/fe165b2b62640b19523059a70a4accde35f39112/data/schema.json#L973-L977