### PR TITLE
feat(language-client): done notification with timeout

### DIFF
--- a/src/language-client/progressPart.ts
+++ b/src/language-client/progressPart.ts
@@ -113,16 +113,15 @@ export class ProgressPart {
     if (message && this._progressTarget === 'statusline') {
       const statusBarItem = this.statusBarItem
       statusBarItem.text = `${this.title} ${message}`
-      setTimeout(() => {
-        this.cancel()
-      }, 300)
     } else {
       if (this._resolve) {
         this._resolve()
         this._resolve = undefined
         this._reject = undefined
       }
-      this.cancel()
     }
+    setTimeout(() => {
+      this.cancel()
+    }, 300)
   }
 }


### PR DESCRIPTION
Some notification is too short to display, and disappear in a flash, it's better to remove it with a timeout.

```
2020-12-09T11:58:45.236 ERROR (pid:91407) [language-client-progressPart] - --begin
2020-12-09T11:58:45.245 ERROR (pid:91407) [language-client-progressPart] - --end
```