### PR TITLE
Let user override default yarn executable name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,10 @@ Try these steps when you have problem with coc.nvim.
 - Checkout the log of coc.nvim by command `:CocOpenLog`.
 - When you have issues with the language server, it's recommended to [checkout
   the output](https://github.com/neoclide/coc.nvim/wiki/Debug-language-server#using-output-channel).
+- Fedora provides `yarn` tool also from nodejs-yarn package. If you install it this way, add
+  `let g:coc_nvim_yarn='nodejs-yarn'`
+  into the head of your vimrc.
+
 
 ## Feedback
 

--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -17,6 +17,12 @@ elseif has('mac')
   let s:activate = 'activate'
 endif
 
+" Let user customize yarn executable name.
+" E.g. Fedora provides executable named as nodejs-yarn.
+if !exists('g:coc_nvim_yarn')
+  let g:coc_nvim_yarn='yarn'
+endif
+
 function! coc#util#has_preview()
   for i in range(1, winnr('$'))
     if getwinvar(i, '&previewwindow')
@@ -674,7 +680,7 @@ endfunction
 function! coc#util#install() abort
   call coc#util#open_terminal({
         \ 'cwd': s:root,
-        \ 'cmd': 'yarn install --frozen-lockfile',
+        \ 'cmd': g:coc_nvim_yarn . ' install --frozen-lockfile',
         \ 'autoclose': 0,
         \ })
 endfunction


### PR DESCRIPTION
The issue is that Fedora have package nodejs-yarn and it provides executable named `nodejs-yarn`.
In the source `yarn` executable is hardcoded.

That patch allow users to override name via global variable `g:coc_nvim_yarn`.