### PR TITLE
docs: add nvim version check for `signcolumn`

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ set shortmess+=c
 
 " Always show the signcolumn, otherwise it would shift the text each time
 " diagnostics appear/become resolved.
-if has("patch-8.1.1564")
+if has("nvim-0.5.0") || has("patch-8.1.1564")
   " Recently vim can merge signcolumn and number column into one
   set signcolumn=number
 else


### PR DESCRIPTION
neovim added support for `signcolumn=number` in neovim/neovim#12621, but `has("patch-8.1.1564")` doesn't work.