### PR TITLE
Fix typo on list.source.symbols.exclude documentation

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -909,7 +909,7 @@
     "list.source.symbols.excludes": {
       "type": "array",
       "default": [],
-      "description": "Patterns of mimimatch for filepath to execlude from symbols list.",
+      "description": "Patterns of minimatch for filepath to execlude from symbols list.",
       "items": {
         "type": "string"
       }

--- a/doc/coc.cnx
+++ b/doc/coc.cnx
@@ -596,7 +596,7 @@ Built-in configurations:~
 
 "list.source.symbols.excludes":~
 
-	Patterns of mimimatch for filepath to execlude from symbols list,
+	Patterns of minimatch for filepath to execlude from symbols list,
 	default: `[]`
 
 "list.source.outline.ctagsFilestypes":~

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -662,7 +662,7 @@ Built-in configurations:~
 
 "list.source.symbols.excludes":~
 
-	Patterns of mimimatch for filepath to execlude from symbols list,
+	Patterns of minimatch for filepath to execlude from symbols list,
 	default: `[]`
 
 "list.source.outline.ctagsFilestypes":~


### PR DESCRIPTION
Signed-off-by: Zasda Yusuf Mikail <zasdaym@gmail.com>