### PR TITLE
fix(workspace): fire BufReadCmd for scheme:/

### DIFF
--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1227,7 +1227,7 @@ export class Workspace implements IWorkspace {
     let schemes = this.schemeProviderMap.keys()
     let cmds: string[] = []
     for (let scheme of schemes) {
-      cmds.push(`autocmd BufReadCmd,FileReadCmd,SourceCmd ${scheme}://* call coc#rpc#request('CocAutocmd', ['BufReadCmd','${scheme}', expand('<amatch>')])`)
+      cmds.push(`autocmd BufReadCmd,FileReadCmd,SourceCmd ${scheme}:/* call coc#rpc#request('CocAutocmd', ['BufReadCmd','${scheme}', expand('<amatch>')])`)
     }
     for (let [id, autocmd] of this.autocmds.entries()) {
       let args = autocmd.arglist && autocmd.arglist.length ? ', ' + autocmd.arglist.join(', ') : ''


### PR DESCRIPTION
`deno lsp` returns `deno:/xxx` which is handled by VSCode, https://github.com/denoland/deno/issues/9514, coc only supports `deno://xxx`.

@chemzqm  I don't find any _stand_ format in LSP, so you can close if this may cause other problems.