### PR TITLE
fix(completion): checkTrigger for triggerSources

### DIFF
--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -314,7 +314,7 @@ export class Completion implements Disposable {
       if (!latestInsertChar) return
       let triggerSources = sources.getTriggerSources(pretext, doc.filetype)
       if (triggerSources.length) {
-        await this.triggerCompletion(doc, this.pretext, false)
+        await this.triggerCompletion(doc, this.pretext)
         return
       }
       this.triggerTimer = setTimeout(async () => {


### PR DESCRIPTION
The point of 365c63e optimization is get trigger sources first before triggerCompletion, then disable checkTrigger to improve perf, did I understand correctly? @chemzqm . But source trigger checking doesn't check suggest.autoTrigger, this causes the issue.

This is a quick fix to #2728, maybe we need to refactor trigger  completions checking, include autoTrigger checking, sources trigger checking, coc_suggest_disable, blacklist etc.

close #2728