### PR TITLE
perf: tree-shaking package.json

### DIFF
--- a/src/attach.ts
+++ b/src/attach.ts
@@ -5,6 +5,8 @@ import Plugin from './plugin'
 import semver from 'semver'
 import { objectLiteral } from './util/is'
 import { URI } from 'vscode-uri'
+import { version as VERSION } from '../package.json'
+
 const logger = require('./util/logger')('attach')
 const isTest = global.hasOwnProperty('__TEST__')
 
@@ -104,8 +106,7 @@ export default (opts: Attach, requestApi = true): Plugin => {
     clientReady = true
     // Used for test client on vim side
     if (isTest) nvim.command(`let g:coc_node_channel_id = ${channelId}`, true)
-    let json = require('../package.json')
-    let { major, minor, patch } = semver.parse(json.version)
+    let { major, minor, patch } = semver.parse(VERSION)
     nvim.setClientInfo('coc', { major, minor, patch }, 'remote', {}, {})
     let entered = await nvim.getVvar('vim_did_enter')
     if (entered && !initialized) {

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -32,6 +32,7 @@ import { getChangedFromEdits } from './util/position'
 import { byteIndex, byteLength } from './util/string'
 import Watchman from './watchman'
 import window from './window'
+import { version as VERSION } from '../package.json'
 
 const APIVERSION = 8
 const logger = require('./util/logger')('workspace')
@@ -106,8 +107,7 @@ export class Workspace implements IWorkspace {
   public readonly configurations: Configurations
 
   constructor() {
-    let json = require('../package.json')
-    this.version = json.version
+    this.version = VERSION
     this.configurations = this.createConfigurations()
     let cwd = process.cwd()
     if (cwd != os.homedir() && inDirectory(cwd, ['.vim'])) {


### PR DESCRIPTION
```
➜  coc.nvim git:(master) wc -l build/before.js 
   65662 build/before.js
➜  coc.nvim git:(master) wc -l build/index.js 
   65540 build/index.js
➜  coc.nvim git:(master) cat build/before.js | grep coverageDirectory
      coverageDirectory: "./coverage/"
➜  coc.nvim git:(master) cat build/index.js | grep coverageDirectory 
➜  coc.nvim git:(master) 
```

and

```
➜  coc.nvim git:(master) cat build/index.js | grep "// package.json" -C 5 --line-number 
42957-  if (isParentFolder(os5.default.tmpdir(), root, true))
42958-    return false;
42959-  return true;
42960-}
42961-
42962:// package.json
42963-var version = "0.0.80";
42964-
42965-// src/workspace.ts
42966-var APIVERSION = 8;
42967-var logger24 = require_logger2()("workspace");
```