### PR TITLE
feat(executeCommand): coc should not suppress error in executeCommand

### DIFF
--- a/src/language-client/client.ts
+++ b/src/language-client/client.ts
@@ -2992,6 +2992,7 @@ class ExecuteCommandFeature
       }
       return client.sendRequest(ExecuteCommandRequest.type, params).then(undefined, (error) => {
         client.logFailedRequest(ExecuteCommandRequest.type, error)
+        throw error
       })
     }
     if (data.registerOptions.commands) {


### PR DESCRIPTION
I find that it can not catch the error when execute command fail from server.

https://github.com/iamcco/coc-flutter/pull/100/files#diff-0119f9dcc1efa64d0039547840186bff37cca3aef54d6924b31510182a16d00eR48