### PR TITLE
use empty line to delimit hover contents for preview target 

### DIFF
--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -811,7 +811,7 @@ export default class Handler {
     }
     let lines = docs.reduce((p, c) => {
       let arr = c.content.split(/\r?\n/)
-      if (p.length > 0) p.push('---')
+      if (p.length > 0) p.push('')
       p.push(...arr)
       return p
     }, [])


### PR DESCRIPTION
`"coc.preferences.hoverTarget": "preview"` uses vim's markdown syntax
plugin, which usually highlights

<pre>
text
---
</pre>

as a markdown header. ~~To prevent this, insert a newline before '---'.~~

**Before**:
![image](https://user-images.githubusercontent.com/19489738/103452803-94713b00-4d16-11eb-9292-eb7dd2968ddc.png)

**After**:
<!--![image](https://user-images.githubusercontent.com/19489738/103452807-9f2bd000-4d16-11eb-8900-a1456a993ac7.png) -->
![image](https://user-images.githubusercontent.com/19489738/103456151-f80b6080-4d36-11eb-931f-eb465dca5a0f.png)

## Note
* ~~This somehow doesn't add the newline for `"coc.preferences.hoverTarget": "float"`, so it won't disturb users using that option.~~
* Ideally, it'd be great if `"coc.preferences.hoverTarget": "preview"` can make use of the markdown renderer that `"float"` is using.   