### PR TITLE
Allow Status Line Config

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -739,6 +739,21 @@
       "default": 10,
       "description": "Height of split list window."
     },
+    "list.statusLineSegments": {
+      "type": ["array", "null"],
+      "default": [
+        "%#CocListMode#-- %{get(b:list_status, \"mode\", \"\")} --%*",
+        "%{get(b:list_status, \"loading\", \"\")}",
+        "%{get(b:list_status, \"args\", \"\")}",
+        "(%L/%{get(b:list_status, \"total\", \"\")})",
+        "%=",
+        "%#CocListPath# %{get(b:list_status, \"cwd\", \"\")} %l/%L%*"
+      ],
+      "items": {
+        "types": "string"
+      },
+      "description": "An array of statusline segments that will be used to draw the status line for list windows."
+    },
     "list.signOffset": {
       "type": "number",
       "default": 900,

--- a/src/list/ui.ts
+++ b/src/list/ui.ts
@@ -18,15 +18,6 @@ export interface MousePosition {
   current: boolean
 }
 
-const StatusLineOption = [
-  '%#CocListMode#-- %{get(b:list_status, "mode", "")} --%*',
-  '%{get(b:list_status, "loading", "")}',
-  '%{get(b:list_status, "args", "")}',
-  '(%L/%{get(b:list_status, "total", "")})',
-  '%=',
-  '%#CocListPath# %{get(b:list_status, "cwd", "")} %l/%L%*'
-].join(' ')
-
 export default class ListUI {
   private window: Window
   private height: number
@@ -364,11 +355,14 @@ export default class ListUI {
 
   private async setLines(lines: string[], append = false, index: number): Promise<void> {
     let { nvim, buffer, window } = this
+    let statusSegments : Array<String> | null = this.config.get('statusLineSegments')
     if (!buffer || !window) return
     nvim.pauseNotification()
     nvim.call('coc#util#win_gotoid', [window.id], true)
     if (!append) {
-      window.notify('nvim_win_set_option', ['statusline', StatusLineOption])
+      if(statusSegments) {
+        window.notify('nvim_win_set_option', ['statusline', statusSegments.join(" ")])
+      }
       nvim.call('clearmatches', [], true)
       if (!lines.length) {
         lines = ['No results, press ? on normal mode to get help.']


### PR DESCRIPTION
Calling `nvim_win_set_options` to set the statusline on each appended line prevents Airline from managing the status line based on the `filetype` setting, as described in their documentation.

This moves the status line segment configuration into the `coc-settings.json` file to allow for finer grained configuration of the status line in List windows. You can also set the configuration item to `null` to let Airline or other status line manager manage the statusline function directly.