### PR TITLE
fix(diagnostic): highlight hints, deprecated and unused text with their own unique hlgroups

### DIFF
--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -2510,7 +2510,7 @@ CocFadeOut						*CocFadeOut*
 
   Default: `hi default CocFadeOut       guifg=#928374 ctermfg=245`
 
-  Used for highlight unnecessary code.
+  Used for faded out text, such as for highlighting unnecessary code.
 
 CocStrikeThrough 					*CocStrikeThrough*
 
@@ -2621,6 +2621,18 @@ CocHintHighlight					*CocHintHighlight*
   Default: `hi default link CocHintHighlight   CocUnderline`
 
   Used for hint text.
+
+CocDeprecatedHighlight					*CocDeprecatedHighlight*
+
+  Default: `hi default link CocDeprecatedHighlight   CocStrikeThrough`
+
+  Used for usages of deprecated API.
+
+CocUnusedHighlight					*CocUnusedHighlight*
+
+  Default: `hi default link CocUnusedHighlight   CocFadeOut`
+
+  Used for unnecessary code.
 
 CocHighlightText					*CocHighlightText*
 

--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -369,6 +369,8 @@ function! s:Hi() abort
   hi default link CocWarningHighlight CocUnderline
   hi default link CocInfoHighlight    CocUnderline
   hi default link CocHintHighlight    CocUnderline
+  hi default link CocDeprecatedHighlight CocStrikeThrough
+  hi default link CocUnusedHighlight     CocFadeOut
   hi default link CocListMode ModeMsg
   hi default link CocListPath Comment
   hi default link CocHighlightText  CursorColumn

--- a/src/diagnostic/buffer.ts
+++ b/src/diagnostic/buffer.ts
@@ -18,9 +18,9 @@ export enum DiagnosticHighlight {
   Error = 'CocErrorHighlight',
   Warning = 'CocWarningHighlight',
   Information = 'CocInfoHighlight',
-  Hint = 'CocHintFloat',
-  Deprecated = 'CocStrikeThrough',
-  Unused = 'CocFadeOut'
+  Hint = 'CocHintHighlight',
+  Deprecated = 'CocDeprecatedHighlight',
+  Unused = 'CocUnusedHighlight'
 }
 
 const ErrorSymbol = Symbol('CocError')


### PR DESCRIPTION
This PR fixes the remaining entries in `DiagnosticHighlight` to use unique hlgroups, namely `Coc<Something>Highlight`, instead of reusing existing ones. Note that I say "remaining" because that enum was using `CocErrorHighlight` and `CocWarningHighlight` from the beginning (commit df7a1d94233bac9e26d593fe11f4f14b049e0a14, [relevant code](https://github.com/neoclide/coc.nvim/commit/df7a1d94233bac9e26d593fe11f4f14b049e0a14#diff-23ccea505c03101016c60ed7cbc58543c16d244e9b2fd5c3446ca3f7f7ced9bbR17-R24)), then `CocInfoFloat` was correctly replaced with `CocInfoHighlight` in commit 4cd2b40390a2dadb56baf3135064f74b148c9211, and finally I replace the remaining hlgroup for the "hint" severity with `CocHintHighlight` in this PR.

Additionally, I added the `CocDeprecatedHighlight` and `CocUnusedHighlight` groups for deprecated and unused code respectively, which link to `CocStrikeThrough` and `CocFadeOut`. This was done both for the sake of consistency, and future-proofing in case the `CocStrikeThrough` and `CocFadeOut` groups may come in handy for text formatting in other unrelated things, similarly to hlgroups such as `CocBold`, `CocItalic`, `CocUnderline` and others. Because the two new hlgroups are by default just linked, this will have no visible effect on user configurations.

As for `CocHintHighlight`, this PR indeed fixes highlighting of hints, which right now look like:

![image](https://user-images.githubusercontent.com/15367354/124277630-ea9c2b00-db4d-11eb-8f16-4be29a37e7f4.png)

And here is how they will look after this PR (which was the behavior before commit df7a1d94233bac9e26d593fe11f4f14b049e0a14):

![image](https://user-images.githubusercontent.com/15367354/124277716-0b648080-db4e-11eb-81ed-7f9da463b57e.png)

As you can see, their highlighting of the relevant source code is now consistent with errors because by default all `Coc*Highlight` groups are linked to `CocUnderline`.