### PR TITLE
Avoiding permission errors when installing nodejs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -31,6 +31,7 @@ Install [nodejs](https://nodejs.org/en/download/) >= 12.12:
 ```sh
 curl -sL install-node.now.sh/lts | bash
 ```
+If you get an error about no permissions, change it to `sudo bash` and run it.
 
 For [vim-plug](https://github.com/junegunn/vim-plug) users:
 


### PR DESCRIPTION


When installing the quickstart nodejs,   I got the following `permission denied` error. (Ubuntu 20.04.1 )


```
$ curl -sL install-node.now.sh/lts | bash
						:
tar: include/node: Cannot mkdir: Permission denied
tar: include/node/openssl/bn_conf.h: Cannot open: No such file or directory
tar: include/node: Cannot mkdir: Permission denied
tar: include/node/openssl/dso_conf.h: Cannot open: No such file or directory
tar: include/node: Cannot mkdir: Permission denied
tar: include/node/openssl/opensslconf.h: Cannot open: No such file or directory
tar: include/node: Cannot mkdir: Permission denied
tar: include/node/openssl/dso_conf_asm.h: Cannot open: No such file or directory
tar: include/node: Cannot mkdir: Permission denied
						:

```

This problem has been solved by using `sudo bash`.  It may help linux beginners to write this solution in `Readme.md` beforehand. 