### PR TITLE
feat: CocListClose event

### DIFF
--- a/src/list/session.ts
+++ b/src/list/session.ts
@@ -304,7 +304,10 @@ export default class ListSession {
         await wait(10)
       }
     }
+    nvim.pauseNotification()
     nvim.call('coc#prompt#stop_prompt', ['list'], true)
+    nvim.call('coc#util#do_autocmd', ['CocListClose'], true)
+    await nvim.resumeNotification()
   }
 
   public toggleMode(): void {


### PR DESCRIPTION
I use `CocList name` in coc-explorer, but in the floating window, I need to rerender explorer when the `CocList` is closed, so I need something like this.
I named it `CocListClose`, if there is a better name or solution, I can adjust it.