### PR TITLE
fix: applyEdits newline in win32

### DIFF
--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -291,6 +291,8 @@ export default class Document {
     let textDocument = TextDocument.create(this.uri, this.filetype, 1, current)
     // apply edits to current textDocument
     let applied = TextDocument.applyEdits(textDocument, edits)
+    // avoid \r\n on Windows platform
+    applied = applied.replace(/\r\n/g, '\n')
     // could be equal sometimes
     if (current !== applied) {
       let newLines = (this.eol && applied.endsWith('\n') ? applied.slice(0, -1) : applied).split('\n')

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -9,6 +9,7 @@ import { diffLines, getChange } from '../util/diff'
 import { disposeAll, getUri, wait } from '../util/index'
 import { Mutex } from '../util/mutex'
 import { equals } from '../util/object'
+import { isWindows } from '../util/platform'
 import { byteLength, byteSlice } from '../util/string'
 import { Chars } from './chars'
 import { LinesTextDoucment } from './textdocument'
@@ -291,8 +292,10 @@ export default class Document {
     let textDocument = TextDocument.create(this.uri, this.filetype, 1, current)
     // apply edits to current textDocument
     let applied = TextDocument.applyEdits(textDocument, edits)
-    // avoid \r\n on Windows platform
-    applied = applied.replace(/\r\n/g, '\n')
+    if (isWindows) {
+      // avoid \r\n on Windows platform
+      applied = applied.replace(/\r\n/g, '\n')
+    }
     // could be equal sometimes
     if (current !== applied) {
       let newLines = (this.eol && applied.endsWith('\n') ? applied.slice(0, -1) : applied).split('\n')


### PR DESCRIPTION
Our `getDocumentContent()` uses `\n`, but `applyEdits()` returns `\r\n`, causing redundant characters to appear on Windows

![image](https://user-images.githubusercontent.com/1709861/108140065-4cf31280-70fc-11eb-9079-0aa0fe8b4419.png)
