### PR TITLE
docs: inconsistent suggest.triggerCompletionWait value

### DIFF
--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -243,7 +243,7 @@ Built-in configurations:~
 "suggest.triggerCompletionWait":~
 
 	Delay between typing the trigger character and completion start which
-	initiates server synchronization, default: `50`
+	initiates server synchronization, default: `100`
 
 "suggest.echodocSupport":~
 


### PR DESCRIPTION
The default value in code is 100, but in help is 50