### PR TITLE
feat(diagnostic): reverse on virtualText

### DIFF
--- a/src/diagnostic/buffer.ts
+++ b/src/diagnostic/buffer.ts
@@ -182,7 +182,7 @@ export class DiagnosticBuffer implements BufferSyncItem {
       })
     }
     buffer.clearNamespace(srcId)
-    for (let diagnostic of diagnostics) {
+    for (let diagnostic of [...diagnostics].reverse()) {
       let { line } = diagnostic.range.start
       let highlight = getNameFromSeverity(diagnostic.severity) + 'VirtualText'
       let msg = diagnostic.message.split(/\n/)


### PR DESCRIPTION
`diagnostic/manager` will sort diagnostics by severity `a.severity - b.severity`.

For example diagnostics from LS: `[{message: A, severity: 4}, {message: B, severity: 1}, {message: C, severity: 2}]`

After the sorting `[{message: B, severity: 1}, {message: C, severity: 2}, {message: A, severity: 4}]`.

Because `severity: 1`'s level is Error, the sorted diagnostics is OK in `:CocList diagnostics` or `CocDiagnostics`, error diagnostic will be listed at first.

But coc will setVirtualText following the sorted, this make `{message: A, severity: 4}` be displayed in virtual text. It's better to display error level diagnostic.