### PR TITLE
Add coc#float#nvim_scroll() with synchronized scrollbar

### DIFF
--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -875,7 +875,8 @@ function! coc#float#nvim_scroll(forward, ...)
   if buf_height < win_height | return '' | endif
   let pos = nvim_win_get_cursor(float)
   let amount = (a:forward == 1 ? 1 : -1) * get(a:, 1, max([1, win_height/2]))
-  let scrolloff = &scrolloff*2 < win_height ? &scrolloff : 0
+  let scrolloff = getwinvar(float, '&scrolloff', 0)
+  let scrolloff = scrolloff*2 < win_height ? scrolloff : 0
   try
     let last_amount = nvim_win_get_var(float, 'coc_float_scroll_last_amount')
   catch

--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -874,14 +874,10 @@ function! coc#float#nvim_scroll(forward, ...)
   let win_height = nvim_win_get_height(float)
   if buf_height < win_height | return '' | endif
   let pos = nvim_win_get_cursor(float)
-  let amount = (a:forward == 1 ? 1 : -1) * get(a:, 1, max([1, win_height/2]))
   let scrolloff = getwinvar(float, '&scrolloff', 0)
   let scrolloff = scrolloff*2 < win_height ? scrolloff : 0
-  try
-    let last_amount = nvim_win_get_var(float, 'coc_float_scroll_last_amount')
-  catch
-    let last_amount = 0
-  endtry
+  let amount = (a:forward == 1 ? 1 : -1) * get(a:, 1, max([1, win_height/2]))
+  let last_amount = getwinvar(float, 'coc_float_nvim_scroll_last_amount', 0)
   if amount > 0
     if pos[0] == 1
       let pos[0] += amount + win_height - scrolloff*1 - 1
@@ -901,7 +897,7 @@ function! coc#float#nvim_scroll(forward, ...)
     endif
     let pos[0] = pos[0] > scrolloff ? pos[0] : 1
   endif
-  call nvim_win_set_var(float, 'coc_float_scroll_last_amount', amount)
+  call setwinvar(float, 'coc_float_nvim_scroll_last_amount', amount)
   call nvim_win_set_cursor(float, pos)
   call timer_start(10, { -> coc#float#nvim_scrollbar(float) })
   return ''

--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -72,44 +72,6 @@ function! coc#util#float_scroll(forward)
   call coc#float#scroll(a:forward)
 endfunction
 
-" scroll float without exiting insert mode (nvim only)
-function! coc#util#float_scroll_i(amount)
-  let float = coc#float#get_float_win()
-  if !float | return '' | endif
-  let buf = nvim_win_get_buf(float)
-  let buf_height = nvim_buf_line_count(buf)
-  let win_height = nvim_win_get_height(float)
-  if buf_height < win_height | return '' | endif
-  let pos = nvim_win_get_cursor(float)
-  try
-    let last_amount = nvim_win_get_var(float, 'coc_float_scroll_last_amount')
-  catch
-    let last_amount = 0
-  endtry
-  if a:amount > 0
-    if pos[0] == 1
-      let pos[0] += a:amount + win_height - 2
-    elseif last_amount > 0
-      let pos[0] += a:amount
-    else
-      let pos[0] += a:amount + win_height - 3
-    endif
-    let pos[0] = pos[0] < buf_height ? pos[0] : buf_height
-  elseif a:amount < 0
-    if pos[0] == buf_height
-      let pos[0] += a:amount - win_height + 2
-    elseif last_amount < 0
-      let pos[0] += a:amount
-    else
-      let pos[0] += a:amount - win_height + 3
-    endif
-    let pos[0] = pos[0] > 1 ? pos[0] : 1
-  endif
-  call nvim_win_set_var(float, 'coc_float_scroll_last_amount', a:amount)
-  call nvim_win_set_cursor(float, pos)
-  return ''
-endfunction
-
 " get cursor position
 function! coc#util#cursor()
   let pos = getcurpos()

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -1643,6 +1643,23 @@ coc#float#scroll({forward}, [{amount}])
 
 	Note: this function requires nvim >= 0.4.3 or vim >= 8.2.750 to work.
 
+coc#float#nvim_scroll({forward}, [{amount}]) 		*coc#float#nvim_scroll()*
+
+	NeoVim-only function to scroll float window on current tab, scroll
+	backward when {forward} is not `1`. {amount} could be number, or
+	approximately half page when omitted.
+	Example key-mappings:
+>
+	if has('nvim')
+	  vnoremap <nowait><expr> <C-f> coc#float#has_scroll() ? coc#float#nvim_scroll(1, 1) : "\<C-f>"
+	  vnoremap <nowait><expr> <C-b> coc#float#has_scroll() ? coc#float#nvim_scroll(0, 1) : "\<C-b>"
+	endif
+<
+	Note: This function is only relevant for visual mode mapping, to be
+	able to scroll on jump placeholder of signature help expansion, where
+	|coc#float#scroll| is not implemented. Use |coc#float#scroll|
+	otherwise.
+
 CocRequest({id}, {method}, [{params}])			*CocRequest()*
 
 	Send a request to language client of {id} with {method} and optional


### PR DESCRIPTION
- Replace recent `coc#util#float_scroll_i` for something better named
- Add scrollbar synchronization
- Fix missing calculation of &scrolloff
- Nvim-only. Only useful for visual mode mappings (see added doc)

Partially solves #2521