### PR TITLE
don't run pclose in onHover with target == 'preview'

### DIFF
--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -364,8 +364,6 @@ export default class Handler {
     let target = hoverTarget ?? this.preferences.hoverTarget
     if (target == 'float') {
       this.hoverFactory.close()
-    } else if (target == 'preview') {
-      this.nvim.command('pclose', true)
     }
     await synchronizeDocument(doc)
     let hovers = await this.withRequestToken<Hover[]>('hover', token => {


### PR DESCRIPTION
I think it's ok not to run pclose before doing a hover with preview target because:
* Somtimes the preview doesn't open up on `CocActionAsync('doHover')`;
  the preview window is just gone!
* Not doing `pclose` is not problem unlike `this.hoverFactory.close()` for float target:
  it can reuse current `coc://document` buffer (bufnr preserved).