### PR TITLE
fix(float): limit get_float_win_list to coc floats

### DIFF
--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -30,9 +30,7 @@ function! coc#float#close_all() abort
   let winids = coc#float#get_float_win_list()
   for id in winids
     try
-      if getwinvar(id, 'float')
-        call coc#float#close(id)
-      endif
+      call coc#float#close(id)
     catch /E5555:/
       " ignore
     endtry
@@ -600,11 +598,12 @@ function! coc#float#get_float_win() abort
   return 0
 endfunction
 
+" Returns a list of floating/popup windows created by coc.nvim.
 function! coc#float#get_float_win_list() abort
+  let res = []
   if s:is_vim && exists('*popup_list')
-    return filter(popup_list(), 'popup_getpos(v:val)["visible"]')
+    call extend(res, filter(popup_list(), 'popup_getpos(v:val)["visible"]'))
   elseif has('nvim') && exists('*nvim_win_get_config')
-    let res = []
     for i in range(1, winnr('$'))
       let id = win_getid(i)
       let config = nvim_win_get_config(id)
@@ -613,9 +612,9 @@ function! coc#float#get_float_win_list() abort
         call add(res, id)
       endif
     endfor
-    return res
   endif
-  return []
+  call filter(res, 'getwinvar(v:val, "float", 0)')
+  return res
 endfunction
 
 " Check if a float window is scrollable

--- a/src/__tests__/modules/window.test.ts
+++ b/src/__tests__/modules/window.test.ts
@@ -233,6 +233,15 @@ describe('window functions', () => {
     let res = await p
     expect(res).toBe('first')
   })
+
+  it('should not consider other floating windows', async () => {
+    await nvim.call(
+      'nvim_open_win', [0, false, {relative: 'win', row: 1, col: 1, width: 1, height: 1}])
+    let ids = await nvim.call('coc#float#get_float_win_list')
+    expect(ids.length).toBe(0)
+    let hasFloat = await nvim.call('coc#float#has_float')
+    expect(hasFloat).toBe(0)
+  })
 })
 
 describe('window notifications', () => {

--- a/src/__tests__/modules/window.test.ts
+++ b/src/__tests__/modules/window.test.ts
@@ -235,12 +235,15 @@ describe('window functions', () => {
   })
 
   it('should not consider other floating windows', async () => {
-    await nvim.call(
+    let floatId = await nvim.call(
       'nvim_open_win', [0, false, {relative: 'win', row: 1, col: 1, width: 1, height: 1}])
-    let ids = await nvim.call('coc#float#get_float_win_list')
-    expect(ids.length).toBe(0)
-    let hasFloat = await nvim.call('coc#float#has_float')
-    expect(hasFloat).toBe(0)
+    let cocIds = await nvim.call('coc#float#get_float_win_list')
+    expect(cocIds.length).toBe(0)
+    let hasCocFloat = await nvim.call('coc#float#has_float')
+    expect(hasCocFloat).toBe(0)
+    await nvim.call('coc#float#close_all')
+    let floatValid = await nvim.call('nvim_win_is_valid', floatId)
+    expect(floatValid).toBe(true)
   })
 })
 


### PR DESCRIPTION
(I had originally opened PR #3066 with this proposed change, but the PR was automatically closed when I tried changing the base branch from `release` to `master`)

(I had then opened PR #3067 with this proposed change, but then saw in [CONTRIBUTING.md](https://github.com/neoclide/coc.nvim/blob/89a2dc8fc80c0834b07677b858fb8e6977fd663f/CONTRIBUTING.md) that there is a format convention for commit messages, which I've now followed)

In https://github.com/dstein64/nvim-scrollview/issues/39, it was reported that `coc.nvim` functionality was not working properly after a recent update I made to [`nvim-scrollview`](https://github.com/dstein64/nvim-scrollview).

It appears that the scrolling functionality in `coc.nvim` considers all floating windows, instead of only those created by `coc.nvim`.

This PR updates the `get_float_win_list` function to only return floating windows that have the `float` window variable set, which matches how `has_float` and `close_all` functions check for windows created by `coc.nvim`. Along with this update, the `close_all` function was updated to exclude the aforementioned check for the `float` variable, since it's no longer necessary with `get_float_win_list` only returning windows with that variable set.

I have manually tested that this update works as expected on Neovim and Vim.