### PR TITLE
fix(languages): don't set item.data if undefined

### DIFF
--- a/src/languages.ts
+++ b/src/languages.ts
@@ -734,8 +734,7 @@ class Languages {
       }
     }
     if (item.preselect) obj.preselect = true
-    item.data = item.data || {}
-    if (item.data.optional) obj.abbr = obj.abbr + '?'
+    if (item.data?.optional) obj.abbr = obj.abbr + '?'
     return obj
   }
 }


### PR DESCRIPTION
```
/**
 * An data entry field that is preserved on a completion item between
 * a [CompletionRequest](#CompletionRequest) and a [CompletionResolveRequest]
 * (#CompletionResolveRequest)
 */
data?: any;
```

`completionItem.data` is used to preserve custom data for LS, should be set by LS. If LS didn't set data, coc should not set it, otherwise, LS checked `data` is not null, LS will try to get custom data in the `CompletionResolveRequest`, this makes an error. https://github.com/fannheyward/coc-rust-analyzer/issues/597