### PR TITLE
docs: fix a typo in CocSearch section

### DIFF
--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -2269,7 +2269,7 @@ COMMANDS						*coc-commands*
 >
 	:CocSearch import\ \{\ Neovim
 <
-	The escape for `{` is required because rg use regexp be default, or:
+	The escape for `{` is required because rg uses regexp by default, or:
 >
 	:CocSearch -F import\ {\ Neovim
 <


### PR DESCRIPTION
This resolves minor typos in the docs for CocSearch.