### PR TITLE
fix(autoload): allow synmaxcolumn to be 0

### DIFF
--- a/autoload/coc/highlight.vim
+++ b/autoload/coc/highlight.vim
@@ -18,7 +18,11 @@ function! coc#highlight#ranges(bufnr, key, hlGroup, ranges) abort
   if !bufloaded(bufnr) || !exists('*getbufline')
     return
   endif
-  let synmaxcol = min([getbufvar(a:bufnr, '&synmaxcol', 1000), 1000])
+  let synmaxcol = getbufvar(a:bufnr, '&synmaxcol', 1000)
+  if synmaxcol == 0
+    let synmaxcol = 1000
+  endif
+  let synmaxcol = min([synmaxcol, 1000])
   let srcId = s:create_namespace(a:key)
   for range in a:ranges
     let start = range['start']


### PR DESCRIPTION
`synmaxcol` can be set to `0` to disable the maximum column syntax highlighting feature. The logic in `highlight.vim` led to nothing being highlighted if that was the case, this PR fixes that logic.