### PR TITLE
Fix textEdit when start of the range of the textEdit is after the start of current word

### DIFF
--- a/src/util/complete.ts
+++ b/src/util/complete.ts
@@ -25,7 +25,7 @@ export function getWord(item: CompletionItem, opt: CompleteOption, invalidInsert
       let { line, col, colnr } = opt
       let character = characterIndex(line, col)
       if (range.start.character > character) {
-        let before = line.slice(character - range.start.character)
+        let before = line.slice(character, range.start.character)
         newText = before + newText
       } else {
         let start = line.slice(range.start.character, character)


### PR DESCRIPTION
This pull request solve the issue descibed below.

I found coc.nvim cannot apply the textEdit as it is, when the start point of the range of this textEdit is after the start of the current word. For example, if I have a line like
```
bbbverynewtext
```
with the cursor at the end. Then I pressed `<TAB>` to select the entry like
```typescript
label: 'newText',
sortText: context.option.input,
filterText: context.option.input,
textEdit: {
  range: {
    start: { line: 0, character: 3 },
    end: { line: 0, character: 14 }
  },
  newText: 'newText'
}
```
and I expect the text to be
```
bbbnewText
```
Sometimes coc.nvim gets it right, but most of the time I get some like
```
bbtnewText
bxtnewText
extnewText
```
However, if I selected this entry and confirm it with `<cr>`, then the textEdit will applied as I expect.

The way to reproduce this bug is as follows

- Clone a sample plugin that will generate a completion that cause this bug.
```sh
git clone https://github.com/tonyfettes/coc-rime.git
git checkout textedit
```

- Create file `mini.vim` with：

```vim
" Change /path/to/coc.nvim to your coc.nvim installation location
set runtimepath^=/path/to/coc.nvim
" Change /path/to/sample/plugin to where the plugin you download in last step is.
set runtimepath^=/path/to/buggy/plugin
set hidden
set nobackup
set nowritebackup
set cmdheight=2
set updatetime=300
set shortmess+=c
inoremap <silent><expr> <TAB>
      \ pumvisible() ? "\<C-n>" :
      \ <SID>check_back_space() ? "\<TAB>" :
      \ coc#refresh()
inoremap <expr><S-TAB> pumvisible() ? "\<C-p>" : "\<C-h>"

function! s:check_back_space() abort
  let col = col('.') - 1
  return !col || getline('.')[col - 1]  =~# '\s'
endfunction
```

- Start neovim with command: `nvim -u mini.vim`

- Go to insert mode, type
```
bbbverynewtext
```
and press `<TAB>`.

## Screenshots (optional)

![screenshot_2021_02_17_21_39_42](https://user-images.githubusercontent.com/29998228/108212369-bf99d780-7168-11eb-8e8b-1bed783be829.png)
