### PR TITLE
Limit get_float_win_list's output to coc.nvim windows

### DIFF
--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -30,9 +30,7 @@ function! coc#float#close_all() abort
   let winids = coc#float#get_float_win_list()
   for id in winids
     try
-      if getwinvar(id, 'float')
-        call coc#float#close(id)
-      endif
+      call coc#float#close(id)
     catch /E5555:/
       " ignore
     endtry
@@ -600,11 +598,12 @@ function! coc#float#get_float_win() abort
   return 0
 endfunction
 
+" Returns a list of floating/popup windows created by coc.nvim.
 function! coc#float#get_float_win_list() abort
+  let res = []
   if s:is_vim && exists('*popup_list')
-    return filter(popup_list(), 'popup_getpos(v:val)["visible"]')
+    call extend(res, filter(popup_list(), 'popup_getpos(v:val)["visible"]'))
   elseif has('nvim') && exists('*nvim_win_get_config')
-    let res = []
     for i in range(1, winnr('$'))
       let id = win_getid(i)
       let config = nvim_win_get_config(id)
@@ -613,9 +612,9 @@ function! coc#float#get_float_win_list() abort
         call add(res, id)
       endif
     endfor
-    return res
   endif
-  return []
+  call filter(res, 'getwinvar(v:val, "float", 0)')
+  return res
 endfunction
 
 " Check if a float window is scrollable


### PR DESCRIPTION
(I had originally opened PR #3066 with this proposed change, but the PR was automatically closed when I tried changing the base branch from `release` to `master`)

In https://github.com/dstein64/nvim-scrollview/issues/39, it was reported that `coc.nvim` functionality was not working properly after a recent update I made to [`nvim-scrollview`](https://github.com/dstein64/nvim-scrollview).

It appears that the scrolling functionality in `coc.nvim` considers all floating windows, instead of only those created by `coc.nvim`.

This PR updates the `get_float_win_list` function to only return floating windows that have the `float` window variable set, which matches how `has_float` and `close_all` functions check for windows created by `coc.nvim`. Along with this update, the `close_all` function was updated to exclude the aforementioned check for the `float` variable, since it's no longer necessary with `get_float_win_list` only returning windows with that variable set.
