### PR TITLE
feat(float): do not conceal in the floats

### DIFF
--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -168,7 +168,7 @@ function! coc#float#create_float_win(winid, bufnr, config) abort
   call setwinvar(winid, '&colorcolumn', 0)
   call setwinvar(winid, '&wrap', 1)
   call setwinvar(winid, '&linebreak', 1)
-  call setwinvar(winid, '&conceallevel', 2)
+  call setwinvar(winid, '&conceallevel', 0)
   let g:coc_last_float_win = winid
   call coc#util#do_autocmd('CocOpenFloat')
   return [winid, bufnr]

--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -265,7 +265,7 @@ function! coc#util#preview_info(info, filetype, ...) abort
   setl nobuflisted
   setl nospell
   exe 'setl filetype='.a:filetype
-  setl conceallevel=2
+  setl conceallevel=0
   setl nofoldenable
   for command in a:000
     execute command


### PR DESCRIPTION
Several Vim themes are broken with regards to concealments, especially in coc's popup. In many cases, user-defined concealments are hard to use or unwanted in the context of writing code.

While normally you can set their `conceallevel` manually as you wish, coc's popup/float feature **hardwires it** to `2`.

Here's a screenshot with the [`iceberg`](http://github.com/cocopon/iceberg.vim) theme. Several things, such as the `⛏️`, the bold  **`B`** for `bool`, the `.` instead of `::` in `llvm::cl`, or `⊥`  instead of `false` come from conceals.
Note how `☥` and `∅` in the normal code (behind the popup) looks okay.

![Screenshot_20210325_170607](https://user-images.githubusercontent.com/1969470/112507018-96cfb800-8d8e-11eb-84ca-d590c8a88b1f.png)

As suggested, we will instead hardwire to `0`, resulting in no concealments:
![Screenshot_20210325_171606](https://user-images.githubusercontent.com/1969470/112507401-e44c2500-8d8e-11eb-8b40-2ea1b8354edd.png)