### PR TITLE
Columnar alignment of CocLists

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -516,6 +516,17 @@
       "default": "hint",
       "enum": ["hint", "information", "warning", "error"]
     },
+    "diagnostic.listIncludeCode": {
+      "type": "boolean",
+      "description":"Whether to show the diagnostic code in the list.",
+      "default": true
+    },
+   "diagnostic.listFormatPath": {
+      "type": "string",
+      "description":"Decide how the filepath is shown in the list.",
+      "enum": ["full", "short", "filename", "hidden"],
+      "default": "full"
+    },
     "diagnostic.locationlistUpdate": {
       "type": "boolean",
       "description": "Update locationlist on diagnostics change, only works with locationlist opened by :CocDiagnostics command and first window of associated buffer.",
@@ -773,6 +784,11 @@
       "type": "string",
       "default": ">",
       "description": "The character used as first character in prompt line"
+    },
+    "list.alignColumns": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to align lists in columns, default: `false`"
     },
     "list.interactiveDebounceTime": {
       "type": "number",

--- a/data/schema.json
+++ b/data/schema.json
@@ -516,17 +516,6 @@
       "default": "hint",
       "enum": ["hint", "information", "warning", "error"]
     },
-    "diagnostic.listIncludeCode": {
-      "type": "boolean",
-      "description":"Whether to show the diagnostic code in the list.",
-      "default": true
-    },
-   "diagnostic.listFormatPath": {
-      "type": "string",
-      "description":"Decide how the filepath is shown in the list.",
-      "enum": ["full", "short", "filename", "hidden"],
-      "default": "full"
-    },
     "diagnostic.locationlistUpdate": {
       "type": "boolean",
       "description": "Update locationlist on diagnostics change, only works with locationlist opened by :CocDiagnostics command and first window of associated buffer.",
@@ -869,6 +858,17 @@
       "type": "object",
       "default": {},
       "description": "Custom keymappings on insert mode."
+    },
+    "list.source.diagnostics.includeCode": {
+      "type": "boolean",
+      "description":"Whether to show the diagnostic code in the list.",
+      "default": true
+    },
+   "list.source.diagnostics.pathFormat": {
+      "type": "string",
+      "description":"Decide how the filepath is shown in the list.",
+      "enum": ["full", "short", "filename", "hidden"],
+      "default": "full"
     },
     "list.source.symbols.excludes": {
       "type": "array",

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -329,20 +329,6 @@ Built-in configurations:~
 
 	Display diagnostics, default: `true`
 
-"diagnostic.listFormatPath":~
-
-	Decide how the filepath is shown in the list.
-
-	Valid options: ["full", "short", "filename", "hidden"].
-
-	default: `"full"`
-
-"diagnostic.listIncludeCode":~
-
-	Whether to show the diagnostic code in the list.
-
-	default: `true`
-
 "diagnostic.enableSign":~
 
 	Enable signs for diagnostics, default: `true`
@@ -652,6 +638,21 @@ Built-in configurations:~
 
 	Filetypes that should use `ctags` for outline instead of language server,
 	default: `[]`
+
+
+"list.source.diagnostics.pathFormat":~
+
+	Decide how the filepath is shown in the list.
+
+	Valid options: ["full", "short", "filename", "hidden"].
+
+	default: `"full"`
+
+"list.source.diagnostics.includeCode":~
+
+	Whether to show the diagnostic code in the list.
+
+	default: `true`
 
 							*coc-config-preferences*
 "coc.preferences.maxFileSize":~

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -329,6 +329,20 @@ Built-in configurations:~
 
 	Display diagnostics, default: `true`
 
+"diagnostic.listFormatPath":~
+
+	Decide how the filepath is shown in the list.
+
+	Valid options: ["full", "short", "filename", "hidden"].
+
+	default: `"full"`
+
+"diagnostic.listIncludeCode":~
+
+	Whether to show the diagnostic code in the list.
+
+	default: `true`
+
 "diagnostic.enableSign":~
 
 	Enable signs for diagnostics, default: `true`
@@ -570,6 +584,10 @@ Built-in configurations:~
 "list.indicator":~
 
 	The character used as first character in prompt line, default: `">"`
+
+"list.alignColumns":~
+
+	Whether to align lists in columns, default: `false`
 
 "list.height":~
 

--- a/src/__tests__/modules/diagnosticBuffer.test.ts
+++ b/src/__tests__/modules/diagnosticBuffer.test.ts
@@ -29,8 +29,6 @@ const config: DiagnosticConfig = {
   warningSign: '>>',
   infoSign: '>>',
   refreshAfterSave: false,
-  listIncludeCode: true,
-  listFormatPath: "full",
   hintSign: '>>',
   filetypeMap: {
     default: ''

--- a/src/__tests__/modules/diagnosticBuffer.test.ts
+++ b/src/__tests__/modules/diagnosticBuffer.test.ts
@@ -29,6 +29,9 @@ const config: DiagnosticConfig = {
   warningSign: '>>',
   infoSign: '>>',
   refreshAfterSave: false,
+  listIncludeCode: true,
+  listAlign: true,
+  listFormatPath: "full",
   hintSign: '>>',
   filetypeMap: {
     default: ''

--- a/src/__tests__/modules/diagnosticBuffer.test.ts
+++ b/src/__tests__/modules/diagnosticBuffer.test.ts
@@ -30,7 +30,6 @@ const config: DiagnosticConfig = {
   infoSign: '>>',
   refreshAfterSave: false,
   listIncludeCode: true,
-  listAlign: true,
   listFormatPath: "full",
   hintSign: '>>',
   filetypeMap: {

--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -46,6 +46,9 @@ export interface DiagnosticConfig {
   showUnused?: boolean
   showDeprecated?: boolean
   format?: string
+  listIncludeCode: boolean
+  listFormatPath: "full" | "short" | "filename"
+  listAlign: boolean
 }
 
 export class DiagnosticManager implements Disposable {
@@ -426,7 +429,9 @@ export class DiagnosticManager implements Disposable {
             file,
             lnum: start.line + 1,
             col: start.character + 1,
-            message: `[${diagnostic.source || collection.name}${diagnostic.code ? ' ' + diagnostic.code : ''}] ${diagnostic.message}`,
+            code: diagnostic.code,
+            source: diagnostic.source || collection.name,
+            message: diagnostic.message,
             severity: getSeverityName(diagnostic.severity),
             level: diagnostic.severity || 0,
             location: Location.create(uri, diagnostic.range)
@@ -623,7 +628,10 @@ export class DiagnosticManager implements Disposable {
       filetypeMap: config.get<object>('filetypeMap', {}),
       showUnused: config.get<boolean>('showUnused', true),
       showDeprecated: config.get<boolean>('showDeprecated', true),
-      format: config.get<string>('format', '[%source%code] [%severity] %message')
+      format: config.get<string>('format', '[%source%code] [%severity] %message'),
+      listIncludeCode: config.get<boolean>('listIncludeCode', true),
+      listFormatPath: config.get<"full" | "short" | "filename">('listFormatPath', "full"),
+      listAlign: config.get<boolean>('listAlign', true)
     }
     this.enabled = config.get<boolean>('enable', true)
     if (this.config.displayByAle) {

--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -17,8 +17,6 @@ import DiagnosticCollection from './collection'
 import { getSeverityName, getSeverityType, severityLevel, getLocationListItem } from './util'
 const logger = require('../util/logger')('diagnostic-manager')
 
-export type PathFormatting = "full" | "short" | "filename" | "hidden"
-
 export interface DiagnosticConfig {
   enableSign: boolean
   locationlistUpdate: boolean
@@ -48,8 +46,6 @@ export interface DiagnosticConfig {
   showUnused?: boolean
   showDeprecated?: boolean
   format?: string
-  listIncludeCode: boolean
-  listFormatPath: PathFormatting
 }
 
 export class DiagnosticManager implements Disposable {
@@ -630,8 +626,6 @@ export class DiagnosticManager implements Disposable {
       showUnused: config.get<boolean>('showUnused', true),
       showDeprecated: config.get<boolean>('showDeprecated', true),
       format: config.get<string>('format', '[%source%code] [%severity] %message'),
-      listIncludeCode: config.get<boolean>('listIncludeCode', true),
-      listFormatPath: config.get<PathFormatting>('listFormatPath', "full"),
     }
     this.enabled = config.get<boolean>('enable', true)
     if (this.config.displayByAle) {

--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -17,6 +17,8 @@ import DiagnosticCollection from './collection'
 import { getSeverityName, getSeverityType, severityLevel, getLocationListItem } from './util'
 const logger = require('../util/logger')('diagnostic-manager')
 
+export type PathFormatting = "full" | "short" | "filename" | "hidden"
+
 export interface DiagnosticConfig {
   enableSign: boolean
   locationlistUpdate: boolean
@@ -47,8 +49,7 @@ export interface DiagnosticConfig {
   showDeprecated?: boolean
   format?: string
   listIncludeCode: boolean
-  listFormatPath: "full" | "short" | "filename"
-  listAlign: boolean
+  listFormatPath: PathFormatting
 }
 
 export class DiagnosticManager implements Disposable {
@@ -630,8 +631,7 @@ export class DiagnosticManager implements Disposable {
       showDeprecated: config.get<boolean>('showDeprecated', true),
       format: config.get<string>('format', '[%source%code] [%severity] %message'),
       listIncludeCode: config.get<boolean>('listIncludeCode', true),
-      listFormatPath: config.get<"full" | "short" | "filename">('listFormatPath', "full"),
-      listAlign: config.get<boolean>('listAlign', true)
+      listFormatPath: config.get<PathFormatting>('listFormatPath', "full"),
     }
     this.enabled = config.get<boolean>('enable', true)
     if (this.config.displayByAle) {

--- a/src/list/basic.ts
+++ b/src/list/basic.ts
@@ -50,6 +50,10 @@ export default abstract class BasicList implements IList, Disposable {
     this.config = new ListConfiguration()
   }
 
+  public get alignColumns(): boolean {
+    return this.config.get('alignColumns', false)
+  }
+
   protected get hlGroup(): string {
     return this.config.get('previewHighlightGroup', 'Search')
   }

--- a/src/list/formatting.ts
+++ b/src/list/formatting.ts
@@ -1,0 +1,42 @@
+export function alignElements(elements: string[][]): string[] {
+  if (elements.length === 0 || !elements.every((elem) => elem.length === elements[0].length)) {
+    return []
+  }
+  const lengths = elements.map((item) => item.map((x) => x.length))
+
+  const maxLengths = []
+  for (let elementIdx = 0; elementIdx < elements[0].length; elementIdx++) {
+    maxLengths.push(Math.max(...lengths.map((x) => x[elementIdx])))
+  }
+  return elements
+    .map((item) => item.map((element, elementIdx) => element.padEnd(maxLengths[elementIdx])))
+    .map((line) => line.join("\t"))
+}
+
+export function formatPath(format: "full" | "short" | "filename", path: string): string {
+  if (format === "full") {
+    return path
+  } else if (format === "short") {
+    const segments = path.split("/")
+    if (segments.length < 2) {
+      return path
+    }
+    const shortenedInit = segments
+      .slice(0, segments.length - 2)
+      .filter((seg) => seg.length > 0)
+      .map((seg) => seg[0])
+    return [...shortenedInit, segments[segments.length - 1]].join("/")
+  } else {
+    const segments = path.split("/")
+    return segments[segments.length - 1] ?? ""
+  }
+}
+
+export function zip<A, B>(first: A[], second: B[]): [A, B][] {
+  const shorterLength = Math.min(first.length, second.length)
+  const result = []
+  for (let i = 0; i < shorterLength; i++) {
+    result.push([first[i], second[i]])
+  }
+  return result
+}

--- a/src/list/formatting.ts
+++ b/src/list/formatting.ts
@@ -1,20 +1,24 @@
+import { PathFormatting } from '../diagnostic/manager'
+
 export function alignElements(elements: string[][]): string[] {
-  if (elements.length === 0 || !elements.every((elem) => elem.length === elements[0].length)) {
+  if (elements.length === 0 || !elements.every(elem => elem.length === elements[0].length)) {
     return []
   }
-  const lengths = elements.map((item) => item.map((x) => x.length))
+  const lengths = elements.map(item => item.map(x => x.length))
 
   const maxLengths = []
   for (let elementIdx = 0; elementIdx < elements[0].length; elementIdx++) {
-    maxLengths.push(Math.max(...lengths.map((x) => x[elementIdx])))
+    maxLengths.push(Math.max(...lengths.map(x => x[elementIdx])))
   }
   return elements
-    .map((item) => item.map((element, elementIdx) => element.padEnd(maxLengths[elementIdx])))
-    .map((line) => line.join("\t"))
+    .map(item => item.map((element, elementIdx) => element.padEnd(maxLengths[elementIdx])))
+    .map(line => line.join("\t"))
 }
 
-export function formatPath(format: "full" | "short" | "filename", path: string): string {
-  if (format === "full") {
+export function formatPath(format: PathFormatting, path: string): string {
+  if (format === "hidden") {
+    return ""
+  } else if (format === "full") {
     return path
   } else if (format === "short") {
     const segments = path.split("/")
@@ -23,20 +27,11 @@ export function formatPath(format: "full" | "short" | "filename", path: string):
     }
     const shortenedInit = segments
       .slice(0, segments.length - 2)
-      .filter((seg) => seg.length > 0)
-      .map((seg) => seg[0])
+      .filter(seg => seg.length > 0)
+      .map(seg => seg[0])
     return [...shortenedInit, segments[segments.length - 1]].join("/")
   } else {
     const segments = path.split("/")
     return segments[segments.length - 1] ?? ""
   }
-}
-
-export function zip<A, B>(first: A[], second: B[]): [A, B][] {
-  const shorterLength = Math.min(first.length, second.length)
-  const result = []
-  for (let i = 0; i < shorterLength; i++) {
-    result.push([first[i], second[i]])
-  }
-  return result
 }

--- a/src/list/formatting.ts
+++ b/src/list/formatting.ts
@@ -1,6 +1,7 @@
-import { PathFormatting } from '../diagnostic/manager'
 import { ListItem } from '../types'
 import path from 'path'
+
+export type PathFormatting = "full" | "short" | "filename" | "hidden"
 
 export interface UnformattedListItem extends Omit<ListItem, 'label'> {
   label: string[]

--- a/src/list/formatting.ts
+++ b/src/list/formatting.ts
@@ -1,5 +1,6 @@
 import { PathFormatting } from '../diagnostic/manager'
 import { ListItem } from '../types'
+import path from 'path'
 
 export interface UnformattedListItem extends Omit<ListItem, 'label'> {
   label: string[]
@@ -32,23 +33,23 @@ export function formatListItems(align: boolean, list: UnformattedListItem[]): Li
   return processedList
 }
 
-export function formatPath(format: PathFormatting, path: string): string {
+export function formatPath(format: PathFormatting, pathToFormat: string): string {
   if (format === "hidden") {
     return ""
   } else if (format === "full") {
-    return path
+    return pathToFormat
   } else if (format === "short") {
-    const segments = path.split("/")
+    const segments = pathToFormat.split(path.sep)
     if (segments.length < 2) {
-      return path
+      return pathToFormat
     }
     const shortenedInit = segments
       .slice(0, segments.length - 2)
       .filter(seg => seg.length > 0)
       .map(seg => seg[0])
-    return [...shortenedInit, segments[segments.length - 1]].join("/")
+    return [...shortenedInit, segments[segments.length - 1]].join(path.sep)
   } else {
-    const segments = path.split("/")
+    const segments = pathToFormat.split(path.sep)
     return segments[segments.length - 1] ?? ""
   }
 }

--- a/src/list/formatting.ts
+++ b/src/list/formatting.ts
@@ -1,18 +1,35 @@
 import { PathFormatting } from '../diagnostic/manager'
+import { ListItem } from '../types'
 
-export function alignElements(elements: string[][]): string[] {
-  if (elements.length === 0 || !elements.every(elem => elem.length === elements[0].length)) {
+export interface UnformattedListItem extends Omit<ListItem, 'label'> {
+  label: string[]
+}
+
+export function formatListItems(align: boolean, list: UnformattedListItem[]): ListItem[] {
+  if (list.length === 0) {
     return []
   }
-  const lengths = elements.map(item => item.map(x => x.length))
 
-  const maxLengths = []
-  for (let elementIdx = 0; elementIdx < elements[0].length; elementIdx++) {
-    maxLengths.push(Math.max(...lengths.map(x => x[elementIdx])))
+  let processedList: ListItem[] = []
+
+  if (align) {
+    const maxWidths = Array(Math.min(...list.map(item => item.label.length))).fill(0)
+    for (let item of list) {
+      for (let i = 0; i < maxWidths.length; i++) {
+        maxWidths[i] = Math.max(maxWidths[i], item.label[i].length)
+      }
+    }
+    processedList = list
+      .map(item => ({
+        ...item,
+        label: item.label
+          .map((element, idx) => element.padEnd(maxWidths[idx]))
+          .join("\t")
+      }))
+  } else {
+    processedList = list.map(item => ({...item, label: item.label.join("\t")}))
   }
-  return elements
-    .map(item => item.map((element, elementIdx) => element.padEnd(maxLengths[elementIdx])))
-    .map(line => line.join("\t"))
+  return processedList
 }
 
 export function formatPath(format: PathFormatting, path: string): string {

--- a/src/list/source/commands.ts
+++ b/src/list/source/commands.ts
@@ -5,6 +5,7 @@ import Mru from '../../model/mru'
 import { ListContext, ListItem } from '../../types'
 import workspace from '../../workspace'
 import BasicList from '../basic'
+import { formatListItems, UnformattedListItem } from '../formatting'
 
 export default class CommandsList extends BasicList {
   public defaultAction = 'run'
@@ -28,20 +29,20 @@ export default class CommandsList extends BasicList {
   }
 
   public async loadItems(_context: ListContext): Promise<ListItem[]> {
-    let items: ListItem[] = []
+    let items: UnformattedListItem[] = []
     let list = commandManager.commandList
     let { titles } = commandManager
     let mruList = await this.mru.load()
     for (const o of list) {
       const { id } = o
       items.push({
-        label: `${id}\t${titles.get(id) || ''}`,
+        label: [id, ...(titles.get(id) ? [titles.get(id)] : [])],
         filterText: id,
         data: { cmd: id, score: score(mruList, id) }
       })
     }
     items.sort((a, b) => b.data.score - a.data.score)
-    return items
+    return formatListItems(this.alignColumns, items)
   }
 
   public doHighlight(): void {

--- a/src/list/source/diagnostics.ts
+++ b/src/list/source/diagnostics.ts
@@ -3,7 +3,7 @@ import diagnosticManager from '../../diagnostic/manager'
 import { DiagnosticItem, ListContext, ListItem } from '../../types'
 import LocationList from './location'
 import { isParentFolder } from '../../util/fs'
-import { formatListItems, formatPath, UnformattedListItem } from '../formatting'
+import { formatListItems, formatPath, PathFormatting, UnformattedListItem } from '../formatting'
 const logger = require('../../util/logger')('list-symbols')
 
 export default class DiagnosticsList extends LocationList {
@@ -15,11 +15,14 @@ export default class DiagnosticsList extends LocationList {
     let list: DiagnosticItem[] = diagnosticManager.getDiagnosticList()
     let { cwd } = context
 
+    const shouldIncludeCode = this.getConfig().get<boolean>('includeCode', true)
+    const pathFormat = this.getConfig().get<PathFormatting>('pathFormat', "full")
+
     const unformatted: UnformattedListItem[] = list.map(item => {
       const file = isParentFolder(cwd, item.file) ? path.relative(cwd, item.file) : item.file
-      const formattedPath = formatPath(diagnosticManager.config.listFormatPath, file)
-      const formattedPosition = diagnosticManager.config.listFormatPath !== "hidden" ? [`${formattedPath}:${item.lnum}`] : []
-      const code = diagnosticManager.config.listIncludeCode ? [`[${item.source}${item.code ? '' : ']'}`, item.code ? `${item.code}]` : ''] : []
+      const formattedPath = formatPath(pathFormat, file)
+      const formattedPosition = pathFormat !== "hidden" ? [`${formattedPath}:${item.lnum}`] : []
+      const code = shouldIncludeCode ? [`[${item.source}${item.code ? '' : ']'}`, item.code ? `${item.code}]` : ''] : []
       return {
         label: [...formattedPosition, ...code, item.severity, item.message],
         location: item.location,

--- a/src/list/source/diagnostics.ts
+++ b/src/list/source/diagnostics.ts
@@ -3,6 +3,7 @@ import diagnosticManager from '../../diagnostic/manager'
 import { DiagnosticItem, ListContext, ListItem } from '../../types'
 import LocationList from './location'
 import { isParentFolder } from '../../util/fs'
+import { zip, formatPath, alignElements } from '../formatting'
 const logger = require('../../util/logger')('list-symbols')
 
 export default class DiagnosticsList extends LocationList {
@@ -13,23 +14,30 @@ export default class DiagnosticsList extends LocationList {
   public async loadItems(context: ListContext): Promise<ListItem[]> {
     let list: DiagnosticItem[] = diagnosticManager.getDiagnosticList()
     let { cwd } = context
-    return list.map(item => {
-      let file = isParentFolder(cwd, item.file) ? path.relative(cwd, item.file) : item.file
-      return {
-        label: `${file}:${item.lnum}:${item.col}\t${item.severity}\t${item.message.replace(/\n/g, '')}`,
-        location: item.location
-      }
+
+    if (list.length === 0) {
+      return []
+    }
+
+    const lines = list.map(item => {
+      const file = isParentFolder(cwd, item.file) ? path.relative(cwd, item.file) : item.file
+      const formattedPath = formatPath(diagnosticManager.config.listFormatPath, file)
+      const optionalCode = diagnosticManager.config.listIncludeCode ? [`[${item.source}`, `${item.code}]`] : []
+      return [ `${formattedPath}:${item.lnum}`, ...optionalCode, item.severity, item.message ]
     })
+    const alignedLines = alignElements(lines)
+    return zip(alignedLines, list).map(( [label, {location}] ) => ({ label, location })
+    )
   }
 
   public doHighlight(): void {
     let { nvim } = this
     nvim.pauseNotification()
     nvim.command('syntax match CocDiagnosticsFile /\\v^\\s*\\S+/ contained containedin=CocDiagnosticsLine', true)
-    nvim.command('syntax match CocDiagnosticsError /\\tError\\t/ contained containedin=CocDiagnosticsLine', true)
-    nvim.command('syntax match CocDiagnosticsWarning /\\tWarning\\t/ contained containedin=CocDiagnosticsLine', true)
-    nvim.command('syntax match CocDiagnosticsInfo /\\tInformation\\t/ contained containedin=CocDiagnosticsLine', true)
-    nvim.command('syntax match CocDiagnosticsHint /\\tHint\\t/ contained containedin=CocDiagnosticsLine', true)
+    nvim.command('syntax match CocDiagnosticsError /\\tError\\s*\\t/ contained containedin=CocDiagnosticsLine', true)
+    nvim.command('syntax match CocDiagnosticsWarning /\\tWarning\\s*\\t/ contained containedin=CocDiagnosticsLine', true)
+    nvim.command('syntax match CocDiagnosticsInfo /\\tInformation\\s*\\t/ contained containedin=CocDiagnosticsLine', true)
+    nvim.command('syntax match CocDiagnosticsHint /\\tHint\\s*\\t/ contained containedin=CocDiagnosticsLine', true)
     nvim.command('highlight default link CocDiagnosticsFile Comment', true)
     nvim.command('highlight default link CocDiagnosticsError CocErrorSign', true)
     nvim.command('highlight default link CocDiagnosticsWarning CocWarningSign', true)
@@ -40,3 +48,4 @@ export default class DiagnosticsList extends LocationList {
     })
   }
 }
+

--- a/src/list/source/extensions.ts
+++ b/src/list/source/extensions.ts
@@ -9,6 +9,7 @@ import { wait } from '../../util'
 import workspace from '../../workspace'
 import window from '../../window'
 import BasicList from '../basic'
+import { formatListItems, UnformattedListItem } from '../formatting'
 const logger = require('../../util/logger')('list-extensions')
 
 export default class ExtensionList extends BasicList {
@@ -112,7 +113,7 @@ export default class ExtensionList extends BasicList {
   }
 
   public async loadItems(_context: ListContext): Promise<ListItem[]> {
-    let items: ListItem[] = []
+    let items: UnformattedListItem[] = []
     let list = await extensions.getExtensionStates()
     let lockedList = await extensions.getLockedList()
     for (let stat of list) {
@@ -127,7 +128,7 @@ export default class ExtensionList extends BasicList {
       let root = await this.nvim.call('resolve', stat.root)
       let locked = lockedList.includes(stat.id)
       items.push({
-        label: `${prefix} ${stat.id}${locked ? ' ' : ''}\t${stat.isLocal ? '[RTP]\t' : ''}${stat.version}\t${root.replace(os.homedir(), '~')}`,
+        label: [`${prefix} ${stat.id}${locked ? ' ' : ''}`, ...(stat.isLocal ? ['[RTP]'] : []), stat.version, root.replace(os.homedir(), '~')],
         filterText: stat.id,
         data: {
           id: stat.id,
@@ -144,7 +145,7 @@ export default class ExtensionList extends BasicList {
       }
       return b.data.id - a.data.id ? 1 : -1
     })
-    return items
+    return formatListItems(this.alignColumns, items)
   }
 
   public doHighlight(): void {

--- a/src/list/source/lists.ts
+++ b/src/list/source/lists.ts
@@ -2,6 +2,7 @@ import { Neovim } from '@chemzqm/neovim'
 import { IList, ListContext, ListItem } from '../../types'
 import BasicList from '../basic'
 import Mru from '../../model/mru'
+import { formatListItems, UnformattedListItem } from '../formatting'
 
 export default class LinksList extends BasicList {
   public readonly name = 'lists'
@@ -20,12 +21,12 @@ export default class LinksList extends BasicList {
   }
 
   public async loadItems(_context: ListContext): Promise<ListItem[]> {
-    let items: ListItem[] = []
+    let items: UnformattedListItem[] = []
     let mruList = await this.mru.load()
     for (let list of this.listMap.values()) {
       if (list.name == 'lists') continue
       items.push({
-        label: `${list.name}\t${list.description || ''}`,
+        label: [list.name, ...(list.description ? [list.description] : [])],
         data: {
           name: list.name,
           interactive: list.interactive,
@@ -34,7 +35,7 @@ export default class LinksList extends BasicList {
       })
     }
     items.sort((a, b) => b.data.score - a.data.score)
-    return items
+    return formatListItems(this.alignColumns, items)
   }
 
   public doHighlight(): void {

--- a/src/list/source/services.ts
+++ b/src/list/source/services.ts
@@ -3,6 +3,7 @@ import services from '../../services'
 import { ListContext, ListItem } from '../../types'
 import BasicList from '../basic'
 import { wait } from '../../util'
+import { formatListItems } from '../formatting'
 
 export default class ServicesList extends BasicList {
   public defaultAction = 'toggle'
@@ -22,13 +23,13 @@ export default class ServicesList extends BasicList {
   public async loadItems(_context: ListContext): Promise<ListItem[]> {
     let stats = services.getServiceStats()
     stats.sort((a, b) => a.id > b.id ? -1 : 1)
-    return stats.map(stat => {
+    return formatListItems(this.alignColumns, stats.map(stat => {
       let prefix = stat.state == 'running' ? '*' : ' '
       return {
-        label: `${prefix}\t${stat.id}\t[${stat.state}]\t${stat.languageIds.join(', ')}`,
+        label: [prefix, stat.id, `[${stat.state}]`, stat.languageIds.join(', ')],
         data: { id: stat.id }
       }
-    })
+    }))
   }
 
   public doHighlight(): void {

--- a/src/list/source/symbols.ts
+++ b/src/list/source/symbols.ts
@@ -10,7 +10,7 @@ import { getSymbolKind } from '../../util/convert'
 import { isParentFolder } from '../../util/fs'
 import { score } from '../../util/fzy'
 import { CancellationToken, CancellationTokenSource } from 'vscode-languageserver-protocol'
-import { formatPath } from '../formatting'
+import { formatListItems, formatPath, UnformattedListItem } from '../formatting'
 const logger = require('../../util/logger')('list-symbols')
 
 export default class Symbols extends LocationList {
@@ -37,7 +37,7 @@ export default class Symbols extends LocationList {
     }
     let config = this.getConfig()
     let excludes = config.get<string[]>('excludes', [])
-    let items: ListItem[] = []
+    let items: UnformattedListItem[] = []
     for (let s of symbols) {
       let kind = getSymbolKind(s.kind)
       if (filterKind && kind.toLowerCase() != filterKind) {
@@ -51,7 +51,7 @@ export default class Symbols extends LocationList {
         continue
       }
       items.push({
-        label: `${s.name}\t[${kind}]\t${file}`,
+        label: [s.name, `[${kind}]`, file],
         filterText: `${s.name}`,
         location: s.location,
         data: { original: s, kind: s.kind, file, score: score(input, s.name) }
@@ -66,7 +66,7 @@ export default class Symbols extends LocationList {
       }
       return a.data.file.length - b.data.file.length
     })
-    return items
+    return formatListItems(this.alignColumns, items)
   }
 
   public async resolveItem(item: ListItem): Promise<ListItem> {

--- a/src/list/source/symbols.ts
+++ b/src/list/source/symbols.ts
@@ -10,6 +10,7 @@ import { getSymbolKind } from '../../util/convert'
 import { isParentFolder } from '../../util/fs'
 import { score } from '../../util/fzy'
 import { CancellationToken, CancellationTokenSource } from 'vscode-languageserver-protocol'
+import { formatPath } from '../formatting'
 const logger = require('../../util/logger')('list-symbols')
 
 export default class Symbols extends LocationList {
@@ -50,7 +51,7 @@ export default class Symbols extends LocationList {
         continue
       }
       items.push({
-        label: `${s.name} [${kind}]\t${file}`,
+        label: `${s.name}\t[${kind}]\t${file}`,
         filterText: `${s.name}`,
         location: s.location,
         data: { original: s, kind: s.kind, file, score: score(input, s.name) }
@@ -90,7 +91,7 @@ export default class Symbols extends LocationList {
     let { nvim } = this
     nvim.pauseNotification()
     nvim.command('syntax match CocSymbolsName /\\v^\\s*\\S+/ contained containedin=CocSymbolsLine', true)
-    nvim.command('syntax match CocSymbolsKind /\\[\\w\\+\\]\\t/ contained containedin=CocSymbolsLine', true)
+    nvim.command('syntax match CocSymbolsKind /\\[\\w\\+\\]\\s*\\t/ contained containedin=CocSymbolsLine', true)
     nvim.command('syntax match CocSymbolsFile /\\S\\+$/ contained containedin=CocSymbolsLine', true)
     nvim.command('highlight default link CocSymbolsName Normal', true)
     nvim.command('highlight default link CocSymbolsKind Typedef', true)

--- a/src/list/ui.ts
+++ b/src/list/ui.ts
@@ -8,6 +8,7 @@ import { Mutex } from '../util/mutex'
 import workspace from '../workspace'
 import window from '../window'
 import ListConfiguration from './configuration'
+import { alignElements } from './formatting'
 const logger = require('../util/logger')('list-ui')
 
 export type MouseEvent = 'mouseDown' | 'mouseDrag' | 'mouseUp' | 'doubleClick'
@@ -348,7 +349,11 @@ export default class ListUI {
     release()
     if (token && token.isCancellationRequested) return
     if (count !== this.drawCount) return
-    let lines = this.items.map(item => item.label)
+
+    const lines = this.config.get('alignColumns')
+      ? alignElements(this.items.map(item => item.label.split("\t")))
+      : this.items.map(item => item.label)
+
     this.clearSelection()
     let newIndex = reload ? this.currIndex : 0
     await this.setLines(lines, false, newIndex)

--- a/src/list/ui.ts
+++ b/src/list/ui.ts
@@ -8,7 +8,6 @@ import { Mutex } from '../util/mutex'
 import workspace from '../workspace'
 import window from '../window'
 import ListConfiguration from './configuration'
-import { alignElements } from './formatting'
 const logger = require('../util/logger')('list-ui')
 
 export type MouseEvent = 'mouseDown' | 'mouseDrag' | 'mouseUp' | 'doubleClick'
@@ -350,9 +349,7 @@ export default class ListUI {
     if (token && token.isCancellationRequested) return
     if (count !== this.drawCount) return
 
-    const lines = this.config.get('alignColumns')
-      ? alignElements(this.items.map(item => item.label.split("\t")))
-      : this.items.map(item => item.label)
+    const lines = this.items.map(item => item.label)
 
     this.clearSelection()
     let newIndex = reload ? this.currIndex : 0

--- a/src/types.ts
+++ b/src/types.ts
@@ -530,6 +530,8 @@ export interface DiagnosticItem {
   file: string
   lnum: number
   col: number
+  source: string
+  code: string | number
   message: string
   severity: string
   level: number


### PR DESCRIPTION
This PR implements improved formatting options for CocList as proposed in #2630.  Specifically, it adds the option to align the content of CocLists in columns, making it look much nicer.

Additionally, it adds a couple options to configure what is shown in the diagnostics output, making the filepath and diagnostic-code configurable. 

## Example images

### Outline view
![coc-showcase-1](https://user-images.githubusercontent.com/5300871/99919904-89db8300-2d20-11eb-88c0-d695439cd5d7.png)

### lists list
![coc-showcase-2](https://user-images.githubusercontent.com/5300871/99919905-8c3ddd00-2d20-11eb-8cde-1df4c6b6d592.png)

### Commands list
![coc-showcase-3](https://user-images.githubusercontent.com/5300871/99919916-a1b30700-2d20-11eb-991c-16fb0eebfb86.png)

### Diagnostics list with minimal configuration
Here the only the filename is shown, and the error code is completely hidden
![coc-showcase-4](https://user-images.githubusercontent.com/5300871/99919941-b98a8b00-2d20-11eb-81be-2c1755d84100.png)

### Diagnostics list with more data
Here a shortened version of the path is shown
![coc-showcase-5](https://user-images.githubusercontent.com/5300871/99919952-ceffb500-2d20-11eb-8eb8-c74492563f3a.png)

