### PR TITLE
fix: gotoDefinition workaround for java on Windows

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -157,8 +157,15 @@ function! coc#util#jump(cmd, filepath, ...) abort
   if (has('win32unix'))
     let path = substitute(a:filepath, '\v\\', '/', 'g')
   endif
-  let file = fnamemodify(path, ":~:.")
-  exe a:cmd.' '.fnameescape(file)
+  " Workaround for https://github.com/neoclide/coc-java/issues/82
+  if has('win32') && !has('win32unix') && path =~ "jdt://"
+    enew
+    call nvim_buf_set_name(0, path)
+    exe a:cmd.' %'
+  else
+    let file = fnamemodify(path, ":~:.")
+    exe a:cmd.' '.fnameescape(file)
+  endif
   if !empty(get(a:, 1, []))
     let line = getline(a:1[0] + 1)
     " TODO need to use utf16 here

--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -158,7 +158,7 @@ function! coc#util#jump(cmd, filepath, ...) abort
     let path = substitute(a:filepath, '\v\\', '/', 'g')
   endif
   " Workaround for https://github.com/neoclide/coc-java/issues/82
-  if has('win32') && !has('win32unix') && path =~ "jdt://"
+  if has('nvim') && has('win32') && !has('win32unix') && path =~ "jdt://"
     enew
     call nvim_buf_set_name(0, path)
     exe a:cmd.' %'

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -27,7 +27,8 @@ export function wait(ms: number): Promise<any> {
 
 export function getUri(fullpath: string, id: number, buftype: string, isCygwin: boolean): string {
   if (!fullpath) return `untitled:${id}`
-  if (platform.isWindows && !isCygwin) fullpath = path.win32.normalize(fullpath)
+  // Last conditional is workaround for https://github.com/neoclide/coc-java/issues/82
+  if (platform.isWindows && !isCygwin && !fullpath.startsWith('jdt://')) fullpath = path.win32.normalize(fullpath)
   if (path.isAbsolute(fullpath)) return URI.file(fullpath).toString()
   if (isuri.isValid(fullpath)) return URI.parse(fullpath).toString()
   if (buftype != '') return `${buftype}:${id}`


### PR DESCRIPTION
Fixes: https://github.com/neoclide/coc-java/issues/82

Adds specific workarounds to fix "go to definition" functionality on Windows.
Two workarounds are implemented:

As the `:edit` command was failing, we instead call `nvim_buf_set_name` to set the buffer name without expansion. Then we `:edit` the current file in order to run autocommands.

Additionally, the URI of the loaded definition was `unknown:2`, which is incorrect. So we do not normalize the path when in a `jdt://` file.
