### PR TITLE
Activated code actions resolution

### DIFF
--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -580,7 +580,7 @@ export default class Handler {
   public async applyCodeAction(action: CodeAction): Promise<void> {
     if (action.data !== undefined) {
       return this.resolveCodeAction(action).then(resolved => {
-        if (resolved && resolved.data === undefined) { // Code action was resolved
+        if (resolved.data === undefined) { // Code action was resolved
           return this.applyCodeAction(resolved)
         }
       })
@@ -609,8 +609,8 @@ export default class Handler {
     }
   }
 
-  public async resolveCodeAction(action: CodeAction): Promise<CodeAction | null> {
-     let { doc } = await this.getCurrentState()
+  public async resolveCodeAction(action: CodeAction): Promise<CodeAction> {
+     const { doc } = await this.getCurrentState()
      return this.withRequestToken('codeaction resolve', token => {
       return languages.resolveCodeAction(doc.textDocument, action, token)
      }, true)

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -600,6 +600,20 @@ export default class Handler {
         }
       }
     }
+    if (action.data !== undefined) {
+      return this.resolveCodeAction(action).then(resolved => {
+        if (resolved && resolved.data === undefined) { // Code action was resolved
+          return this.applyCodeAction(resolved)
+        }
+      })
+    }
+  }
+
+  public async resolveCodeAction(action: CodeAction): Promise<CodeAction | null> {
+     let { doc } = await this.getCurrentState()
+     return this.withRequestToken('codeaction resolve', token => {
+      return languages.resolveCodeAction(doc.textDocument, action, token)
+     }, true)
   }
 
   public async doCodeLensAction(): Promise<void> {

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -578,6 +578,13 @@ export default class Handler {
   }
 
   public async applyCodeAction(action: CodeAction): Promise<void> {
+    if (action.data !== undefined) {
+      return this.resolveCodeAction(action).then(resolved => {
+        if (resolved && resolved.data === undefined) { // Code action was resolved
+          return this.applyCodeAction(resolved)
+        }
+      })
+    }
     let { command, edit } = action
     if (edit) await workspace.applyEdit(edit)
     if (command) {
@@ -599,13 +606,6 @@ export default class Handler {
             })
         }
       }
-    }
-    if (action.data !== undefined) {
-      return this.resolveCodeAction(action).then(resolved => {
-        if (resolved && resolved.data === undefined) { // Code action was resolved
-          return this.applyCodeAction(resolved)
-        }
-      })
     }
   }
 

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -367,6 +367,10 @@ class Languages {
     return await this.codeActionManager.provideCodeActions(document, range, context, token)
   }
 
+  public async resolveCodeAction(document: TextDocument, action: CodeAction, token: CancellationToken): Promise<CodeAction | null> {
+    return this.codeActionManager.resolveCodeAction(document, action, token)
+  }
+
   public async getDocumentHighLight(document: TextDocument, position: Position, token: CancellationToken): Promise<DocumentHighlight[]> {
     return await this.documentHighlightManager.provideDocumentHighlights(document, position, token)
   }

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -367,7 +367,7 @@ class Languages {
     return await this.codeActionManager.provideCodeActions(document, range, context, token)
   }
 
-  public async resolveCodeAction(document: TextDocument, action: CodeAction, token: CancellationToken): Promise<CodeAction | null> {
+  public async resolveCodeAction(document: TextDocument, action: CodeAction, token: CancellationToken): Promise<CodeAction> {
     return this.codeActionManager.resolveCodeAction(document, action, token)
   }
 

--- a/src/provider/codeActionmanager.ts
+++ b/src/provider/codeActionmanager.ts
@@ -30,7 +30,7 @@ export default class CodeActionManager extends Manager<CodeActionProvider> imple
     const provider = this.getProviders(document).map(p => p.provider).find(p => typeof p.resolveCodeAction === 'function')
     if (provider !== undefined) {
       const resolved: CodeAction = await provider.resolveCodeAction(action, token)
-      if (resolved.clientId !== action.clientId) { // If resolved action hasn't required clientId presented in original action
+      if (resolved.clientId !== action.clientId) { // If resolved action hasn't `clientId` in original action
         resolved.clientId = action.clientId
       }
       return resolved

--- a/src/provider/codeActionmanager.ts
+++ b/src/provider/codeActionmanager.ts
@@ -24,13 +24,13 @@ export default class CodeActionManager extends Manager<CodeActionProvider> imple
   }
 
   public async resolveCodeAction(document: TextDocument, action: CodeAction, token: CancellationToken): Promise<CodeAction | null> {
-    if (action.data == null) { // Code action does't need resolution
+    if (action.data === undefined) { // Code action doesn't need a resolution
       return action
     }
     const provider = this.getProviders(document).map(p => p.provider).find(p => typeof p.resolveCodeAction === 'function')
     if (provider !== undefined) {
       const resolved: CodeAction = await provider.resolveCodeAction(action, token)
-      if (resolved.clientId !== action.clientId) {
+      if (resolved.clientId !== action.clientId) { // If resolved action hasn't required clientId presented in original action
         resolved.clientId = action.clientId
       }
       return resolved

--- a/src/provider/codeActionmanager.ts
+++ b/src/provider/codeActionmanager.ts
@@ -23,6 +23,22 @@ export default class CodeActionManager extends Manager<CodeActionProvider> imple
     })
   }
 
+  public async resolveCodeAction(document: TextDocument, action: CodeAction, token: CancellationToken): Promise<CodeAction | null> {
+    if (action.data == null) { // Code action does't need resolution
+      return action
+    }
+    const provider = this.getProviders(document).map(p => p.provider).find(p => typeof p.resolveCodeAction === 'function')
+    if (provider !== undefined) {
+      const resolved: CodeAction = await provider.resolveCodeAction(action, token)
+      if (resolved.clientId !== action.clientId) {
+        resolved.clientId = action.clientId
+      }
+      return resolved
+    } else {
+      return null
+    }
+  }
+
   public async provideCodeActions(
     document: TextDocument,
     range: Range,

--- a/src/provider/codeActionmanager.ts
+++ b/src/provider/codeActionmanager.ts
@@ -23,20 +23,20 @@ export default class CodeActionManager extends Manager<CodeActionProvider> imple
     })
   }
 
-  public async resolveCodeAction(document: TextDocument, action: CodeAction, token: CancellationToken): Promise<CodeAction | null> {
-    if (action.data === undefined) { // Code action doesn't need a resolution
+  public async resolveCodeAction(document: TextDocument, action: CodeAction, token: CancellationToken): Promise<CodeAction> {
+    if (action.data === undefined) { // Action needs a resolution?
       return action
     }
     const provider = this.getProviders(document).map(p => p.provider).find(p => typeof p.resolveCodeAction === 'function')
-    if (provider !== undefined) {
-      const resolved: CodeAction = await provider.resolveCodeAction(action, token)
-      if (resolved.clientId !== action.clientId) { // If resolved action hasn't `clientId` in original action
-        resolved.clientId = action.clientId
-      }
-      return resolved
-    } else {
-      return null
+    if (provider === undefined) {
+      return action
     }
+    const resolved: CodeAction = await provider.resolveCodeAction(action, token)
+    if (resolved.clientId !== action.clientId) {
+      // If resolved action hasn't `clientId` field as in the original action
+      resolved.clientId = action.clientId
+    }
+    return resolved
   }
 
   public async provideCodeActions(


### PR DESCRIPTION
Since LSP v3.16.0 languages servers may implement resolution of choosen code actions.
Currently coc.nvim engaged `edit` code actions to be not resolved by default: https://github.com/neoclide/coc.nvim/blob/master/src/language-client/client.ts#L2375
But at the same time resolving of actions is not fully implemented.

For example simple code actions like `Import Qualifier (...)` don't work in `coc-java`.

I've tried to fix it, so please take a look.