### PR TITLE
feat(language-client): progress notification for workDoneProgress

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -805,6 +805,12 @@
         "type": "string"
       }
     },
+    "workspace.progressTarget": {
+      "type": "string",
+      "default": "float",
+      "description": "Target to show workDoneProgress, default is floating window when possible.",
+      "enum": ["statusline", "float"]
+    },
     "list.indicator": {
       "type": "string",
       "default": ">",


### PR DESCRIPTION
<img width="652" alt="截屏2020-12-08 17 17 49" src="https://user-images.githubusercontent.com/345274/101464244-5e3fd600-3979-11eb-8d16-cfc9a566aa93.png">

Add `workspace.progressTarget` configuration, default is `float`.