### PR TITLE
feat(handler): definition content on hover

### DIFF
--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -2055,14 +2055,19 @@ Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 
 	same behavior as "jumpDefinition"
 
-"doHover" [{hoverTarget}]					*coc-action-doHover*
+"doHover" [{hoverTarget}]				*coc-action-doHover*
 
-	Show documentation of the current word in a preview window.
-	Return `v:false` when hover not found.
+	Show documentation of  current symbol, return `v:false` when hover not
+	found.
 
 	{hoverTarget}: optional specification for where to show hover info,
 	defaults to `coc.preferences.hoverTarget` in `coc-settings.json`.
 	Valid options: ["preview", "echo", "float"]
+	
+"definitionHover" [{hoverTarget}]			*coc-action-definitionHover*
+
+	Same as |coc-action-doHover| but includes definition contents from
+	definition provider when possible.
 
 "getHover"						*coc-action-getHover*
 

--- a/src/__tests__/handler/hover.test.ts
+++ b/src/__tests__/handler/hover.test.ts
@@ -152,7 +152,7 @@ describe('Hover', () => {
       }))
       await hover.definitionHover('preview')
       let res = await getDocumentText()
-      expect(res).toBe('foo\nbar\n\nstring hover')
+      expect(res).toBe('string hover\n\nfoo\nbar')
     })
 
     it('should load definition link from file', async () => {
@@ -172,7 +172,7 @@ describe('Hover', () => {
       }))
       await hover.definitionHover('preview')
       let res = await getDocumentText()
-      expect(res).toBe('foo\nbar\n\nstring hover')
+      expect(res).toBe('string hover\n\nfoo\nbar')
     })
   })
 })

--- a/src/completion/complete.ts
+++ b/src/completion/complete.ts
@@ -37,12 +37,6 @@ export interface CompleteConfig {
   asciiCharactersOnly: boolean
 }
 
-export interface Documentation {
-  filetype: string
-  content: string
-  active?: [number, number]
-}
-
 export type Callback = () => void
 
 // first time completion

--- a/src/handler/hover.ts
+++ b/src/handler/hover.ts
@@ -1,13 +1,13 @@
 import { Neovim } from '@chemzqm/neovim'
 import fs from 'fs'
 import { CancellationTokenSource, Disposable, Hover, MarkedString, MarkupContent, Range } from 'vscode-languageserver-protocol'
-import { disposeAll, isMarkdown } from '../util'
 import { URI } from 'vscode-uri'
 import languages from '../languages'
 import { Documentation } from '../markdown'
 import FloatFactory, { FloatWinConfig } from '../model/floatFactory'
 import { TextDocumentContentProvider } from '../provider'
 import { ConfigurationChangeEvent, HandlerDelegate } from '../types'
+import { disposeAll, isMarkdown } from '../util'
 import { readFileLines } from '../util/fs'
 import workspace from '../workspace'
 const logger = require('../util/logger')('handler-hover')
@@ -77,6 +77,7 @@ export default class HoverHandler {
 
   public async onHover(hoverTarget?: HoverTarget): Promise<boolean> {
     let { doc, position, winid } = await this.handler.getCurrentState()
+    if (hoverTarget == 'preview') this.registerProvider()
     this.handler.checkProvier('hover', doc.textDocument)
     await doc.synchronize()
     let hovers = await this.handler.withRequestToken('hover', token => {
@@ -98,6 +99,7 @@ export default class HoverHandler {
 
   public async definitionHover(hoverTarget: HoverTarget): Promise<boolean> {
     const { doc, position } = await this.handler.getCurrentState()
+    if (hoverTarget == 'preview') this.registerProvider()
     this.handler.checkProvier('hover', doc.textDocument)
     await doc.synchronize()
     const hovers = await this.handler.withRequestToken('hover', token => {

--- a/src/handler/hover.ts
+++ b/src/handler/hover.ts
@@ -130,7 +130,7 @@ export default class HoverHandler {
     target = target || this.config.target
     let isPreview = target === 'preview'
     for (let hover of hovers) {
-      if (isDocumentaion(hover)) {
+      if (isDocumentation(hover)) {
         docs.push(hover)
         continue
       }
@@ -223,7 +223,7 @@ function addDocument(docs: Documentation[], text: string, filetype: string, isPr
   docs.push({ content, filetype })
 }
 
-function isDocumentaion(obj: any): obj is Documentation {
+function isDocumentation(obj: any): obj is Documentation {
   if (!obj) return false
   return typeof obj.filetype === 'string' && typeof obj.content === 'string'
 }

--- a/src/handler/hover.ts
+++ b/src/handler/hover.ts
@@ -81,7 +81,7 @@ export default class HoverHandler {
     return true
   }
 
-  private async previewHover(hovers: Hover[], target?: string): Promise<void> {
+  public async previewHover(hovers: Hover[], target?: string): Promise<void> {
     let docs: Documentation[] = []
     target = target || this.config.target
     let isPreview = target === 'preview'

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -1,5 +1,5 @@
 import { NeovimClient as Neovim } from '@chemzqm/neovim'
-import { CancellationToken, CancellationTokenSource, Disposable, Hover, MarkupKind, Position } from 'vscode-languageserver-protocol'
+import { CancellationToken, CancellationTokenSource, Disposable, Position } from 'vscode-languageserver-protocol'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import events from '../events'
 import languages from '../languages'
@@ -16,7 +16,7 @@ import Commands from './commands'
 import Fold from './fold'
 import Format from './format'
 import Highlights from './highlights'
-import HoverHandler, { HoverTarget } from './hover'
+import HoverHandler from './hover'
 import Links from './links'
 import Locations from './locations'
 import Refactor from './refactor/index'
@@ -114,40 +114,6 @@ export default class Handler {
 
   public addDisposable(disposable: Disposable): void {
     this.disposables.push(disposable)
-  }
-
-  public async definitionHover(target: HoverTarget): Promise<void> {
-    const { doc, position } = await this.getCurrentState()
-    this.checkProvier('hover', doc.textDocument)
-    await doc.synchronize()
-    const tokenSource = new CancellationTokenSource()
-    const hovers =  await languages.getHover(doc.textDocument, position, tokenSource.token)
-
-    const locs = await this.locations.definitions()
-    if (!locs.length) {
-      await this.hover.previewHover(hovers, target)
-      return
-    }
-
-    if (locs.length > 1) {
-      // TODO: mutiple locations
-    } else {
-      const loc = locs[0]
-      const doc = await workspace.loadFile(loc.uri)
-      if (!doc) return
-
-      const { start, end } = loc.range
-      const endLine = end.line - start.line >= 8 ? start.line + 8 : end.line
-      const lines = doc.getLines(start.line, endLine)
-      if (lines.length) {
-        const defHover: Hover = {
-          range: loc.range,
-          contents: { kind: MarkupKind.PlainText, value: lines.join('\n') }
-        }
-        hovers.splice(0, 0, defHover)
-      }
-      await this.hover.previewHover(hovers, target)
-    }
   }
 
   /**

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -1,5 +1,5 @@
 import { Neovim } from '@chemzqm/neovim'
-import { CallHierarchyIncomingCall, CallHierarchyItem, CallHierarchyOutgoingCall, CancellationToken, CancellationTokenSource, CodeAction, CodeActionContext, CodeActionKind, CodeLens, ColorInformation, ColorPresentation, CompletionItem, CompletionItemKind, CompletionList, CompletionTriggerKind, Disposable, DocumentHighlight, DocumentLink, DocumentSelector, DocumentSymbol, Emitter, Event, FoldingRange, FormattingOptions, Hover, InsertReplaceEdit, InsertTextFormat, LinkedEditingRanges, Location, LocationLink, Position, Range, SelectionRange, SemanticTokens, SemanticTokensDelta, SemanticTokensLegend, SignatureHelp, SignatureHelpContext, SymbolInformation, TextEdit, WorkspaceEdit } from 'vscode-languageserver-protocol'
+import { CallHierarchyIncomingCall, CallHierarchyItem, CallHierarchyOutgoingCall, CancellationToken, CancellationTokenSource, CodeAction, CodeActionContext, CodeActionKind, CodeLens, ColorInformation, ColorPresentation, CompletionItem, CompletionItemKind, CompletionList, CompletionTriggerKind, DefinitionLink, Disposable, DocumentHighlight, DocumentLink, DocumentSelector, DocumentSymbol, Emitter, Event, FoldingRange, FormattingOptions, Hover, InsertReplaceEdit, InsertTextFormat, LinkedEditingRanges, Location, LocationLink, Position, Range, SelectionRange, SemanticTokens, SemanticTokensDelta, SemanticTokensLegend, SignatureHelp, SignatureHelpContext, SymbolInformation, TextEdit, WorkspaceEdit } from 'vscode-languageserver-protocol'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import commands from './commands'
 import diagnosticManager from './diagnostic/manager'
@@ -313,6 +313,11 @@ class Languages {
   public async getDefinition(document: TextDocument, position: Position, token: CancellationToken): Promise<Location[]> {
     if (!this.definitionManager.hasProvider(document)) return null
     return await this.definitionManager.provideDefinition(document, position, token)
+  }
+
+  public async getDefinitionLinks(document: TextDocument, position: Position, token: CancellationToken): Promise<DefinitionLink[]> {
+    if (!this.definitionManager.hasProvider(document)) return null
+    return await this.definitionManager.provideDefinitionLinks(document, position, token)
   }
 
   public async getDeclaration(document: TextDocument, position: Position, token: CancellationToken): Promise<Location[] | Location | LocationLink[] | null> {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -202,7 +202,7 @@ export default class Plugin extends EventEmitter {
     this.addAction('references', () => this.handler.locations.references())
     this.addAction('jumpUsed', openCommand => this.handler.locations.gotoReferences(openCommand, false))
     this.addAction('doHover', hoverTarget => this.handler.hover.onHover(hoverTarget))
-    this.addAction('definitionHover', hoverTarget => this.handler.definitionHover(hoverTarget))
+    this.addAction('definitionHover', hoverTarget => this.handler.hover.definitionHover(hoverTarget))
     this.addAction('getHover', () => this.handler.hover.getHover())
     this.addAction('showSignatureHelp', () => this.handler.signature.triggerSignatureHelp())
     this.addAction('documentSymbols', async (bufnr?: number) => {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -202,6 +202,7 @@ export default class Plugin extends EventEmitter {
     this.addAction('references', () => this.handler.locations.references())
     this.addAction('jumpUsed', openCommand => this.handler.locations.gotoReferences(openCommand, false))
     this.addAction('doHover', hoverTarget => this.handler.hover.onHover(hoverTarget))
+    this.addAction('definitionHover', hoverTarget => this.handler.definitionHover(hoverTarget))
     this.addAction('getHover', () => this.handler.hover.getHover())
     this.addAction('showSignatureHelp', () => this.handler.signature.triggerSignatureHelp())
     this.addAction('documentSymbols', async (bufnr?: number) => {

--- a/src/provider/definitionManager.ts
+++ b/src/provider/definitionManager.ts
@@ -1,4 +1,4 @@
-import { CancellationToken, Disposable, DocumentSelector, Location, Position } from 'vscode-languageserver-protocol'
+import { CancellationToken, Definition, DefinitionLink, Disposable, DocumentSelector, Location, LocationLink, Position } from 'vscode-languageserver-protocol'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { DefinitionProvider } from './index'
 import Manager, { ProviderItem } from './manager'
@@ -19,18 +19,47 @@ export default class DefinitionManager extends Manager<DefinitionProvider> imple
     })
   }
 
+  private async getDefinitions(
+    document: TextDocument,
+    position: Position,
+    token: CancellationToken
+  ): Promise<(Definition | DefinitionLink[])[]> {
+    const providers = this.getProviders(document)
+    if (!providers.length) return []
+    const arr = await Promise.all(providers.map(item => {
+      const { provider } = item
+      return Promise.resolve(provider.provideDefinition(document, position, token))
+    }))
+    return arr
+  }
+
   public async provideDefinition(
     document: TextDocument,
     position: Position,
     token: CancellationToken
-  ): Promise<Location[] | null> {
-    let providers = this.getProviders(document)
-    if (!providers.length) return null
-    let arr = await Promise.all(providers.map(item => {
-      let { provider } = item
-      return Promise.resolve(provider.provideDefinition(document, position, token))
-    }))
+  ): Promise<Location[]> {
+    const arr = await this.getDefinitions(document, position, token)
     return this.toLocations(arr)
+  }
+
+  public async provideDefinitionLinks(
+    document: TextDocument,
+    position: Position,
+    token: CancellationToken
+  ): Promise<DefinitionLink[]> {
+    const arr = await this.getDefinitions(document, position, token)
+    const defs: DefinitionLink[] = []
+    for (const def of arr) {
+      if (!Array.isArray(def)) continue
+
+      for (const val of def) {
+        if (LocationLink.is(val)) {
+          defs.push(val)
+        }
+      }
+    }
+
+    return defs
   }
 
   public dispose(): void {

--- a/src/provider/definitionManager.ts
+++ b/src/provider/definitionManager.ts
@@ -3,6 +3,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument'
 import { DefinitionProvider } from './index'
 import Manager, { ProviderItem } from './manager'
 import { v4 as uuid } from 'uuid'
+import { equals } from '../util/object'
 const logger = require('../util/logger')('definitionManager')
 
 export default class DefinitionManager extends Manager<DefinitionProvider> implements Disposable {
@@ -51,14 +52,13 @@ export default class DefinitionManager extends Manager<DefinitionProvider> imple
     const defs: DefinitionLink[] = []
     for (const def of arr) {
       if (!Array.isArray(def)) continue
-
       for (const val of def) {
         if (LocationLink.is(val)) {
-          defs.push(val)
+          let idx = defs.findIndex(o => o.targetUri == val.targetUri && equals(o.targetRange, val.targetRange))
+          if (idx == -1) defs.push(val)
         }
       }
     }
-
     return defs
   }
 

--- a/src/provider/manager.ts
+++ b/src/provider/manager.ts
@@ -1,7 +1,6 @@
 import { Definition, DocumentSelector, Location, LocationLink } from 'vscode-languageserver-protocol'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import workspace from '../workspace'
-import window from '../window'
 import { equals } from '../util/object'
 const logger = require('../util/logger')('provider-manager')
 
@@ -63,7 +62,7 @@ export default class Manager<T> {
           }
         }
       } else {
-        window.showMessage(`Bad definition ${JSON.stringify(def)}`, 'error')
+        logger.error(`Bad definition`, def)
       }
     }
     return res


### PR DESCRIPTION
<img width="699" alt="截屏2021-07-28 下午4 26 57" src="https://user-images.githubusercontent.com/345274/127290166-d8b1a928-247c-4d7b-918c-5967a7253923.png">

VSCode: 

<img width="652" alt="截屏2021-07-26 下午5 18 38" src="https://user-images.githubusercontent.com/345274/126965316-38bd9ce3-9ca4-47bd-b192-78b53e12ca73.png">

cc @chemzqm , some Todos:

~1. I put `definitionHover` in `handler` directly because we can use `locations` and `hover` to fetch and preview content, do we need to put into a new separate handler?~
~2. how to handle multiple definition locations? VSCode shows a `Click to show {0} definitions.` action, but we can't put action in hover by now~
~3. the definition content needs to be marked to markdown for highlighting~