### PR TITLE
feat(list): Add cancel command

### DIFF
--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -2624,6 +2624,10 @@ LIST COMMAND						*coc-list-command*
 
 	Reopen last opened list, input and cursor position will be preserved.
 
+:CocListCancel						*:CocListCancel*
+
+	Close list, useful when the list is not the current window.
+
 :CocPrev [{name}]					*:CocPrev*
 
 	Invoke default action for the previous item in the last {name} list.

--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -432,6 +432,7 @@ command! -nargs=+ -complete=custom,s:ExtensionList  CocUninstall :call CocAction
 command! -nargs=* -complete=custom,s:CommandList -range CocCommand :call coc#rpc#notify('runCommand', [<f-args>])
 command! -nargs=* -complete=custom,coc#list#options CocList      :call coc#rpc#notify('openList',  [<f-args>])
 command! -nargs=? -complete=custom,coc#list#names CocListResume   :call coc#rpc#notify('listResume', [<f-args>])
+command! -nargs=0 -complete=custom,coc#list#names CocListCancel   :call coc#rpc#notify('listCancel', [])
 command! -nargs=? -complete=custom,coc#list#names CocPrev         :call coc#rpc#notify('listPrev', [<f-args>])
 command! -nargs=? -complete=custom,coc#list#names CocNext         :call coc#rpc#notify('listNext', [<f-args>])
 command! -nargs=? -complete=custom,coc#list#names CocFirst        :call coc#rpc#notify('listFirst', [<f-args>])

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -73,6 +73,7 @@ export default class Plugin extends EventEmitter {
     })
     this.addAction('selectSymbolRange', (inner: boolean, visualmode: string, supportedSymbols: string[]) => this.handler.selectSymbolRange(inner, visualmode, supportedSymbols))
     this.addAction('listResume', (name?: string) => listManager.resume(name))
+    this.addAction('listCancel', () => listManager.cancel(true))
     this.addAction('listPrev', (name?: string) => listManager.previous(name))
     this.addAction('listNext', (name?: string) => listManager.next(name))
     this.addAction('listFirst', (name?: string) => listManager.first(name))


### PR DESCRIPTION
This PR adds `:CocListCancel` which acts like a counterpart to `:CocListResume` allowing the list to be closed when the list is not the current window.