### PR TITLE
refactor resolveRoot

### DIFF
--- a/src/__tests__/modules/util.test.ts
+++ b/src/__tests__/modules/util.test.ts
@@ -159,7 +159,7 @@ describe('resolveRoot', () => {
   it('should resolve from parent folders', () => {
     let root = path.resolve(__dirname, '../extensions/snippet-sample')
     let res = resolveRoot(root, ['package.json'])
-    expect(res.endsWith('coc.nvim')).toBe(true)
+    expect(res.endsWith('extensions')).toBe(true)
   })
 
   it('should not resolve to home', () => {

--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -62,13 +62,15 @@ export function resolveRoot(folder: string, subs: string[], cwd?: string): strin
   if (isParentFolder(dir, home, true)) return null
   if (cwd && isParentFolder(cwd, dir, true) && inDirectory(cwd, subs)) return cwd
   let parts = dir.split(path.sep)
-  let curr: string[] = [parts.shift()]
-  for (let part of parts) {
-    curr.push(part)
-    let dir = curr.join(path.sep)
+  while (parts.length > 0) {
+    let dir = parts.join(path.sep)
+    if (dir == home) {
+        break
+    }
     if (dir != home && inDirectory(dir, subs)) {
       return dir
     }
+    parts.pop()
   }
   return null
 }


### PR DESCRIPTION
This commit uses the "shift-right" way to find workspace folders.

Earlier version starts from root "/" until the path of the current file,
stopping at where the root patterns are found. The new version starts
from the current file and traverse upwards.

It aims to fix the situation of "embeded" workspaces usually seen in
monorepo. For example, a monorepo root has a ServiceA folder,
"ServiceRoot/ServiceA", both of which have files matching root patterns.
The expected workspace folder should be ServiceRoot/ServiceA, but not
ServiceRoot.

This issue is triggered when jumping from other workspace folder like
ServiceRoot/ServiceB.

Another example is using vim-plug which clones coc.nvim in
~/.vim/plugged folder. It resolves to ~/.vim which contains .git, while the
expected result is ~/.vim/plugged/coc.nvim.