### PR TITLE
fix(diagnostic): keep updating diagnostic at least one time

### DIFF
--- a/src/diagnostic/buffer.ts
+++ b/src/diagnostic/buffer.ts
@@ -92,10 +92,6 @@ export class DiagnosticBuffer implements BufferSyncItem {
     return this.config.displayByAle
   }
 
-  public onChange(): void {
-    this.refresh.clear()
-  }
-
   public changeState(state: DiagnosticState): void {
     this._state = state
   }


### PR DESCRIPTION
For now, updating diagnostic may be canceled which make the diagnostic
information is missing. 

Below video show what the issue is.

https://user-images.githubusercontent.com/17562139/128592201-c1b27c18-112a-4de4-aae5-794d36c120ee.mp4


Remove the onChange method to make sure that the changed buffer will
update diagnostic at least one time