### PR TITLE
feat(workspace): add option to disable cwd check when resolving root directory

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -800,6 +800,11 @@
         "type": "string"
       }
     },
+    "workspace.checkCwd": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether the cwd directory should be checked first when resolving the root directory"
+    },
     "list.indicator": {
       "type": "string",
       "default": ">",

--- a/data/schema.json
+++ b/data/schema.json
@@ -800,7 +800,7 @@
         "type": "string"
       }
     },
-    "workspace.checkCwd": {
+    "workspace.workspaceFolderCheckCwd": {
       "type": "boolean",
       "default": true,
       "description": "Whether the cwd directory should be checked first when resolving the root directory"

--- a/src/__tests__/modules/util.test.ts
+++ b/src/__tests__/modules/util.test.ts
@@ -177,7 +177,7 @@ describe('resolveRoot', () => {
   it('should resolve to root', () => {
     let root = path.resolve(__dirname, '../extensions/test/')
     let res = resolveRoot(root, ['package.json'], root, false, false)
-    expect(res).toBe(root)
+    expect(res).toBe(path.resolve(__dirname, '../../../'))
   })
 
   it('should not resolve to home', () => {

--- a/src/__tests__/modules/util.test.ts
+++ b/src/__tests__/modules/util.test.ts
@@ -167,13 +167,13 @@ describe('resolveRoot', () => {
     let res = resolveRoot(root, ['package.json'], null, true)
     expect(res.endsWith('extensions')).toBe(true)
   })
-  
+
   it('should resolve to cwd', () => {
     let root = path.resolve(__dirname, '../extensions/test/')
     let res = resolveRoot(root, ['package.json'], root, false, true)
     expect(res).toBe(root)
   })
-  
+
   it('should resolve to root', () => {
     let root = path.resolve(__dirname, '../extensions/test/')
     let res = resolveRoot(root, ['package.json'], root, false, false)

--- a/src/__tests__/modules/util.test.ts
+++ b/src/__tests__/modules/util.test.ts
@@ -167,6 +167,18 @@ describe('resolveRoot', () => {
     let res = resolveRoot(root, ['package.json'], null, true)
     expect(res.endsWith('extensions')).toBe(true)
   })
+  
+  it('should resolve to cwd', () => {
+    let root = path.resolve(__dirname, '../extensions/test/')
+    let res = resolveRoot(root, ['package.json'], root, false, true)
+    expect(res).toBe(root)
+  })
+  
+  it('should resolve to root', () => {
+    let root = path.resolve(__dirname, '../extensions/test/')
+    let res = resolveRoot(root, ['package.json'], root, false, false)
+    expect(res).toBe(root)
+  })
 
   it('should not resolve to home', () => {
     let res = resolveRoot(__dirname, ['.config'])

--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -56,11 +56,11 @@ export async function isGitIgnored(fullpath: string): Promise<boolean> {
   return false
 }
 
-export function resolveRoot(folder: string, subs: string[], cwd?: string, bottomup = false): string | null {
+export function resolveRoot(folder: string, subs: string[], cwd?: string, bottomup = false, checkCwd = true): string | null {
   let home = os.homedir()
   let dir = fixDriver(folder)
   if (isParentFolder(dir, home, true)) return null
-  if (cwd && isParentFolder(cwd, dir, true) && inDirectory(cwd, subs)) return cwd
+  if (checkCwd && cwd && isParentFolder(cwd, dir, true) && inDirectory(cwd, subs)) return cwd
   let parts = dir.split(path.sep)
   if (bottomup) {
     while (parts.length > 0) {

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1529,11 +1529,12 @@ augroup end`
     let { cwd } = this
     let config = this.getConfiguration('workspace')
     let bottomUpFileTypes = config.get<string[]>('workspaceFolderBottomUpFiletypes', [])
+    let checkCwd = config.get<boolean>('checkCwd', true)
     for (let patternType of types) {
       let patterns = this.getRootPatterns(document, patternType)
       if (patterns && patterns.length) {
         let isBottomUp = bottomUpFileTypes.includes(document.filetype)
-        let root = resolveRoot(dir, patterns, cwd, isBottomUp)
+        let root = resolveRoot(dir, patterns, cwd, isBottomUp, checkCwd)
         if (root) return root
       }
     }

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1529,7 +1529,7 @@ augroup end`
     let { cwd } = this
     let config = this.getConfiguration('workspace')
     let bottomUpFileTypes = config.get<string[]>('workspaceFolderBottomUpFiletypes', [])
-    let checkCwd = config.get<boolean>('checkCwd', true)
+    let checkCwd = config.get<boolean>('workspaceFolderCheckCwd', true)
     for (let patternType of types) {
       let patterns = this.getRootPatterns(document, patternType)
       if (patterns && patterns.length) {


### PR DESCRIPTION
### Why?

When resolving the root directory, the current working directory is checked before doing a top-down search:

https://github.com/neoclide/coc.nvim/blob/f3b4a47780829f663740f1d276879060b45e8923/src/util/fs.ts#L63

In some cases, it is preferable to skip this check and *always* do a top-down search, particularly in some mono-repo setups.

### How?

This PR adds the option `workspace.workspaceFolderCheckCwd`, which defaults to `true`, so the default behaviour is unchanged. When this option is set to `false`, the current working directory is not checked.