### PR TITLE
fix(completion): avoid unnecessary redraw for floating window

### DIFF
--- a/autoload/coc.vim
+++ b/autoload/coc.vim
@@ -50,11 +50,12 @@ endfunction
 function! coc#_complete() abort
   let items = get(g:coc#_context, 'candidates', [])
   let preselect = get(g:coc#_context, 'preselect', -1)
-  call complete(
-        \ g:coc#_context.start + 1,
-        \ items)
+  let startcol = g:coc#_context.start + 1
   if s:select_api && len(items) && preselect != -1
+    noa call complete(startcol, items)
     call nvim_select_popupmenu_item(preselect, v:false, v:false, {})
+  else
+    call complete(startcol, items)
   endif
   return ''
 endfunction


### PR DESCRIPTION
"suggest.enablePreselect": true, neovim may use `nvim_select_popupmenu_item`
to preselect matched item which will fire `CompleteChanged` event to
redraw detail. We should use `noa complete()` to avoid unnecessary redraw.