### PR TITLE
fix(symbols): keep visual selection after selecting range

### DIFF
--- a/src/handler/symbols.ts
+++ b/src/handler/symbols.ts
@@ -121,7 +121,11 @@ export default class Symbols {
       let endLine = doc.getline(end.line - 1)
       selectRange = Range.create(start.line + 1, line.match(/^\s*/)[0].length, end.line - 1, endLine.length)
     }
-    if (selectRange) await workspace.selectRange(selectRange)
+    if (selectRange) {
+      await workspace.selectRange(selectRange)
+    } else if (['v', 'V', '\x16'].includes(visualmode)) {
+      await this.nvim.command('normal! gv')
+    }
   }
 
   public dispose(): void {

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -642,7 +642,7 @@ export class Workspace implements IWorkspace {
   public async selectRange(range: Range): Promise<void> {
     let { nvim } = this
     let { start, end } = range
-    let [bufnr, ve, selection] = await nvim.eval(`[bufnr('%'), &virtualedit, &selection, mode()]`) as [number, string, string, string]
+    let [bufnr, ve, selection] = await nvim.eval(`[bufnr('%'), &virtualedit, &selection]`) as [number, string, string, string]
     let document = this.getDocument(bufnr)
     if (!document) return
     let line = document.getline(start.line)


### PR DESCRIPTION
When selectRange is missing and use visual mode, we should reselect
the selection.

An edge case like the current range is the same as the range that
languages server returned, coc will make n/vim lose the selection.