### PR TITLE
fix(markdown): improve markdown parser

### DIFF
--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -140,7 +140,7 @@ export function parseMarkdown(content: string): DocumentInfo {
       }
       continue
     }
-    if (/\s*```\s*(\w+)?$/.test(line)) {
+    if (/\s*```\s*([A-Za-z0-9_,]+)?$/.test(line)) {
       let pre = lines[lines.length - 1]
       if (!inCodeBlock) {
         inCodeBlock = true


### PR DESCRIPTION
Sometimes LS returns this code block in document, this will make markdown parser error. This fix just expands `\w+` and add `,` to it: `[A-Za-z0-9_,]`:

```
```compile_fail,E0392
struct Slice<'a, T> {
    start: *const T,
    end: *const T,
}
`` ` // add a space to here, make GitHub renders correctly
```

https://github.com/fannheyward/coc-rust-analyzer/issues/649