### PR TITLE
chore(doc): add constructor glyph example

### DIFF
--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -300,6 +300,7 @@ Built-in configurations:~
 		"variable": "\ue79b",
 		"value": "\uf89f",
 		"operator": "\u03a8",
+		"constructor": "\uf0ad",
 		"function": "\u0192",
 		"reference": "\ufa46",
 		"constant": "\uf8fe",


### PR DESCRIPTION
Add constructor glyph to completionItemKindLabels example.