### PR TITLE
Avoid nvim_win_get_position for window position to support multigrid ui

### DIFF
--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -344,7 +344,7 @@ function! coc#float#nvim_scrollbar(winid) abort
     return
   endif
   let config = nvim_win_get_config(a:winid)
-  let [row, column] = nvim_win_get_position(a:winid)
+  let [row, column] = [config.row, config.col]
   let width = nvim_win_get_width(a:winid)
   let height = nvim_win_get_height(a:winid)
   let bufnr = winbufnr(a:winid)


### PR DESCRIPTION
The current implementation of the scrollbar on the tooltip that coc.nvim pops up is not displayed in the correct position in the Neovim GUI that supports multigrid ui. See: https://github.com/akiyosi/goneovim/issues/231
This fix resolves this issue.

The following is related information on this issue.
* https://github.com/neovim/neovim/issues/11935
* https://github.com/Yggdroot/LeaderF/issues/501