### PR TITLE
Improvements for prompt win in vim

### DIFF
--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -550,6 +550,8 @@ function! coc#float#create_prompt_win(title, default, opts) abort
     exe 'nnoremap <silent><buffer> <esc> :call coc#float#close('.winid.')<CR>'
     exe 'inoremap <silent><expr><nowait><buffer> <cr> "\<C-r>=coc#float#prompt_insert(getline(''.''))\<cr>\<esc>"'
     call feedkeys('A', 'in')
+  else
+    call setbufvar(bufnr, '&termwinkey', '<C-\>')
   endif
   return [bufnr, winid]
 endfunction

--- a/bin/prompt.js
+++ b/bin/prompt.js
@@ -2,11 +2,10 @@
  * Used for prompt popup on vim
  */
 const readline = require("readline")
-readline.emitKeypressEvents(process.stdin)
-process.stdin.setRawMode(true)
 const rl = readline.createInterface({
   input: process.stdin,
-  output: process.stdout
+  output: process.stdout,
+  escapeCodeTimeout: 0
 })
 rl.setPrompt('')
 let value = process.argv[2]


### PR DESCRIPTION
- `termwinkey` default to <kbd>C-W</kbd> in Vim, thus we must press <kbd>C-W .</kbd> to delete word -> set `termwinkey` to <kbd>C-\\</kbd> in prompt win buffer
- <kbd>ESC</kbd> is not recognized immediately in prompt win -> set `escapeCodeTimeout=0`