### PR TITLE
feat(completion): add none default sort method

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -456,7 +456,7 @@
       "type": "string",
       "description": "Default sorting behavior for suggested completion items.",
       "default": "length",
-      "enum": ["length", "alphabetical"]
+      "enum": ["length", "alphabetical", "none"]
     },
     "suggest.completionItemKindLabels": {
       "type": "object",

--- a/src/completion/complete.ts
+++ b/src/completion/complete.ts
@@ -253,6 +253,8 @@ export default class Complete {
       }
       // Default sort method
       switch (this.config.defaultSortMethod) {
+        case 'none':
+          return 0
         case 'alphabetical':
           return a.filterText.localeCompare(b.filterText)
         case 'length':


### PR DESCRIPTION
The completion items will be sorted by score, priority, sortText etc, if none of these works, items will be sorted by defaultSortMethod `length` or `alphabetical`. Add `none` sort method, will follow upstream orders, that means coc doesn't sort them anymore.