### PR TITLE
fix(lens-destruct): default to empty object

### DIFF
--- a/src/handler/codelens/buffer.ts
+++ b/src/handler/codelens/buffer.ts
@@ -162,7 +162,7 @@ export default class CodeLensBuffer implements BufferSyncItem {
   }
 
   public async doAction(line: number): Promise<void> {
-    let { codeLenses } = this.codeLenses
+    let { codeLenses } = this.codeLenses ?? {}
     if (!codeLenses || codeLenses.length == 0) {
       window.showMessage('No codeLenses available', 'warning')
       return


### PR DESCRIPTION
I had this error happening in vim8.2:

![image](https://user-images.githubusercontent.com/33961674/103293368-13513580-49f0-11eb-8811-4977401e1107.png)

and it turns out to be this line