### PR TITLE
feature(tmux): add option to use tmux as terminal

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -1107,6 +1107,11 @@
       "maximum": 5000,
       "description": "Will save handler timeout"
     },
+    "coc.preferences.useTmuxTerminal": {
+        "type": "boolean",
+        "default": false,
+        "description": "Use tmux when creating a terminal. Will default to using a terminal buffer when not running within tmux. CocTerminalOpen will not trigger when a tmux pane is created."
+    },
     "coc.source.around.enable": {
       "type": "boolean",
       "default": true

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -842,6 +842,12 @@ Built-in configurations:~
 
 	Will save handler timeout, default: `500`
 
+"coc.preferences.useTmuxTerminal"
+
+	Use tmux when creating a terminal. Will default to using a terminal
+	buffer when not running within tmux. CocTerminalOpen will not trigger
+	when a tmux pane is created.
+
 "cursors.cancelKey":~
 
 	Key used for cancel cursors session, default: `<esc>`

--- a/src/model/tmuxterm.ts
+++ b/src/model/tmuxterm.ts
@@ -1,0 +1,130 @@
+import { promisify } from 'util'
+import { Terminal } from '../types'
+import { Neovim } from '@chemzqm/neovim'
+import { execFile, execFileSync } from 'child_process'
+import { EOL } from 'os'
+import { env } from 'process'
+
+const execFileAsync = promisify(execFile)
+
+export default class TmuxTerminalModel implements Terminal {
+  public bufnr: number
+  private pid = 0
+  private baseArgs: string[]
+
+  constructor(private cmd: string,
+    private args: string[],
+    private nvim: Neovim,
+    private _name?: string) {
+    const socket = env.TMUX.split(',')[0]
+    this.baseArgs = ['-S', socket]
+  }
+
+  public async start(cwd?: string, env?: { [key: string]: string | null }): Promise<void> {
+    let args = this.baseArgs.concat(['split-window', '-P'])
+    if (cwd) {
+      args.push('-c', cwd)
+    }
+    if (env) {
+      for (const [k, v] of Object.entries(env)) {
+        args.push('-e', `${k}=${v}`)
+      }
+    }
+    args.push(this.cmd, ...this.args)
+    const splitProc = await execFileAsync('tmux', args)
+    const pane = splitProc.stdout.trim()
+    const pidsProc = await execFileAsync(
+      'tmux',
+      this.baseArgs.concat([
+        'list-panes',
+        '-aF',
+        '#{session_name}:#{window_index}.#{pane_index}|#{pane_pid}',
+      ]),
+    )
+    const paneToPid = Object.fromEntries(
+      pidsProc.stdout
+        .trim()
+        .split(EOL)
+        .map(line => line.split('|'))
+    )
+    this.pid = parseInt(paneToPid[pane], 10)
+    this.bufnr = null
+  }
+
+  public get name(): string {
+    return this._name || this.cmd
+  }
+
+  public get processId(): Promise<number> {
+    return Promise.resolve(this.pid)
+  }
+
+  public sendText(text: string, addNewLine = true): void {
+    const pane = this.getPaneSync()
+    if (pane) {
+      execFileSync('tmux', this.baseArgs.concat('send-keys', '-lt', pane, text))
+      if (addNewLine) {
+        execFileSync('tmux', this.baseArgs.concat('send-keys', '-t', pane, 'Enter'))
+      }
+    }
+  }
+
+  public async show(_preserveFocus?: boolean): Promise<boolean> {
+    const pane = await this.getPane()
+    if (pane) {
+      await execFileAsync('tmux', this.baseArgs.concat(['join-pane', '-s', pane]))
+      return true
+    } else {
+      return false
+    }
+  }
+
+  public async hide(): Promise<void> {
+    const pane = await this.getPane()
+    if (pane) {
+      await execFileAsync('tmux', this.baseArgs.concat(['break-pane', '-ds', pane]))
+    }
+  }
+
+  public dispose(): void {
+    const pane = this.getPaneSync()
+    if (pane) {
+      execFileSync('tmux', this.baseArgs.concat(['kill-pane', '-t', pane]))
+    }
+  }
+
+  private async getPane(): Promise<string> {
+    const proc = await execFileAsync(
+      'tmux',
+      this.baseArgs.concat([
+        'list-panes',
+        '-aF',
+        '#{pane_pid}|#{session_name}:#{window_index}.#{pane_index}',
+      ])
+    )
+    return Object.fromEntries(
+      proc.stdout
+        .trim()
+        .split(EOL)
+        .map(line => line.split('|'))
+    )[this.pid]
+  }
+
+  private getPaneSync(): string {
+    return Object.fromEntries(
+      execFileSync(
+        'tmux',
+        this.baseArgs.concat([
+          'list-panes',
+          '-aF',
+          '#{pane_pid}|#{session_name}:#{window_index}.#{pane_index}',
+        ]),
+        {encoding: "utf8"},
+      )
+      .trim()
+      .split(EOL)
+      .map(line => line.split('|'))
+    )[this.pid]
+  }
+}
+


### PR DESCRIPTION
Add an option to use tmux when creating a new terminal. The option is off by default. When the option is set and neovim is not running within tmux, it falls back to the default behavior. It should be mostly compatible with plugins. The `Terminal` interface is implemented for all functions and properties except for `bufnr`. The terminal is not running in a buffer, so it cannot be set. There is no change in test failures because of these changes.

This should be viewed as WIP. I'm uncertain what kind of tests would be good for this because I doubt it would be acceptable require tests to be run within a tmux session. Also, there are currently 21 tests failing on my system. Is that normal? I've tested manually for creating and sending text to the terminal using coc-rust-analyzer. I'm not certain what's the best way I should be testing the show/hide/dispose functionality of the terminal because I haven't found a plugin which uses them.

Any input on these questions would be appreciated.