### PR TITLE
Fix extension installer with pnpm

### DIFF
--- a/src/model/installer.ts
+++ b/src/model/installer.ts
@@ -118,7 +118,7 @@ export class Installer extends EventEmitter {
         if (url.startsWith('https://github.com')) {
           args = ['install']
         }
-        if (this.npm.endsWith('npm')) {
+        if (this.npm.endsWith('npm') && !this.npm.endsWith('pnpm')) {
           args.push('--legacy-peer-deps')
         }
         if (this.npm.endsWith('yarn')) {


### PR DESCRIPTION
pnpm doesn't have the `--legacy-peer-deps` arguments, which results in an error when installing some extensions:

```
 ERROR  Unknown option: 'legacy-peer-deps'
Did you mean 'strict-peer-dependencies'? Use "--config.unknown=value" to force an unknown option.
For help, run: pnpm help instal
```