### PR TITLE
feat(markdown): ignore image in markdown doc

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -1109,6 +1109,11 @@
       "description": "Tell the language server that markdown text format is supported, note that markdown text may not rendered as expected.",
       "default": true
     },
+    "coc.preferences.excludeImageLinksInMarkdownDocument": {
+      "type": "boolean",
+      "description": "Exclude image links from document markdown text",
+      "default": true
+    },
     "coc.preferences.silentAutoupdate": {
       "type": "boolean",
       "description": "Not open split window with update status when performing auto update.",

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -3,6 +3,7 @@ import Renderer from './renderer'
 import { parseAnsiHighlights } from '../util/ansiparse'
 import { Documentation } from '../types'
 import { byteLength } from '../util/string'
+import workspace from '../workspace'
 export const diagnosticFiletypes = ['Error', 'Warning', 'Info', 'Hint']
 const logger = require('../util/logger')('markdown-index')
 
@@ -140,6 +141,14 @@ export function parseMarkdown(content: string): DocumentInfo {
       }
       continue
     }
+
+    const exclude = workspace.getConfiguration('coc.preferences').get<boolean>('excludeImageLinksInMarkdownDocument')
+    if (exclude) {
+      line = line.replace(/!\[.*?\]\(.*?\)/, '')
+      // eslint-disable-next-line no-control-regex
+      if (!line.replace(/\u001b\[(?:\d{1,3})(?:;\d{1,3})*m/g, '').trim().length) continue
+    }
+
     if (/\s*```\s*([A-Za-z0-9_,]+)?$/.test(line)) {
       if (!inCodeBlock) {
         inCodeBlock = true


### PR DESCRIPTION
ignore `![alt](href)` in markdown text.