### PR TITLE
Recreate disposed channels

### DIFF
--- a/src/channels.ts
+++ b/src/channels.ts
@@ -39,7 +39,7 @@ export class Channels {
   public create(name: string, nvim: Neovim): OutputChannel | null {
     if (outputChannels.has(name)) {
       const channel = outputChannels.get(name)
-      if (!channel.disposed) return channel
+      if (!(channel as any).disposed) return channel
     }
     if (!/^[\w\s-.]+$/.test(name)) throw new Error(`Invalid channel name "${name}", only word characters and white space allowed.`)
     let channel = new BufferChannel(name, nvim)

--- a/src/channels.ts
+++ b/src/channels.ts
@@ -37,7 +37,10 @@ export class Channels {
   }
 
   public create(name: string, nvim: Neovim): OutputChannel | null {
-    if (outputChannels.has(name)) return outputChannels.get(name)
+    if (outputChannels.has(name)) {
+      const channel = outputChannels.get(name)
+      if (!channel.disposed) return channel
+    }
     if (!/^[\w\s-.]+$/.test(name)) throw new Error(`Invalid channel name "${name}", only word characters and white space allowed.`)
     let channel = new BufferChannel(name, nvim)
     outputChannels.set(name, channel)

--- a/src/model/outputChannel.ts
+++ b/src/model/outputChannel.ts
@@ -10,7 +10,7 @@ export default class BufferChannel implements OutputChannel {
   private disposables: Disposable[] = []
   constructor(public name: string, private nvim: Neovim) {
   }
-  
+
   public get disposed(): boolean {
     return this._disposed
   }

--- a/src/model/outputChannel.ts
+++ b/src/model/outputChannel.ts
@@ -10,6 +10,10 @@ export default class BufferChannel implements OutputChannel {
   private disposables: Disposable[] = []
   constructor(public name: string, private nvim: Neovim) {
   }
+  
+  public get disposed(): boolean {
+    return this._disposed
+  }
 
   public get content(): string {
     return this.lines.join('\n')


### PR DESCRIPTION
Currently if an extension disposes an output channel for any reason a new one cannot be created again with the same id.
This PR fixes that