### PR TITLE
Match code action on startsWith rather than exact match

### DIFF
--- a/src/provider/codeActionmanager.ts
+++ b/src/provider/codeActionmanager.ts
@@ -56,14 +56,14 @@ export default class CodeActionManager extends Manager<CodeActionProvider> imple
           } else {
             if (context.only) {
               if (!action.kind) continue
-              let { only } = context
-              if (intersect(only, [CodeActionKind.Source, CodeActionKind.Refactor])) {
-                if (!only.includes(action.kind.split('.', 2)[0])) {
-                  continue
+              let found = false
+              for (let only of context.only) {
+                if (action.kind.startsWith(only)) {
+                  found = true
+                  break
                 }
-              } else if (!context.only.includes(action.kind)) {
-                continue
               }
+              if (!found) continue
             }
             let idx = res.findIndex(o => o.title == action.title)
             if (idx == -1) res.push(Object.assign({ clientId }, action))


### PR DESCRIPTION
Fixes #2877

@chemzqm like discussed in #2877 [the vscode docs](https://github.com/microsoft/vscode-languageserver-node/blob/b90b25cc4c69824a948af71ec29e1e3c6de019d8/types/src/main.ts#L2722-L2729) state the following:

> Kinds are a hierarchical list of identifiers separated by `.`, e.g. `"refactor.extract.function"`

Meaning that it makes more sense to match the only using a startsWith (to catch only the base) rather than doing an exact match since the kind `quickfix` is a quickfix but `quickfix.something.else` is still a quickfix and should thus be matched by the only `quickfix`

I chose to do startsWith instead of splitting and checking the parts since it simplifies the code and also allows people to do some more rough matching if they want