### PR TITLE
add conf file for single js extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@
 
 _True snippet and additional text editing support_
 
-<a href="https://www.zhipin.com/job_detail/b872ed13edf92a701nZz2967ElFW.html" target="_blank"><img src="https://alfs.chigua.cn/dianyou/data/platform/default/20210322/react.jpg"></a>
-
 ## Why?
 
 - 🚀 **Fast**: [instant increment completion](https://github.com/neoclide/coc.nvim/wiki/Completion-with-sources), increment buffer sync using buffer update events.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 _True snippet and additional text editing support_
 
-![qingzhou](https://alfs.chigua.cn/dianyou/data/platform/default/20210322/react.jpg)
+<a href="https://www.zhipin.com/job_detail/b872ed13edf92a701nZz2967ElFW.html" target="_blank"><img src="https://alfs.chigua.cn/dianyou/data/platform/default/20210322/react.jpg"></a>
 
 ## Why?
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 
 _True snippet and additional text editing support_
 
+![qingzhou](https://alfs.chigua.cn/dianyou/data/platform/default/20210322/react.jpg)
+
 ## Why?
 
 - 🚀 **Fast**: [instant increment completion](https://github.com/neoclide/coc.nvim/wiki/Completion-with-sources), increment buffer sync using buffer update events.

--- a/README.md
+++ b/README.md
@@ -299,6 +299,12 @@ Try these steps when you have problem with coc.nvim.
 <a href="https://opencollective.com/cocnvim/backer/9/website?requireActive=false" target="_blank"><img src="https://opencollective.com/cocnvim/backer/9/avatar.svg?requireActive=false"></a>
 <a href="https://opencollective.com/cocnvim/backer/10/website?requireActive=false" target="_blank"><img src="https://opencollective.com/cocnvim/backer/10/avatar.svg?requireActive=false"></a>
 <a href="https://opencollective.com/cocnvim/backer/11/website?requireActive=false" target="_blank"><img src="https://opencollective.com/cocnvim/backer/11/avatar.svg?requireActive=false"></a>
+<a href="https://opencollective.com/cocnvim/backer/12/website?requireActive=false" target="_blank"><img src="https://opencollective.com/cocnvim/backer/12/avatar.svg?requireActive=false"></a>
+<a href="https://opencollective.com/cocnvim/backer/13/website?requireActive=false" target="_blank"><img src="https://opencollective.com/cocnvim/backer/13/avatar.svg?requireActive=false"></a>
+<a href="https://opencollective.com/cocnvim/backer/14/website?requireActive=false" target="_blank"><img src="https://opencollective.com/cocnvim/backer/14/avatar.svg?requireActive=false"></a>
+<a href="https://opencollective.com/cocnvim/backer/15/website?requireActive=false" target="_blank"><img src="https://opencollective.com/cocnvim/backer/15/avatar.svg?requireActive=false"></a>
+<a href="https://opencollective.com/cocnvim/backer/16/website?requireActive=false" target="_blank"><img src="https://opencollective.com/cocnvim/backer/16/avatar.svg?requireActive=false"></a>
+<a href="https://opencollective.com/cocnvim/backer/17/website?requireActive=false" target="_blank"><img src="https://opencollective.com/cocnvim/backer/17/avatar.svg?requireActive=false"></a>
 
 <a href="https://opencollective.com/cocnvim#backer" target="_blank"><img src="https://images.opencollective.com/static/images/become_backer.svg"></a>
 

--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -374,7 +374,7 @@ function! s:funcs.buf_set_lines(bufnr, start, end, strict, ...) abort
       if delCount
         let start = startLnum + len(replacement)
         "8.1.0039
-        call deletebufline(a:bufnr, start, start + delCount - 1)
+        silent call deletebufline(a:bufnr, start, start + delCount - 1)
       endif
     endif
   endif

--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -168,7 +168,7 @@ function! coc#float#create_float_win(winid, bufnr, config) abort
   call setwinvar(winid, '&colorcolumn', 0)
   call setwinvar(winid, '&wrap', 1)
   call setwinvar(winid, '&linebreak', 1)
-  call setwinvar(winid, '&conceallevel', 2)
+  call setwinvar(winid, '&conceallevel', 0)
   let g:coc_last_float_win = winid
   call coc#util#do_autocmd('CocOpenFloat')
   return [winid, bufnr]

--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -846,7 +846,7 @@ function! coc#float#get_config_cursor(lines, config) abort
   if vh <= 0
     return v:null
   endif
-  let maxWidth = coc#helper#min(get(a:config, 'maxWidth', &columns - 1), &columns - 1)
+  let maxWidth = coc#helper#min(get(a:config, 'maxWidth', &columns - 1), &columns - 1, 80)
   if maxWidth < 3
     return v:null
   endif

--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -27,14 +27,10 @@ function! coc#float#has_float() abort
 endfunction
 
 function! coc#float#close_all() abort
-  if !has('nvim') && exists('*popup_clear')
-    call popup_clear()
-    return
-  endif
   let winids = coc#float#get_float_win_list()
   for id in winids
     try
-      if nvim_win_get_var(id, 'float')
+      if getwinvar(id, 'float')
         call coc#float#close(id)
       endif
     catch /E5555:/

--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -33,7 +33,13 @@ function! coc#float#close_all() abort
   endif
   let winids = coc#float#get_float_win_list()
   for id in winids
-    call coc#float#close(id)
+    try
+      if nvim_win_get_var(id, 'float')
+        call coc#float#close(id)
+      endif
+    catch /E5555:/
+      " ignore
+    endtry
   endfor
 endfunction
 

--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -1242,8 +1242,8 @@ function! coc#float#create_buf(bufnr, ...) abort
     if has('nvim')
       call nvim_buf_set_lines(bufnr, 0, -1, v:false, lines)
     else
-      call deletebufline(bufnr, 1, '$')
-      call setbufline(bufnr, 1, lines)
+      silent call deletebufline(bufnr, 1, '$')
+      silent call setbufline(bufnr, 1, lines)
     endif
   endif
   return bufnr

--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -846,7 +846,7 @@ function! coc#float#get_config_cursor(lines, config) abort
   if vh <= 0
     return v:null
   endif
-  let maxWidth = coc#helper#min(get(a:config, 'maxWidth', &columns - 1), &columns - 1, 80)
+  let maxWidth = coc#helper#min(get(a:config, 'maxWidth', &columns - 1), &columns - 1)
   if maxWidth < 3
     return v:null
   endif

--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -503,7 +503,7 @@ function! coc#float#create_prompt_win(title, default, opts) abort
   call coc#float#close_auto_hide_wins()
   " Calculate col
   let curr = win_screenpos(winnr())[1] + wincol() - 2
-  let width = coc#helper#min(max([strdisplaywidth(a:title) + 2, s:prompt_win_width]), &columns - 2)
+  let width = coc#helper#min(max([strdisplaywidth(a:default) + 2, s:prompt_win_width]), &columns - 2)
   if width == &columns - 2
     let col = 0 - curr
   else

--- a/autoload/coc/highlight.vim
+++ b/autoload/coc/highlight.vim
@@ -175,7 +175,7 @@ function! coc#highlight#match_ranges(winid, bufnr, ranges, hlGroup, priority) ab
   endif
   let ids = []
   for range in a:ranges
-    let list = []
+    let pos = []
     let start = range['start']
     let end = range['end']
     for lnum in range(start['line'] + 1, end['line'] + 1)
@@ -189,12 +189,25 @@ function! coc#highlight#match_ranges(winid, bufnr, ranges, hlGroup, priority) ab
       if colStart == colEnd
         continue
       endif
-      call add(list, [lnum, colStart, colEnd - colStart])
+      call add(pos, [lnum, colStart, colEnd - colStart])
     endfor
-    if !empty(list)
+    if !empty(pos)
       let opts = s:clear_match_by_window ? {'window': a:winid} : {}
-      let id = matchaddpos(a:hlGroup, list, a:priority, -1, opts)
-      call add(ids, id)
+      let i = 1
+      let l = []
+      for p in pos
+        call add(l, p)
+        if i % 8 == 0
+          let id = matchaddpos(a:hlGroup, l, a:priority, -1, opts)
+          call add(ids, id)
+          let l = []
+        endif
+        let i += 1
+      endfor
+      if !empty(l)
+        let id = matchaddpos(a:hlGroup, l, a:priority, -1, opts)
+        call add(ids, id)
+      endif
     endif
   endfor
   if !s:clear_match_by_window

--- a/autoload/coc/list.vim
+++ b/autoload/coc/list.vim
@@ -18,7 +18,7 @@ function! coc#list#setlines(bufnr, lines, append)
     silent call appendbufline(a:bufnr, '$', a:lines)
   else
     if exists('*deletebufline')
-      call deletebufline(a:bufnr, len(a:lines) + 1, '$')
+      silent call deletebufline(a:bufnr, len(a:lines) + 1, '$')
     else
       let n = len(a:lines) + 1
       let saved_reg = @"

--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -265,7 +265,7 @@ function! coc#util#preview_info(info, filetype, ...) abort
   setl nobuflisted
   setl nospell
   exe 'setl filetype='.a:filetype
-  setl conceallevel=2
+  setl conceallevel=0
   setl nofoldenable
   for command in a:000
     execute command

--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -914,7 +914,7 @@ endfunction
 function! coc#util#set_buf_lines(bufnr, lines) abort
   let res = setbufline(a:bufnr, 1, a:lines)
   if res == 0
-    call deletebufline(a:bufnr, len(a:lines) + 1, '$')
+    silent call deletebufline(a:bufnr, len(a:lines) + 1, '$')
   endif
 endfunction
 

--- a/data/schema.json
+++ b/data/schema.json
@@ -727,6 +727,25 @@
       "default": 3,
       "description": "Print num lines of trailing context after each match."
     },
+    "hover.target": {
+      "type": "string",
+      "description": "Target to show hover information, default is floating window when possible.",
+      "enum": ["preview", "echo", "float"]
+    },
+    "hover.floatMaxWidth": {
+      "type": "number",
+      "default": 80,
+      "description": "Maximum width of hover float window, not bigger than 80."
+    },
+    "hover.floatMaxHeight": {
+      "type": "number",
+      "description": "Maximum width of hover float window, not bigger than 80."
+    },
+    "hover.autoHide": {
+      "type": "boolean",
+      "default": true,
+      "description": "Automatically hide hover float window on CursorMove or InsertEnter."
+    },
     "dialog.maxHeight": {
       "type": "number",
       "default": 20,
@@ -986,11 +1005,6 @@
       "type": "string",
       "default": "SNIP",
       "description": "Text shown in statusline to indicate snippet session is activated."
-    },
-    "coc.preferences.hoverTarget": {
-      "type": "string",
-      "description": "Target to show hover information, default is floating window when possible.",
-      "enum": ["preview", "echo", "float"]
     },
     "coc.preferences.colorSupport": {
       "type": "boolean",

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -514,6 +514,26 @@ Built-in configurations:~
 
 	Print num lines of trailing context after each match, default: `3`
 
+							*coc-config-hover*
+"hover.target":~
+
+	Target to show hover information, default is floating window when possible.
+
+	Valid options: ["preview", "echo", "float"]
+
+"hover.floatMaxWidth":~
+
+	Maximum width of hover float window, not bigger than 80.
+
+"hover.floatMaxHeight":~
+
+	Maximum height fo hover float window.
+
+"hover.autoHide":~
+
+	Automatically hide hover float window on CursorMove or InsertEnter,
+	default `true`.
+
 							*coc-config-dialog*
 "dialog.maxWidth": ~
 
@@ -726,12 +746,6 @@ Built-in configurations:~
 	Check |coc-status| for statusline integration.
 
 	Default: `"SNIP"`
-
-"coc.preferences.hoverTarget":~
-
-	Target to show hover information, default is floating window when possible.
-
-	Valid options: ["preview", "echo", "float"]
 
 "coc.preferences.previewAutoClose":~
 

--- a/src/__tests__/modules/textdocument.test.ts
+++ b/src/__tests__/modules/textdocument.test.ts
@@ -1,11 +1,11 @@
 import { Position, Range } from 'vscode-languageserver-protocol'
-import { LinesTextDoucment } from '../../model/textdocument'
+import { LinesTextDocument } from '../../model/textdocument'
 
-function createTextDocument(lines: string[]): LinesTextDoucment {
-  return new LinesTextDoucment('file://a', 'txt', 1, lines, true)
+function createTextDocument(lines: string[]): LinesTextDocument {
+  return new LinesTextDocument('file://a', 'txt', 1, lines, true)
 }
 
-describe('LinesTextDoucment', () => {
+describe('LinesTextDocument', () => {
   it('should get line count and content', async () => {
     let doc = createTextDocument(['a', 'b'])
     expect(doc.lineCount).toBe(3)

--- a/src/channels.ts
+++ b/src/channels.ts
@@ -39,7 +39,9 @@ export class Channels {
   public create(name: string, nvim: Neovim): OutputChannel | null {
     if (outputChannels.has(name)) return outputChannels.get(name)
     if (!/^[\w\s-.]+$/.test(name)) throw new Error(`Invalid channel name "${name}", only word characters and white space allowed.`)
-    let channel = new BufferChannel(name, nvim)
+    let channel = new BufferChannel(name, nvim, () => {
+      outputChannels.delete(name)
+    })
     outputChannels.set(name, channel)
     return channel
   }

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -295,7 +295,7 @@ export class Completion implements Disposable {
     }
     // not handle when not triggered by character insert
     if (!hasInsert || !pretext) return
-    if (sources.shouldTrigger(pretext, document.filetype)) {
+    if (sources.shouldTrigger(pretext, document.filetype, document.uri)) {
       await this.triggerCompletion(document, pretext)
     } else {
       await this.resumeCompletion()
@@ -312,7 +312,7 @@ export class Completion implements Disposable {
     // try trigger on character type
     if (!this.activated) {
       if (!latestInsertChar) return
-      let triggerSources = sources.getTriggerSources(pretext, doc.filetype)
+      let triggerSources = sources.getTriggerSources(pretext, doc.filetype, doc.uri)
       if (triggerSources.length) {
         await this.triggerCompletion(doc, this.pretext)
         return
@@ -353,7 +353,7 @@ export class Completion implements Disposable {
       }
     }
     // prefer trigger completion
-    if (sources.shouldTrigger(pretext, doc.filetype)) {
+    if (sources.shouldTrigger(pretext, doc.filetype, doc.uri)) {
       await this.triggerCompletion(doc, pretext)
     } else {
       await this.resumeCompletion()
@@ -450,16 +450,16 @@ export class Completion implements Disposable {
     return latestInsert.character
   }
 
-  public shouldTrigger(document: Document, pre: string): boolean {
+  public shouldTrigger(doc: Document, pre: string): boolean {
     let autoTrigger = this.config.autoTrigger
     if (autoTrigger == 'none') return false
-    if (sources.shouldTrigger(pre, document.filetype)) return true
+    if (sources.shouldTrigger(pre, doc.filetype, doc.uri)) return true
     if (autoTrigger !== 'always' || this.isActivated) return false
     let last = pre.slice(-1)
-    if (last && (document.isWord(pre.slice(-1)) || last.codePointAt(0) > 255)) {
+    if (last && (doc.isWord(pre.slice(-1)) || last.codePointAt(0) > 255)) {
       let minLength = this.config.minTriggerInputLength
       if (minLength == 1) return true
-      let input = this.getInput(document, pre)
+      let input = this.getInput(doc, pre)
       return input.length >= minLength
     }
     return false

--- a/src/handler/helper.ts
+++ b/src/handler/helper.ts
@@ -48,7 +48,7 @@ export function sortDocumentSymbols(a: DocumentSymbol, b: DocumentSymbol): numbe
   return ra.start.character - rb.start.character
 }
 
-export function addDoucmentSymbol(res: SymbolInfo[], sym: DocumentSymbol, level: number): void {
+export function addDocumentSymbol(res: SymbolInfo[], sym: DocumentSymbol, level: number): void {
   let { name, selectionRange, kind, children, range } = sym
   let { start } = selectionRange
   res.push({
@@ -63,7 +63,7 @@ export function addDoucmentSymbol(res: SymbolInfo[], sym: DocumentSymbol, level:
   if (children && children.length) {
     children.sort(sortDocumentSymbols)
     for (let sym of children) {
-      addDoucmentSymbol(res, sym, level + 1)
+      addDocumentSymbol(res, sym, level + 1)
     }
   }
 }

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -830,7 +830,7 @@ export default class Handler {
     }
     if (target == 'float') {
       let opts: FloatWinConfig = { modes: ['n'] }
-      opts.maxWidth = hoverPreference.get('floatMaxWidth', undefined)
+      opts.maxWidth = hoverPreference.get('floatMaxWidth', 80)
       opts.maxHeight = hoverPreference.get('floatMaxHeight', undefined)
       opts.autoHide = hoverPreference.get('autoHide', true)
       await this.hoverFactory.show(docs, opts)

--- a/src/handler/refactor/index.ts
+++ b/src/handler/refactor/index.ts
@@ -33,7 +33,10 @@ export default class Refactor {
     workspace.onDidChangeConfiguration(this.setConfiguration, this, this.disposables)
     workspace.onDidCloseTextDocument(e => {
       let buf = this.buffers.get(e.bufnr)
-      if (buf) this.buffers.delete(e.bufnr)
+      if (buf) {
+        buf.dispose()
+        this.buffers.delete(e.bufnr)
+      }
     }, null, this.disposables)
     workspace.onDidChangeTextDocument(e => {
       let buf = this.buffers.get(e.bufnr)

--- a/src/handler/symbols.ts
+++ b/src/handler/symbols.ts
@@ -10,7 +10,7 @@ import { equals } from '../util/object'
 import { positionInRange, rangeInRange } from '../util/position'
 import window from '../window'
 import workspace from '../workspace'
-import { addDoucmentSymbol, getPreviousContainer, isDocumentSymbols, sortDocumentSymbols, sortSymbolInformations, SymbolInfo } from './helper'
+import { addDocumentSymbol, getPreviousContainer, isDocumentSymbols, sortDocumentSymbols, sortSymbolInformations, SymbolInfo } from './helper'
 
 export default class Symbols {
   private buffers: BufferSync<SymbolsBuffer>
@@ -178,7 +178,7 @@ class SymbolsBuffer implements SyncItem {
     let pre = null
     if (isDocumentSymbols(symbols)) {
       symbols.sort(sortDocumentSymbols)
-      symbols.forEach(s => addDoucmentSymbol(res, s, level))
+      symbols.forEach(s => addDocumentSymbol(res, s, level))
     } else {
       symbols.sort(sortSymbolInformations)
       for (let sym of symbols) {

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -160,19 +160,19 @@ class Languages {
   public registerCompletionItemProvider(
     name: string,
     shortcut: string,
-    languageIds: string | string[] | null,
+    selector: DocumentSelector | null,
     provider: CompletionItemProvider,
     triggerCharacters: string[] = [],
     priority?: number,
     allCommitCharacters?: string[]
   ): Disposable {
-    languageIds = typeof languageIds == 'string' ? [languageIds] : languageIds
-    let source = this.createCompleteSource(name, shortcut, provider, languageIds, triggerCharacters, allCommitCharacters || [], priority)
+    selector = typeof selector == 'string' ? [selector] : selector
+    let source = this.createCompleteSource(name, shortcut, provider, selector, triggerCharacters, allCommitCharacters || [], priority)
     sources.addSource(source)
     logger.debug('created service source', name)
     return {
       dispose: () => {
-        sources.removeSource(source)
+        sources.removeSource(name)
       }
     }
   }
@@ -451,7 +451,7 @@ class Languages {
     name: string,
     shortcut: string,
     provider: CompletionItemProvider,
-    languageIds: string[] | null,
+    selector: DocumentSelector,
     triggerCharacters: string[],
     allCommitCharacters: string[],
     priority?: number | undefined
@@ -469,7 +469,7 @@ class Languages {
       shortcut,
       enable: true,
       sourceType: SourceType.Service,
-      filetypes: languageIds,
+      documentSelector: selector,
       triggerCharacters: triggerCharacters || [],
       toggle: () => {
         source.enable = !source.enable

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -12,7 +12,7 @@ import { equals } from '../util/object'
 import { isWindows } from '../util/platform'
 import { byteLength, byteSlice } from '../util/string'
 import { Chars } from './chars'
-import { LinesTextDoucment } from './textdocument'
+import { LinesTextDocument } from './textdocument'
 const logger = require('../util/logger')('model-document')
 
 export type LastChangeType = 'insert' | 'change' | 'delete'
@@ -444,7 +444,7 @@ export default class Document {
    */
   public get textDocument(): TextDocument {
     let { version, filetype, uri } = this
-    return new LinesTextDoucment(uri, filetype, version, this.syncLines, this.eol)
+    return new LinesTextDocument(uri, filetype, version, this.syncLines, this.eol)
   }
 
   /**

--- a/src/model/outputChannel.ts
+++ b/src/model/outputChannel.ts
@@ -8,7 +8,7 @@ export default class BufferChannel implements OutputChannel {
   private _disposed = false
   private lines: string[] = ['']
   private disposables: Disposable[] = []
-  constructor(public name: string, private nvim: Neovim) {
+  constructor(public name: string, private nvim: Neovim, private onDispose?: () => void) {
   }
 
   public get content(): string {
@@ -82,6 +82,7 @@ export default class BufferChannel implements OutputChannel {
 
   public dispose(): void {
     if (this._disposed) return
+    if (this.onDispose) this.onDispose()
     this._disposed = true
     this.hide()
     this.lines = []

--- a/src/model/textdocument.ts
+++ b/src/model/textdocument.ts
@@ -20,7 +20,7 @@ function computeLineOffsets(text: string, isAtLineStart: boolean, textOffset = 0
  *
  * Created for save memory since we could reuse readonly lines.
  */
-export class LinesTextDoucment implements TextDocument {
+export class LinesTextDocument implements TextDocument {
   private _lineOffsets: number[] | undefined
   constructor(
     public readonly uri: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1226,7 +1226,10 @@ export interface ISource {
   triggerPatterns?: RegExp[]
   disableSyntaxes?: string[]
   isSnippet?: boolean
+  // @deprecated, use documentSelector instead.
   filetypes?: string[]
+  // enhanced filter than filetypes
+  documentSelector?: DocumentSelector
   filepath?: string
   // should the first character always match
   firstMatch?: boolean

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     "plugins": []
   },
   "include": ["src"],
-  "exclude": ["typings", "build"]
+  "exclude": ["typings", "build", "node_modules"]
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -167,11 +167,11 @@ declare module 'coc.nvim' {
     /**
      * The text document.
      */
-    textDocument: TextDocumentIdentifier;
+    textDocument: TextDocumentIdentifier
     /**
      * The position inside the text document.
      */
-    position: Position;
+    position: Position
   }
 
   export interface WorkspaceFolder {
@@ -4142,14 +4142,14 @@ declare module 'coc.nvim' {
      *
      * @param name Name of completion source.
      * @param shortcut Shortcut used in completion menu.
-     * @param languageIds Language ids of created completion source.
+     * @param selector Document selector of created completion source.
      * @param provider A completion provider.
      * @param triggerCharacters Trigger completion when the user types one of the characters.
      * @param priority Higher priority would shown first.
      * @param allCommitCharacters Commit characters of completion source.
      * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
      */
-    export function registerCompletionItemProvider(name: string, shortcut: string, languageIds: string | string[] | null, provider: CompletionItemProvider, triggerCharacters?: string[], priority?: number, allCommitCharacters?: string[]): Disposable
+    export function registerCompletionItemProvider(name: string, shortcut: string, selector: DocumentSelector | null, provider: CompletionItemProvider, triggerCharacters?: string[], priority?: number, allCommitCharacters?: string[]): Disposable
 
     /**
      * Register a code action provider.
@@ -4542,7 +4542,14 @@ declare module 'coc.nvim' {
      * Identifier name
      */
     name: string
+    /**
+     * @deprecated use documentSelector instead.
+     */
     filetypes?: string[]
+    /**
+     * Filters of document.
+     */
+    documentSelector?: DocumentSelector
     enable?: boolean
     shortcut?: string
     priority?: number


### PR DESCRIPTION
add conf file for single js extension, config `activationEvents` and `contributes` for single js extension in `coc-extensions`.

ex:
```
% tree coc-extensions
coc-extensions
├── coc-ext.js
└── coc-ext.json
```

support config `coc-ext.js` in `coc-ext.json` like this:
```json
{
  "activationEvents": ["*"],
  "contributes": {
    "configuration": {
      "type": "object",
      "title": "coc-ext configuration",
      "properties": {
        "coc-ext.enabled": {
          "type": "boolean",
          "default": true,
          "description": "Enable coc-ext extension"
        },
        "coc-ext.debug": {
          "type": "string",
          "default": "debug",
          "description": "debug"
        }
      }
    },
    "commands": [
      {
        "command": "coc-ext.Command",
        "title": "coc-ext command title"
      }
    ]
  }
}
```