### PR TITLE
Change the hover floating window default max width

### DIFF
--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -846,7 +846,7 @@ function! coc#float#get_config_cursor(lines, config) abort
   if vh <= 0
     return v:null
   endif
-  let maxWidth = coc#helper#min(get(a:config, 'maxWidth', &columns - 1), &columns - 1, 80)
+  let maxWidth = coc#helper#min(get(a:config, 'maxWidth', &columns - 1), &columns - 1, 500)
   if maxWidth < 3
     return v:null
   endif


### PR DESCRIPTION
This PR changes the hover floating window max width from 80 to 500. Note the window width is still configurable from coc-settings, as the value changed by this PR is only a upper bound of the setting value.

This PR would resolve https://github.com/neoclide/coc.nvim/issues/2984.