### PR TITLE
fix(api): vim call_atomic exception list

### DIFF
--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -80,14 +80,20 @@ function! s:funcs.list_wins() abort
   return map(getwininfo(), 'v:val["winid"]')
 endfunction
 
+function s:inspect_type(v) abort
+  let types = ['Number', 'String', 'Funcref', 'List', 'Dictionary', 'Float', 'Boolean', 'Null']
+  return get(types, type(a:v), 'Unknown('.a:v.')')
+endfunction
+
 function! s:funcs.call_atomic(calls)
   let res = []
-  for [key, arglist] in a:calls
+  for i in range(len(a:calls))
+    let [key, arglist] = a:calls[i]
     let name = key[5:]
     try
       call add(res, call(s:funcs[name], arglist))
     catch /.*/
-      return [res, v:exception]
+      return [res, [i, s:inspect_type(v:exception), v:exception]]
     endtry
   endfor
   return [res, v:null]

--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -82,7 +82,7 @@ endfunction
 
 function s:inspect_type(v) abort
   let types = ['Number', 'String', 'Funcref', 'List', 'Dictionary', 'Float', 'Boolean', 'Null']
-  return get(types, type(a:v), 'Unknown('.a:v.')')
+  return get(types, type(a:v), 'Unknown')
 endfunction
 
 function! s:funcs.call_atomic(calls)
@@ -93,7 +93,7 @@ function! s:funcs.call_atomic(calls)
     try
       call add(res, call(s:funcs[name], arglist))
     catch /.*/
-      return [res, [i, s:inspect_type(v:exception), v:exception]]
+      return [res, [i, "VimException(".s:inspect_type(v:exception).")", v:exception]]
     endtry
   endfor
   return [res, v:null]


### PR DESCRIPTION
According to the [nodejs client](https://github.com/neoclide/neovim/blob/neoclide/src/transport/base.ts#L75) and [nvim help](https://github.com/neovim/neovim/blob/master/runtime/doc/api.txt#L580-L586), my understanding is that the error return value of vim-api's `call_atomic` is different from that of neovim built-in, cause an unreadable [error](https://github.com/weirongxu/coc-explorer/issues/458) in vim.