### PR TITLE
fix(extensions): activate extension on command

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -40,6 +40,7 @@ class CommandItem implements Disposable, Command {
 export class CommandManager implements Disposable {
   private readonly commands = new Map<string, CommandItem>()
   public titles = new Map<string, string>()
+  public onCommandList: string[] = []
   private mru: Mru
 
   public init(nvim: Neovim, plugin: Plugin): void {

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -733,6 +733,7 @@ export class Extensions {
           }
         }, null, disposables)
       } else if (ev == 'onCommand') {
+        commandManager.onCommandList.push(parts[1])
         events.on('Command', async command => {
           if (command == parts[1]) {
             await active()

--- a/src/list/source/commands.ts
+++ b/src/list/source/commands.ts
@@ -30,11 +30,10 @@ export default class CommandsList extends BasicList {
 
   public async loadItems(_context: ListContext): Promise<ListItem[]> {
     let items: UnformattedListItem[] = []
-    let list = commandManager.commandList
-    let { titles } = commandManager
     let mruList = await this.mru.load()
-    for (const o of list) {
-      const { id } = o
+    let { commandList, onCommandList, titles } = commandManager
+    let ids = commandList.map(c => c.id).concat(onCommandList)
+    for (const id of [...new Set(ids)]) {
       items.push({
         label: [id, ...(titles.get(id) ? [titles.get(id)] : [])],
         filterText: id,


### PR DESCRIPTION
Command of `onCommand:xxx` in `activationEvents` should be listed in `:CocList commands` and active the extension.

This bug was brought in by https://github.com/neoclide/coc.nvim/pull/2295 , should fix https://github.com/iamcco/coc-flutter/issues/63 cc @iamcco