### PR TITLE
feat(plugin): use tabe for CocOpenLog

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -115,7 +115,7 @@ export default class Plugin extends EventEmitter {
     })
     this.addAction('openLog', async () => {
       let file = logger.getLogFile()
-      await workspace.jumpTo(URI.file(file).toString())
+      await workspace.jumpTo(URI.file(file).toString(), null, 'tabe')
     })
     this.addAction('attach', () => {
       return workspace.attach()


### PR DESCRIPTION
~By default `CocOpenLog` will open log file by `edit` in current buffer, it's better to use `tabe` for log view.~

Update: default behavior will follow `coc.preferences.jumpCommand`, but I think it's better to use tab...