### PR TITLE
feat(typings): make markdown optional

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -7739,7 +7739,7 @@ declare module 'coc.nvim' {
     middleware?: Middleware
     workspaceFolder?: WorkspaceFolder
     connectionOptions?: ConnectionOptions
-    markdown: {
+    markdown?: {
       isTrusted: boolean
     }
   }


### PR DESCRIPTION
Tested with 0.0.81-next.5, this should be optional.