### PR TITLE
feat(semanticTokens): provide basic default colors

### DIFF
--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -2733,6 +2733,38 @@ CocListPath						*CocListPath*
 
   Used for current cwd in statusline of CocList.
 
+CocSem_*						*CocSem*
+
+  Used for words whose semantics are provided by the language server, which
+  typically analyzes source code more deeply than vim's builtin syntax parser.
+
+  Basic defaults are provided for the "standard" token kinds, but any kind
+  supported by the server can be highlighted by creating the highlight group.
+
+  Default (disable by setting `g:coc_default_semantic_highlight_groups = 0`):
+  `hi default link CocSem_namespace Identifier`
+  `hi default link CocSem_type Type`
+  `hi default link CocSem_class Structure`
+  `hi default link CocSem_enum Type`
+  `hi default link CocSem_interface Type`
+  `hi default link CocSem_struct Structure`
+  `hi default link CocSem_typeParameter Type`
+  `hi default link CocSem_parameter Identifier`
+  `hi default link CocSem_variable Identifier`
+  `hi default link CocSem_property Identifier`
+  `hi default link CocSem_enumMember Constant`
+  `hi default link CocSem_event Identifier`
+  `hi default link CocSem_function Function`
+  `hi default link CocSem_method Function`
+  `hi default link CocSem_macro Macro`
+  `hi default link CocSem_keyword Keyword`
+  `hi default link CocSem_modifier StorageClass`
+  `hi default link CocSem_comment Comment`
+  `hi default link CocSem_string String`
+  `hi default link CocSem_number Number`
+  `hi default link CocSem_regexp Normal`
+  `hi default link CocSem_operator Operator`
+
 ==============================================================================
 LIST SUPPORT						*coc-list*
 

--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -398,28 +398,30 @@ function! s:Hi() abort
   endif
   call s:AddAnsiGroups()
 
-  hi default link CocSem_namespace Identifier
-  hi default link CocSem_type Type
-  hi default link CocSem_class Structure
-  hi default link CocSem_enum Type
-  hi default link CocSem_interface Type
-  hi default link CocSem_struct Structure
-  hi default link CocSem_typeParameter Type
-  hi default link CocSem_parameter Identifier
-  hi default link CocSem_variable Identifier
-  hi default link CocSem_property Identifier
-  hi default link CocSem_enumMember Constant
-  hi default link CocSem_event Identifier
-  hi default link CocSem_function Function
-  hi default link CocSem_method Function
-  hi default link CocSem_macro Macro
-  hi default link CocSem_keyword Keyword
-  hi default link CocSem_modifier StorageClass
-  hi default link CocSem_comment Comment
-  hi default link CocSem_string String
-  hi default link CocSem_number Number
-  hi default link CocSem_regexp Normal
-  hi default link CocSem_operator Operator
+  if get(g:, 'coc_default_semantic_highlight_groups', 1) == 1
+    hi default link CocSem_namespace Identifier
+    hi default link CocSem_type Type
+    hi default link CocSem_class Structure
+    hi default link CocSem_enum Type
+    hi default link CocSem_interface Type
+    hi default link CocSem_struct Structure
+    hi default link CocSem_typeParameter Type
+    hi default link CocSem_parameter Identifier
+    hi default link CocSem_variable Identifier
+    hi default link CocSem_property Identifier
+    hi default link CocSem_enumMember Constant
+    hi default link CocSem_event Identifier
+    hi default link CocSem_function Function
+    hi default link CocSem_method Function
+    hi default link CocSem_macro Macro
+    hi default link CocSem_keyword Keyword
+    hi default link CocSem_modifier StorageClass
+    hi default link CocSem_comment Comment
+    hi default link CocSem_string String
+    hi default link CocSem_number Number
+    hi default link CocSem_regexp Normal
+    hi default link CocSem_operator Operator
+  endif
 endfunction
 
 function! s:FormatFromSelected(type)

--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -397,6 +397,29 @@ function! s:Hi() abort
     endfor
   endif
   call s:AddAnsiGroups()
+
+  hi default link CocSem_namespace Identifier
+  hi default link CocSem_type Type
+  hi default link CocSem_class Structure
+  hi default link CocSem_enum Type
+  hi default link CocSem_interface Type
+  hi default link CocSem_struct Structure
+  hi default link CocSem_typeParameter Type
+  hi default link CocSem_parameter Identifier
+  hi default link CocSem_variable Identifier
+  hi default link CocSem_property Identifier
+  hi default link CocSem_enumMember Constant
+  hi default link CocSem_event Identifier
+  hi default link CocSem_function Function
+  hi default link CocSem_method Function
+  hi default link CocSem_macro Macro
+  hi default link CocSem_keyword Keyword
+  hi default link CocSem_modifier StorageClass
+  hi default link CocSem_comment Comment
+  hi default link CocSem_string String
+  hi default link CocSem_number Number
+  hi default link CocSem_regexp Normal
+  hi default link CocSem_operator Operator
 endfunction
 
 function! s:FormatFromSelected(type)


### PR DESCRIPTION
Not sure if this was omitted intentionally, but the fact that there was no highlighting at all by default threw me for a loop!

---

This maps each of the "standard"[1] CocSem_* highlight groups to the
semantically-closest standard vim group, e.g. CocSem_enum => Type.

This means that a user with coc.nvim and a colorscheme enabled will get
some basic highlighting out of semanticTokens. Not enough to distinguish
everything, but at least e.g. types vs variables.
Today you get nothing by default, as the CocSem_* groups are undefined.

The possible downside: AFAICS coc.nvim doesn't apply highlight groups that
don't exist, so defining these groups means we'll pay the performance
cost of applying the styles even if the benefit is small.

[1] Specifically these are the SemanticTokenTypes defined in LSP:
https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#semanticTokenTypes
(though language servers can support others)