### PR TITLE
[RFC] Support callHierarchy in tree view

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -1075,6 +1075,16 @@
       "default": true,
       "description": "Recreate outline view after user changed to another buffer on current tab."
     },
+    "callHierarchy.openCommand": {
+      "type": "string",
+      "default": "edit",
+      "description": "Open command for callHierarchy tree view."
+    },
+    "callHierarchy.splitCommand": {
+      "type": "string",
+      "default": "botright 30vs",
+      "description": "Window split command used by callHierarchy tree view."
+    },
     "coc.preferences.enableMessageDialog": {
       "type": "boolean",
       "default": false,

--- a/data/schema.json
+++ b/data/schema.json
@@ -1085,6 +1085,11 @@
       "default": "botright 30vs",
       "description": "Window split command used by callHierarchy tree view."
     },
+    "callHierarchy.enableTooltip": {
+      "type": "boolean",
+      "default": true,
+      "description": "Enable tooltip to show relative filepath of call hierarchy."
+    },
     "coc.preferences.enableMessageDialog": {
       "type": "boolean",
       "default": false,

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -975,6 +975,16 @@ Built-in configurations:~
 	Recreate outline view after changed to another buffer on current tab.
 	Default `true`
 
+						*coc-config-callHierarchy*
+
+"callHierarchy.openCommand":~
+
+	Open command for callHierarchy tree view, default to "edit".
+	
+"callHierarchy.splitCommand":~
+
+	Window split command used by callHierarchy tree view.
+
 						*coc-config-npm*
 "npm.binPath":~
 
@@ -2377,6 +2387,16 @@ Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 
 	Retrieve outgoing calls from {CallHierarchyItem} or current position
 	when not provided.
+
+"showIncomingCalls"  				*coc-action-showIncomingCalls*
+
+	Show incoming calls of current function in call hierarchy tree view.
+	Configured by |coc-config-callHierarchy| and |coc-config-tree|.
+						
+"showOutgoingCalls"  				*coc-action-showOutgoingCalls*
+
+	Show outgoing calls of current function in call hierarchy tree view.
+	Configured by |coc-config-callHierarchy| and |coc-config-tree|.
 
 ------------------------------------------------------------------------------
 COMMANDS						*coc-commands*

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -2205,8 +2205,8 @@ Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 "highlight"						*coc-action-highlight*
 
 	Highlight the symbols under the cursor.
-	Overwrite the highlight groups `CocHighlightText`, `CocHighlightRead`
-	and `CocHighlightWrite` for customizing the colors.
+	Overwrite the highlight groups |CocHighlightText|, |CocHighlightRead|
+	and |CocHighlightWrite| for customizing the colors.
 
 	To enable highlight on CursorHold, create an autocmd like this: >
 
@@ -2764,6 +2764,7 @@ Others~
 *CocHoverRange* for range of current hovered symbol.
 *CocMenuSel* for current menu item in menu dialog, works on neovim only since
 vim doesn't support change highlight group of cursorline inside popup.
+*CocSelectedRange* for highlight ranges of outgoing calls.
 
 Semantic highlights~
 

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -904,11 +904,13 @@ Built-in configurations:~
 						*coc-config-tree*
 "tree.closedIcon": ~
 	
-	Closed icon of tree view, default: '+'
+	Closed icon of tree view, use '' to make it looks better when you
+	have patched font, default: '+'.
 
 "tree.openedIcon": ~
 	
-	Opened icon of tree view, default: '-'
+	Opened icon of tree view, use '' to make it looks better when you
+	have patched font, default: '-'
 
 "tree.key.toggleSelection":~
 

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -1,4 +1,4 @@
-*coc-nvim.txt*				LSP support for Vim & Neovim.
+*coc-nvim.txt*				NodeJS client for Vim & Neovim.
 
 Version: 0.0.80
 Author: Qiming Zhao <chemzqm at gmail.com>
@@ -2716,6 +2716,7 @@ Tree view related~
 CocTree* 						*CocTree*
 
 *CocTreeTitle* for title in tree view.
+*CocTreeDescription* for description beside label.
 *CocTreeOpenClose* for open and close icon in tree view.
 *CocTreeSelected* for highlight lines contains selected node.
 

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -367,7 +367,7 @@ Built-in configurations:~
 "diagnostic.autoRefresh":~
 
 	Enable automatically refresh diagnostics, use
-	|coc-action-diagnosticRefresh| action to refresh diagnostics when it's
+	|CocAction('diagnosticRefresh')| action to refresh diagnostics when it's
 	disabled.
 
 "diagnostic.enableSign":~
@@ -1207,7 +1207,7 @@ Note: Key-mappings are provided for convenient, use |CocActionAsync()| or
 Normal mode key-mappings:~
 
 *<plug>(coc-diagnostic-info)* Show diagnostic message of current position by
-invoke |coc-action-diagnosticInfo|
+invoke |CocAction('diagnosticInfo')|
 
 *<plug>(coc-diagnostic-next)* Jump to next diagnostic position.
 
@@ -1218,19 +1218,19 @@ invoke |coc-action-diagnosticInfo|
 *<plug>(coc-diagnostic-prev-error)* Jump to previous diagnostic error position.
 
 *<plug>(coc-definition)* Jump to definition(s) of current symbol by invoke
-|coc-action-jumpDefinition|
+|CocAction('jumpDefinition')|
 
 *<plug>(coc-declaration)* Jump to declaration(s) of current symbol by invoke
-||coc-action-jumpDeclaration||
+|CocAction('jumpDeclaration')|
 
 *<plug>(coc-implementation)* Jump to implementation(s) of current symbol by
-invoke ||coc-action-jumpImplementation||
+invoke |CocAction('jumpImplementation')|
 
 *<plug>(coc-type-definition)* Jump to type definition(s) of current symbol by
-invoke ||coc-action-jumpTypeDefinition||
+invoke |CocAction('jumpTypeDefinition')|
 
 *<plug>(coc-references)* Jump to references of current symbol by invoke
-|coc-action-jumpReferences|
+|CocAction('jumpReferences')|
 
 *<plug>(coc-references-used)* Jump to references of current symbol exclude
 declarations.
@@ -1250,7 +1250,7 @@ declarations.
 
 *<plug>(coc-format)*
 
-	Format the whole buffer by invoke |coc-action-format|, normally you
+	Format the whole buffer by invoke |CocAction('format')|, normally you
 	would like to use a command like: >
 
 	command! -nargs=0 Format :call CocAction('format')
@@ -1258,10 +1258,10 @@ declarations.
 	to format current buffer.
 
 *<plug>(coc-rename)* Rename symbol under cursor to a new word by invoke
-|coc-action-rename|
+|CocAction('rename')|
 
 *<plug>(coc-refactor)* Open refactor window for refactor of current symbol by
-invoke |coc-action-refactor|
+invoke |CocAction('refactor')|
 
 *<plug>(coc-command-repeat)* Repeat latest |CocCommand|.
 
@@ -1964,7 +1964,7 @@ CocAction({action}, [...{args}])			*CocAction()*
 
 	Run {action} of coc with optional extra {args}.
 
-	Checkout |coc-action| for available actions.
+	Checkout |coc-actions| for available actions.
 
 							*CocActionAsync()*
 
@@ -1975,7 +1975,7 @@ CocActionAsync({action}, [...{args}, [{callback}]])
 	Optional callback is called with `error` as the first argument and
 	`response` as the second argument.
 
-	Checkout |coc-action| for available actions.
+	Checkout |coc-actions| for available actions.
 
 CocHasProvider({feature})				*CocHasProvider()*
 
@@ -1998,41 +1998,41 @@ CocTagFunc({pattern}, {flags}, {info})			*CocTagFunc()*
 	:echo exists('&tagfunc')
 <
 ------------------------------------------------------------------------------
-							*coc-action*
+							*coc-actions*
 Available Actions ~
 
 Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 
-"sourceStat"						*coc-action-sourceStat*
+"sourceStat"						*CocAction('sourceStat')*
 
 	get the list of completion source stats for the current buffer.
 
-"refreshSource" [{source}]				*coc-action-refreshSource*
+"refreshSource" [{source}]				*CocAction('refreshSource')*
 
 	refresh all sources or a source with a name of {source}.
 
-"toggleSource" {source}					*coc-action-toggleSource*
+"toggleSource" {source}					*CocAction('toggleSource')*
 
 	enable/disable {source}.
 
-"diagnosticList"					*coc-action-diagnosticList*
+"diagnosticList"					*CocAction('diagnosticList')*
 
 	Get all diagnostic items of the current Neovim session.
 
-"diagnosticInfo"					*coc-action-diagnosticInfo*
+"diagnosticInfo"					*CocAction('diagnosticInfo')*
 
 	Show diagnostic message at the current position, do not truncate.
 
-"diagnosticToggle"					*coc-action-diagnosticToggle*
+"diagnosticToggle"					*CocAction('diagnosticToggle')*
 
 	Enable/disable diagnostics on the fly, not work when `displayByAle` is
 	enabled.
 
-"diagnosticPreview"					*coc-action-diagnosticPreview*
+"diagnosticPreview"					*CocAction('diagnosticPreview')*
 
 	Show diagnostics under current cursor in preview window.
 
-"jumpDefinition" [{openCommand}]			*coc-action-jumpDefinition*
+"jumpDefinition" [{openCommand}]			*CocAction('jumpDefinition')*
 
 	jump to definition position of the current symbol.
 	Return `v:false` when location not found.
@@ -2046,7 +2046,7 @@ Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 	{openCommand}: optional command to open buffer, default to
 	`coc.preferences.jumpCommand` in `coc-settings.json`
 
-"jumpDeclaration" [{openCommand}]			*coc-action-jumpDeclaration*
+"jumpDeclaration" [{openCommand}]			*CocAction('jumpDeclaration')*
 
 	jump to declaration position of the current symbol.
 	Return `v:false` when location not found.
@@ -2055,28 +2055,28 @@ Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 
 	When {openCommand} is `v:false`, location list would be always used.
 
-"jumpImplementation" [{openCommand}]			*coc-action-jumpImplementation*
+"jumpImplementation" [{openCommand}]			*CocAction('jumpImplementation')*
 
 	Jump to implementation position of the current symbol.
 	Return `v:false` when location not found.
 
 	same behavior as "jumpDefinition"
 
-"jumpTypeDefinition" [{openCommand}]			*coc-action-jumpTypeDefinition*
+"jumpTypeDefinition" [{openCommand}]			*CocAction('jumpTypeDefinition')*
 
 	Jump to type definition position of the current symbol.
 	Return `v:false` when location not found.
 
 	same behavior as "jumpDefinition"
 
-"jumpReferences" [{openCommand}]			*coc-action-jumpReferences*
+"jumpReferences" [{openCommand}]			*CocAction('jumpReferences')*
 
 	Jump to references position of the current symbol.
 	Return `v:false` when location not found.
 
 	same behavior as "jumpDefinition"
 
-"doHover" [{hoverTarget}]				*coc-action-doHover*
+"doHover" [{hoverTarget}]				*CocAction('doHover')*
 
 	Show documentation of  current symbol, return `v:false` when hover not
 	found.
@@ -2085,17 +2085,17 @@ Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 	defaults to `coc.preferences.hoverTarget` in `coc-settings.json`.
 	Valid options: ["preview", "echo", "float"]
 	
-"definitionHover" [{hoverTarget}]			*coc-action-definitionHover*
+"definitionHover" [{hoverTarget}]			*CocAction('definitionHover')*
 
-	Same as |coc-action-doHover| but includes definition contents from
+	Same as |CocAction('doHover')|, but includes definition contents from
 	definition provider when possible.
 
-"getHover"						*coc-action-getHover*
+"getHover"						*CocAction('getHover')*
 
 	Get documentation text array on current position, returns array of
 	string.
 
-"showSignatureHelp"					*coc-action-showSignatureHelp*
+"showSignatureHelp"					*CocAction('showSignatureHelp')*
 
 	Echo signature help of current function, return `v:false` when
 	signature not found.  You may want to set up an autocmd like this: >
@@ -2103,15 +2103,15 @@ Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 	autocmd User CocJumpPlaceholder call
 				\ CocActionAsync('showSignatureHelp')
 <
-"getCurrentFunctionSymbol"				 *coc-action-getCurrentFunctionSymbol*
+"getCurrentFunctionSymbol"				 *CocAction('getCurrentFunctionSymbol')*
 
 	Return the function string that current cursor in.
 
-"documentSymbols" [{bufnr}]				*coc-action-documentSymbols*
+"documentSymbols" [{bufnr}]				*CocAction('documentSymbols')*
 
 	Get a list of symbols of current buffer or specific {bufnr}.
 
-"ensureDocument" 					*coc-action-ensureDocument*
+"ensureDocument" 					*CocAction('ensureDocument')*
 
 	Ensure current document is attached to coc.nvim, should be used when
 	you need invoke action of current document just after document
@@ -2126,7 +2126,7 @@ Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 	configuration.
 	4. The buffer is used for command line window.
 
-"rename"						*coc-action-rename*
+"rename"						*CocAction'(rename)*
 
 	Rename the symbol under the cursor position, user will be prompted for
 	a new name.
@@ -2134,24 +2134,24 @@ Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 	Note: coc.nvim supports rename for disk files, but your language server
 	may not.
 
-"selectionRanges"					*coc-action-selectionRanges*
+"selectionRanges"					*CocAction('selectionRanges')*
 
 	Get selection ranges of current position from language server.
 
-"services"						*coc-action-services*
+"services"						*CocAction('services')*
 
 	Get an information list for all services.
 
-"toggleService" {serviceId}				*coc-action-toggleService*
+"toggleService" {serviceId}				*CocAction('toggleService')*
 
 	Start or stop a service.
 
-"format"						*coc-action-format*
+"format"						*CocAction('format')*
 
 	Format current buffer using the language server.
 	Return `v:false` when format failed.
 
-"formatSelected" [{mode}]				*coc-action-formatSelected*
+"formatSelected" [{mode}]				*CocAction('formatSelected')*
 
 	Format the selected range, {mode} should be one of visual mode: `v` ,
 	`V`, `char`, `line`.
@@ -2159,7 +2159,7 @@ Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 	When {mode} is omitted, it should be called using |formatexpr|.
 
 
-"codeAction" [{mode}] [{only}]				*coc-action-codeAction*
+"codeAction" [{mode}] [{only}]				*CocAction('codeAction')*
 
 	Prompt for a code action and do it.
 
@@ -2168,26 +2168,26 @@ Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 
 	{only} can be title of a codeAction or list of CodeActionKind.
 
-"codeActionRange" {start} {end} [{kind}]		*coc-action-codeActionRange*
+"codeActionRange" {start} {end} [{kind}]		*CocAction('codeActionRange')*
 
 	Run code action for range.
 
 	{start} start line number of range.
 	{end} end line number of range.
-	{kind} code action kind, see |coc-action-codeActions| for available
+	{kind} code action kind, see |CocAction('codeActions')| for available
 	action kind.
 
-"codeLensAction"					*coc-action-codeLensAction*
+"codeLensAction"					*CocAction('codeLensAction')*
 
 	Invoke the command for codeLens of current line (or the line that
 	contains codeLens just above). Prompt would be shown when multiple
 	actions are available.
 
-"commands"						*coc-action-commands*
+"commands"						*CocAction('commands')*
 
 	Get a list of available service commands for the current buffer.
 
-"runCommand" [{name}] [...{args}]			*coc-action-runCommand*
+"runCommand" [{name}] [...{args}]			*CocAction('runCommand')*
 
 	Run a global command provided by the language server. If {name} is not
 	provided, a prompt with a list of commands is shown to be selected.
@@ -2199,14 +2199,14 @@ Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 	command! -nargs=0 OrganizeImport
 		\ :call CocActionAsync('runCommand', 'tsserver.organizeImports')
 
-"fold" {{kind}}						*coc-action-fold*
+"fold" {{kind}}						*CocAction('fold')*
 
 	Fold the current buffer, optionally use {kind} for filtering folds,
 	{kind} could be either 'comment', 'imports' or 'region'
 
 	Return `v:false` when failed.
 
-"highlight"						*coc-action-highlight*
+"highlight"						*CocAction('highlight')*
 
 	Highlight the symbols under the cursor.
 	Overwrite the highlight groups |CocHighlightText|, |CocHighlightRead|
@@ -2216,7 +2216,7 @@ Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 
 	autocmd CursorHold * silent call CocActionAsync('highlight')
 <
-"openLink" [{command}]					*coc-action-openlink*
+"openLink" [{command}]					*CocAction('openlink')*
 
 	Open a link under the cursor with {command}.
 	{command} default to `edit`.
@@ -2225,34 +2225,34 @@ Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 
 	Note: it needs language server support documentLink feature to work.
 
-"extensionStats"					*coc-action-extensionStats*
+"extensionStats"					*CocAction('extensionStats')*
 
 	Get all extension states as a list. Including `id`, `root` and
 	`state`.
 
 	State could be `disabled`, `activated` and `loaded`.
 
-"toggleExtension" {id}					*coc-action-toggleExtension*
+"toggleExtension" {id}					*CocAction('toggleExtension')*
 
 	Enable/disable an extension.
 
-"uninstallExtension" {id}				*coc-action-uninstallExtension*
+"uninstallExtension" {id}				*CocAction('uninstallExtension')*
 
 	Uninstall an extension.
 
-"reloadExtension" {id}					*coc-action-reloadExtension*
+"reloadExtension" {id}					*CocAction('reloadExtension')*
 
 	Reload an activated extension.
 
-"activeExtension" {id}					*coc-action-activeExtension*
+"activeExtension" {id}					*CocAction('activeExtension')*
 
 	Activate extension of {id}.
 
-"deactivateExtension" {id}				*coc-action-deactivateExtension*
+"deactivateExtension" {id}				*CocAction('deactivateExtension')*
 
 	Deactivate extension of {id}.
 
-"pickColor"						*coc-action-pickColor*
+"pickColor"						*CocAction'(pickColor)*
 
 	Change the color at the current cursor position.
 
@@ -2261,14 +2261,14 @@ Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 	Note: only works on mac or when you have python support on Vim and
 	have the gtk module installed.
 
-"colorPresentation"					*coc-action-colorPresentation*
+"colorPresentation"					*CocAction('colorPresentation')*
 
 	Change the color presentation at the current color position.
 
 	Requires a language server that supports color representation
 	requests.
 
-"codeActions" [{mode}] [{only}]				*coc-action-codeActions*
+"codeActions" [{mode}] [{only}]				*CocAction('codeActions')*
 
 	Get and invoke codeActions on current document, quickpick menu would
 	be shown when there're many codeActions.
@@ -2289,52 +2289,52 @@ Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 
 	{only} can also be string, which means filter by tilte of codeAction.
 
-"organizeImport" 					*coc-action-organizeImport*
+"organizeImport" 					*CocAction('organizeImport')*
 
 	Run organize import codeAction for current buffer.
 	Show warning when codeAction not found.
 
-"fixAll" 						*coc-action-fixAll*
+"fixAll" 						*CocAction('fixAll')*
 
 	Run fixAll codeAction for current buffer.
 	Show warning when codeAction not found.
 
 
-"quickfixes" [{visualmode}]				*coc-action-quickfixes*
+"quickfixes" [{visualmode}]				*CocAction('quickfixes')*
 
 	Get quickfix codeActions of current buffer.
 
 	Add {visualmode} as second argument get quickfix actions with range of
 	latest |visualmode()|
 
-"doCodeAction" {codeAction}				*coc-action-doCodeAction*
+"doCodeAction" {codeAction}				*CocAction('doCodeAction')*
 
 	Do a codeAction.
 
-"doQuickfix"						*coc-action-doQuickfix*
+"doQuickfix"						*CocAction('doQuickfix')*
 
 	Do the first preferred quickfix action on current line.
 
 	Throw error when no quickfix action found.
 
-"addRanges" {ranges}					*coc-action-addRanges*
+"addRanges" {ranges}					*CocAction('addRanges')*
 
 	Ranges must be provided as array of range type: https://git.io/fjiEG
 
-"getWordEdit"						 *coc-action-getWordEdit*
+"getWordEdit"						 *CocAction('getWordEdit')*
 
 	Get workspaceEdit of current word, language server used when possible,
 	extract word from current buffer as fallback.
 
-"getWorkspaceSymbols" {input}			*coc-action-getWorkspaceSymbols*
+"getWorkspaceSymbols" {input}			*CocAction(getWorkspaceSymbols)*
 
 	Get workspace symbols from {input}.
 
-"resolveWorkspaceSymbol" {symbol} 		 *coc-action-resolveWorkspaceSymbol*
+"resolveWorkspaceSymbol" {symbol} 		 *CocAction('resolveWorkspaceSymbol')*
 
 	Resolve location for workspace {symbol}.
 
-"diagnosticToggleBuffer" [{bufnr}]		 *coc-action-diagnosticToggleBuffer*
+"diagnosticToggleBuffer" [{bufnr}]		 *CocAction('diagnosticToggleBuffer')*
 
 	Toggle diagnostics for specific buffer, current buffer is used when
 	{bufnr} not provided.
@@ -2342,17 +2342,18 @@ Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 	Note: this will only affect diagnostics shown in the UI, list of all
 	diagnostics won't change.
 
-"diagnosticRefresh" [{bufnr}] 			*coc-action-diagnosticRefresh*
+"diagnosticRefresh" [{bufnr}] 			*CocAction('diagnosticRefresh')*
 
 	Force refresh diagnostics for special buffer with {bufnr} or all buffers
 	when {bufnr} not exists, returns `v:null` before diagnostics are shown.
 
 	Useful when `diagnostic.autoRefresh` is `false`.
 
-"showOutline" [{keep}]				*coc-action-showOutline*
+"showOutline" [{keep}]				*CocAction('showOutline')*
 
-	Show outline tree view for current buffer. Old outline view on current
+	Show outline tree view for current buffer. Old outline window on current
 	tab would be replaced.
+	Outline view has Window variable `cocViewId` set to `OUTLINE`.
 
 	{keep} override `"outline.keepWindow"` configuration when specified.
 	Could be 0 or 1.
@@ -2365,7 +2366,7 @@ Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 	provider existence.
 
 	Note: error is shown when current buffer is not attatched, checkout
-	|coc-action-ensureDocument| for possible reasons.
+	|CocAction('ensureDocument')|, for possible reasons.
 
 	Checkout |coc-config-tree| and |coc-config-outline| for available
 	configurations.
@@ -2379,30 +2380,41 @@ Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 	autocmd VimEnter,Tabnew *
 		\ if empty(&buftype) | call CocActionAsync('showOutline', 1) | endif
 <
-"hideOutline" 					*coc-action-hideOutline*
+"hideOutline" 					*CocAction('hideOutline')*
 
 	Close outline window on current tab.  Throws vim error when it can't
 	be closed by vim.
 
-"incomingCalls" [{CallHierarchyItem}] 		*coc-action-incomingCalls*
+"incomingCalls" [{CallHierarchyItem}] 		*CocAction('incomingCalls')*
 
 	Retrieve incoming calls from {CallHierarchyItem} or current position
 	when not provided.
 
-"outgoingCalls" [{CallHierarchyItem}] 		*coc-action-outgoingCalls*
+"outgoingCalls" [{CallHierarchyItem}] 		*CocAction('outgoingCalls')*
 
 	Retrieve outgoing calls from {CallHierarchyItem} or current position
 	when not provided.
 
-"showIncomingCalls"  				*coc-action-showIncomingCalls*
+"showIncomingCalls"  				*CocAction('showIncomingCalls')*
 
-	Show incoming calls of current function in call hierarchy tree view.
-	Configured by |coc-config-callHierarchy| and |coc-config-tree|.
-						
-"showOutgoingCalls"  				*coc-action-showOutgoingCalls*
+	Show incoming calls of current function with |coc-tree|,
+	Configured by |CocSymbol|, |coc-config-callHierarchy| and
+	|coc-config-tree|.
 
-	Show outgoing calls of current function in call hierarchy tree view.
-	Configured by |coc-config-callHierarchy| and |coc-config-tree|.
+	Related ranges are highlighted with |CocSelectedRange| highlight
+	group.
+
+	|coc-dialog-menu| could be invoked by key configured by
+	`"tree.key.actions".  Available actions:
+
+	- Open in new tab.
+	- Show Incoming Calls.
+	- Show Outgoing Calls.
+
+
+"showOutgoingCalls"  				*CocAction('showOutgoingCalls')*
+
+	Show outgoing calls of current function with |coc-tree|.
 
 ------------------------------------------------------------------------------
 COMMANDS						*coc-commands*
@@ -2576,7 +2588,7 @@ COMMANDS						*coc-commands*
 
 :CocOutline 							*:CocOutline*
 
-	Invoke |coc-action-showOutline| by notification.
+	Invoke |CocAction('showOutline')| by notification.
 
 ------------------------------------------------------------------------------
 AUTOCMD							*coc-autocmds*
@@ -2594,7 +2606,7 @@ AUTOCMD							*coc-autocmds*
 	let g:coc_enable_locationlist = 0
 	autocmd User CocLocationsChange CocList --normal location
 <
-						*CocNvimInit*
+							*CocNvimInit*
 :autocmd User CocNvimInit {command}
 
 	Triggered after the coc services have started.
@@ -2602,14 +2614,14 @@ AUTOCMD							*coc-autocmds*
 	If you want to trigger an action of coc after Vim has started, this
 	autocmd should be used because coc is always started asynchronously.
 
-						*CocStatusChange*
+							*CocStatusChange*
 
 :autocmd User CocStatusChange {command}
 
 	Triggered after `g:coc_status` changed, can be used for refresh
 	stautsline.
 
-						*CocDiagnosticChange*
+							*CocDiagnosticChange*
 
 :autocmd User CocDiagnosticChange {command}
 
@@ -2617,7 +2629,7 @@ AUTOCMD							*coc-autocmds*
 
 	Could be used for updating the statusline.
 
-						*CocJumpPlaceholder*
+							*CocJumpPlaceholder*
 
 :autocmd User CocJumpPlaceholder {command}
 
@@ -2626,14 +2638,14 @@ AUTOCMD							*coc-autocmds*
 
 	autocmd User CocJumpPlaceholder call CocActionAsync('showSignatureHelp')
 <
-						*CocOpenFloat*
+							*CocOpenFloat*
 
 :autocmd User CocOpenFloat {command}
 
 	Triggered when a floating window is opened.  The window is not
 	focused, use |g:coc_last_float_win| to get window id.
 
-						*CocTerminalOpen*
+							*CocTerminalOpen*
 :autocmd User CocTerminalOpen {command}
 
 	Triggered when the terminal is shown, can be used for adjusting the
@@ -2807,8 +2819,8 @@ CocSem_*						*CocSem*
 ==============================================================================
 TREE SUPPORT 						*coc-tree*
 
-Tree view is used for |coc-action-showOutline|, following features are
-supported:
+Tree view is used for render outline and call hierarchy, following features
+are supported:
 
 - Data update while keep tree node open/close state.
 - Auto refresh on load error.
@@ -2825,6 +2837,8 @@ Check |coc-config-tree| for related configurations.
 
 The filetype is `'coctree'`, which can be used to overwrite buffer and window
 options.
+
+Use variable |w:cocViewId| to detect the kind of tree.
 
 ------------------------------------------------------------------------------
 

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -2407,6 +2407,7 @@ Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 	|coc-dialog-menu| could be invoked by key configured by
 	`"tree.key.actions".  Available actions:
 
+	- Dismiss.
 	- Open in new tab.
 	- Show Incoming Calls.
 	- Show Outgoing Calls.

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -987,6 +987,10 @@ Built-in configurations:~
 
 	Window split command used by callHierarchy tree view.
 
+"callHierarchy.enableTooltip":~
+
+	Enable tooltip to show relative filepath of call hierarchy.
+
 						*coc-config-npm*
 "npm.binPath":~
 

--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -377,6 +377,7 @@ function! s:Hi() abort
   hi default link CocHighlightWrite CocHighlightText
   " Tree view highlights
   hi default link CocTreeTitle Title
+  hi default link CocTreeDescription Comment
   hi default link CocTreeOpenClose CocBold
   hi default link CocTreeSelected CursorLine
   " Symbol highlights

--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -380,6 +380,7 @@ function! s:Hi() abort
   hi default link CocTreeDescription Comment
   hi default link CocTreeOpenClose CocBold
   hi default link CocTreeSelected CursorLine
+  hi default link CocSelectedRange  CocHighlightText
   " Symbol highlights
   hi default link CocSymbolDefault MoreMsg
   hi default link CocSymbolFile Statement

--- a/src/__tests__/handler/callHierarchy.test.ts
+++ b/src/__tests__/handler/callHierarchy.test.ts
@@ -1,9 +1,11 @@
 import { Neovim } from '@chemzqm/neovim'
-import { Disposable, CallHierarchyItem, SymbolKind, Range } from 'vscode-languageserver-protocol'
+import { Disposable, CallHierarchyItem, SymbolKind, Range, SymbolTag } from 'vscode-languageserver-protocol'
 import CallHierarchyHandler from '../../handler/callHierarchy'
 import languages from '../../languages'
+import workspace from '../../workspace'
 import { disposeAll } from '../../util'
-import helper from '../helper'
+import { URI } from 'vscode-uri'
+import helper, { createTmpFile } from '../helper'
 
 let nvim: Neovim
 let callHierarchy: CallHierarchyHandler
@@ -11,7 +13,7 @@ let disposables: Disposable[] = []
 beforeAll(async () => {
   await helper.setup()
   nvim = helper.nvim
-  callHierarchy = (helper.plugin as any).handler.callHierarchy
+  callHierarchy = helper.plugin.getHandler().callHierarchy
 })
 
 afterAll(async () => {
@@ -38,24 +40,30 @@ function createCallItem(name: string, kind: SymbolKind, uri: string, range: Rang
 }
 
 describe('CallHierarchy', () => {
-  it('should throw for invalid incoming item', async () => {
+  it('should throw for when provider not exists', async () => {
     let err
     try {
-      await callHierarchy.getIncoming({} as any)
+      await callHierarchy.getIncoming()
     } catch (e) {
       err = e
     }
     expect(err).toBeDefined()
   })
 
-  it('should throw for invalid outgoint item', async () => {
-    let err
-    try {
-      await callHierarchy.getOutgoing({} as any)
-    } catch (e) {
-      err = e
-    }
-    expect(err).toBeDefined()
+  it('should get undefined when prepare failed', async () => {
+    disposables.push(languages.registerCallHierarchyProvider([{ language: '*' }], {
+      prepareCallHierarchy() {
+        return undefined
+      },
+      provideCallHierarchyIncomingCalls() {
+        return []
+      },
+      provideCallHierarchyOutgoingCalls() {
+        return []
+      }
+    }))
+    let res = await callHierarchy.getOutgoing()
+    expect(res).toBeUndefined()
   })
 
   it('should get incoming & outgoing callHierarchy items', async () => {
@@ -81,5 +89,310 @@ describe('CallHierarchy', () => {
     expect(res[0].from.name).toBe('bar')
     let outgoing = await callHierarchy.getOutgoing()
     expect(outgoing.length).toBe(1)
+    res = await callHierarchy.getIncoming(outgoing[0].to)
+    expect(res.length).toBe(1)
+  })
+
+  it('should show message when provider not exists', async () => {
+    await callHierarchy.showCallHierarchyTree('incoming')
+    let buf = await nvim.buffer
+    let lines = await buf.lines
+    expect(lines[0]).toMatch('callHierarchy provider not found')
+    await nvim.command('wincmd p')
+  })
+
+  it('should no results when no result returned.', async () => {
+    disposables.push(languages.registerCallHierarchyProvider([{ language: '*' }], {
+      prepareCallHierarchy() {
+        return []
+      },
+      provideCallHierarchyIncomingCalls() {
+        return []
+      },
+      provideCallHierarchyOutgoingCalls() {
+        return []
+      }
+    }))
+    await callHierarchy.showCallHierarchyTree('incoming')
+    let buf = await nvim.buffer
+    let lines = await buf.lines
+    expect(lines[0]).toBe('No results')
+    await nvim.command('wincmd p')
+  })
+
+  it('should render description and support default action', async () => {
+    let doc = await workspace.document
+    let bufnr = doc.bufnr
+    await doc.buffer.setLines(['foo'], { start: 0, end: -1, strictIndexing: false })
+    let fsPath = await createTmpFile('foo\nbar\ncontent\n')
+    let uri = URI.file(fsPath).toString()
+    disposables.push(languages.registerCallHierarchyProvider([{ language: '*' }], {
+      prepareCallHierarchy() {
+        return createCallItem('foo', SymbolKind.Class, doc.uri, Range.create(0, 0, 0, 3))
+      },
+      provideCallHierarchyIncomingCalls() {
+        let item = createCallItem('bar', SymbolKind.Class, uri, Range.create(1, 0, 1, 3))
+        item.detail = 'Detail'
+        item.tags = [SymbolTag.Deprecated]
+        return [{
+          from: item,
+          fromRanges: [Range.create(2, 0, 2, 5)]
+        }]
+      },
+      provideCallHierarchyOutgoingCalls() {
+        return []
+      }
+    }))
+    await callHierarchy.showCallHierarchyTree('incoming')
+    let buf = await nvim.buffer
+    let lines = await buf.lines
+    expect(lines).toEqual([
+      'INCOMING CALLS',
+      '- c foo',
+      '  + c bar Detail'
+    ])
+    await nvim.command('exe 3')
+    await nvim.input('t')
+    await helper.wait(50)
+    let line = await nvim.line
+    expect(line).toEqual('  - c bar Detail')
+    await nvim.input('<cr>')
+    await helper.wait(50)
+    doc = await workspace.document
+    expect(doc.uri).toBe(uri)
+    let res = await nvim.call('coc#util#cursor')
+    expect(res).toEqual([1, 0])
+    let matches = await nvim.call('getmatches') as any[]
+    expect(matches.length).toBe(2)
+    await nvim.command(`b ${bufnr}`)
+    await helper.wait(50)
+    matches = await nvim.call('getmatches')
+    expect(matches.length).toBe(0)
+    await nvim.command(`wincmd o`)
+    await helper.wait(50)
+  })
+
+  it('should invoke open in new tab action', async () => {
+    let doc = await workspace.document
+    await doc.buffer.setLines(['foo', 'bar'], { start: 0, end: -1, strictIndexing: false })
+    let fsPath = await createTmpFile('foo\nbar\ncontent\n')
+    let uri = URI.file(fsPath).toString()
+    disposables.push(languages.registerCallHierarchyProvider([{ language: '*' }], {
+      prepareCallHierarchy() {
+        return createCallItem('foo', SymbolKind.Class, doc.uri, Range.create(0, 0, 0, 3))
+      },
+      provideCallHierarchyIncomingCalls() {
+        return []
+      },
+      provideCallHierarchyOutgoingCalls() {
+        let item = createCallItem('bar', SymbolKind.Class, uri, Range.create(0, 0, 0, 1))
+        item.detail = 'Detail'
+        return [{
+          to: item,
+          fromRanges: [Range.create(1, 0, 1, 3)]
+        }]
+      }
+    }))
+    let win = await nvim.window
+    let tab = await nvim.call('tabpagenr')
+    await callHierarchy.showCallHierarchyTree('outgoing')
+    let buf = await nvim.buffer
+    let lines = await buf.lines
+    expect(lines).toEqual([
+      'OUTGOING CALLS',
+      '- c foo',
+      '  + c bar Detail'
+    ])
+    await nvim.command('exe 3')
+    await nvim.input('<tab>')
+    await helper.wait(50)
+    await nvim.input('<cr>')
+    await helper.wait(200)
+    let newTab = await nvim.call('tabpagenr')
+    expect(newTab != tab).toBe(true)
+    doc = await workspace.document
+    expect(doc.uri).toBe(uri)
+    let res = await nvim.call('getmatches', [win.id])
+    expect(res.length).toBe(1)
+  })
+
+  it('should invoke show incoming calls action', async () => {
+    let doc = await workspace.document
+    await doc.buffer.setLines(['foo', 'bar'], { start: 0, end: -1, strictIndexing: false })
+    let fsPath = await createTmpFile('foo\nbar\ncontent\n')
+    let uri = URI.file(fsPath).toString()
+    disposables.push(languages.registerCallHierarchyProvider([{ language: '*' }], {
+      prepareCallHierarchy() {
+        return createCallItem('foo', SymbolKind.Class, doc.uri, Range.create(0, 0, 0, 3))
+      },
+      provideCallHierarchyIncomingCalls() {
+        return [{
+          from: createCallItem('test', SymbolKind.Class, 'test:///bar', Range.create(1, 0, 1, 5)),
+          fromRanges: [Range.create(0, 0, 0, 5)]
+        }]
+      },
+      provideCallHierarchyOutgoingCalls() {
+        let item = createCallItem('bar', SymbolKind.Class, uri, Range.create(0, 0, 0, 1))
+        item.detail = 'Detail'
+        return [{
+          to: item,
+          fromRanges: [Range.create(1, 0, 1, 3)]
+        }]
+      }
+    }))
+    await callHierarchy.showCallHierarchyTree('outgoing')
+    let buf = await nvim.buffer
+    let lines = await buf.lines
+    expect(lines).toEqual([
+      'OUTGOING CALLS',
+      '- c foo',
+      '  + c bar Detail'
+    ])
+    await nvim.command('exe 3')
+    await nvim.input('<tab>')
+    await helper.wait(50)
+    await nvim.input('2')
+    await helper.wait(200)
+    lines = await buf.lines
+    expect(lines).toEqual([
+      'INCOMING CALLS',
+      '- c bar Detail',
+      '  + c test'
+    ])
+    await nvim.command('bd!')
+  })
+
+  it('should invoke show outgoing calls action', async () => {
+    let doc = await workspace.document
+    await doc.buffer.setLines(['foo', 'bar'], { start: 0, end: -1, strictIndexing: false })
+    let fsPath = await createTmpFile('foo\nbar\ncontent\n')
+    let uri = URI.file(fsPath).toString()
+    disposables.push(languages.registerCallHierarchyProvider([{ language: '*' }], {
+      prepareCallHierarchy() {
+        return createCallItem('foo', SymbolKind.Class, doc.uri, Range.create(0, 0, 0, 3))
+      },
+      provideCallHierarchyIncomingCalls() {
+        return [{
+          from: createCallItem('test', SymbolKind.Class, 'test:///bar', Range.create(1, 0, 1, 5)),
+          fromRanges: [Range.create(0, 0, 0, 5)]
+        }]
+      },
+      provideCallHierarchyOutgoingCalls() {
+        let item = createCallItem('bar', SymbolKind.Class, uri, Range.create(0, 0, 0, 1))
+        item.detail = 'Detail'
+        return [{
+          to: item,
+          fromRanges: [Range.create(1, 0, 1, 3)]
+        }]
+      }
+    }))
+    await callHierarchy.showCallHierarchyTree('incoming')
+    let buf = await nvim.buffer
+    let lines = await buf.lines
+    expect(lines).toEqual([
+      'INCOMING CALLS',
+      '- c foo',
+      '  + c test'
+    ])
+    await nvim.command('exe 3')
+    await nvim.input('<tab>')
+    await helper.wait(50)
+    await nvim.input('3')
+    await helper.wait(200)
+    lines = await buf.lines
+    expect(lines).toEqual([
+      'OUTGOING CALLS',
+      '- c test',
+      '  + c bar Detail'
+    ])
+    await nvim.command('bd!')
+  })
+
+  it('should invoke dismiss action #1', async () => {
+    let doc = await workspace.document
+    await doc.buffer.setLines(['foo', 'bar'], { start: 0, end: -1, strictIndexing: false })
+    let fsPath = await createTmpFile('foo\nbar\ncontent\n')
+    let uri = URI.file(fsPath).toString()
+    disposables.push(languages.registerCallHierarchyProvider([{ language: '*' }], {
+      prepareCallHierarchy() {
+        return createCallItem('foo', SymbolKind.Class, doc.uri, Range.create(0, 0, 0, 3))
+      },
+      provideCallHierarchyIncomingCalls() {
+        return []
+      },
+      provideCallHierarchyOutgoingCalls() {
+        let item = createCallItem('bar', SymbolKind.Class, uri, Range.create(0, 0, 0, 1))
+        item.detail = 'Detail'
+        return [{
+          to: item,
+          fromRanges: [Range.create(1, 0, 1, 3)]
+        }]
+      }
+    }))
+    await callHierarchy.showCallHierarchyTree('outgoing')
+    let buf = await nvim.buffer
+    let lines = await buf.lines
+    expect(lines).toEqual([
+      'OUTGOING CALLS',
+      '- c foo',
+      '  + c bar Detail'
+    ])
+    await nvim.command('exe 3')
+    await nvim.input('<tab>')
+    await helper.wait(50)
+    await nvim.input('4')
+    await helper.wait(200)
+    lines = await buf.lines
+    expect(lines).toEqual([
+      'OUTGOING CALLS',
+      '- c foo'
+    ])
+    await nvim.command('wincmd c')
+  })
+
+  it('should invoke dismiss action #2', async () => {
+    let doc = await workspace.document
+    await doc.buffer.setLines(['foo', 'bar'], { start: 0, end: -1, strictIndexing: false })
+    let fsPath = await createTmpFile('foo\nbar\ncontent\n')
+    let uri = URI.file(fsPath).toString()
+    disposables.push(languages.registerCallHierarchyProvider([{ language: '*' }], {
+      prepareCallHierarchy() {
+        return createCallItem('foo', SymbolKind.Class, doc.uri, Range.create(0, 0, 0, 3))
+      },
+      provideCallHierarchyIncomingCalls() {
+        return []
+      },
+      provideCallHierarchyOutgoingCalls() {
+        let item = createCallItem('bar', SymbolKind.Class, uri, Range.create(0, 0, 0, 1))
+        item.detail = 'Detail'
+        return [{
+          to: item,
+          fromRanges: [Range.create(1, 0, 1, 3)]
+        }]
+      }
+    }))
+    await callHierarchy.showCallHierarchyTree('outgoing')
+    let buf = await nvim.buffer
+    let lines = await buf.lines
+    expect(lines).toEqual([
+      'OUTGOING CALLS',
+      '- c foo',
+      '  + c bar Detail'
+    ])
+    await nvim.command('exe 3')
+    await nvim.input('t')
+    await helper.wait(50)
+    await nvim.command('exe 4')
+    await nvim.input('<tab>')
+    await helper.wait(50)
+    await nvim.input('4')
+    await helper.wait(200)
+    lines = await buf.lines
+    expect(lines).toEqual([
+      'OUTGOING CALLS',
+      '- c foo',
+      '  - c bar Detail'
+    ])
+    await nvim.command('wincmd c')
   })
 })

--- a/src/__tests__/handler/locations.test.ts
+++ b/src/__tests__/handler/locations.test.ts
@@ -18,7 +18,7 @@ beforeAll(async () => {
   Object.assign(workspace.env, {
     locationlist: false
   })
-  locations = (helper.plugin as any).handler.locations
+  locations = helper.plugin.getHandler().locations
 })
 
 afterAll(async () => {
@@ -61,6 +61,12 @@ describe('locations', () => {
       let name = await nvim.call('bufname', ['%'])
       expect(name).toBe('test://foo')
     })
+
+    it('should return false when references not found', async () => {
+      currLocations = []
+      let res = await locations.gotoReferences('edit', true)
+      expect(res).toBe(false)
+    })
   })
 
   describe('definition', () => {
@@ -84,6 +90,12 @@ describe('locations', () => {
       expect(res).toBe(true)
       let name = await nvim.call('bufname', ['%'])
       expect(name).toBe('test://foo')
+    })
+
+    it('should return false when definitions not found', async () => {
+      currLocations = []
+      let res = await locations.gotoDefinition('edit')
+      expect(res).toBe(false)
     })
   })
 
@@ -109,6 +121,12 @@ describe('locations', () => {
       let name = await nvim.call('bufname', ['%'])
       expect(name).toBe('test://foo')
     })
+
+    it('should return false when declaration not found', async () => {
+      currLocations = []
+      let res = await locations.gotoDeclaration('edit')
+      expect(res).toBe(false)
+    })
   })
 
   describe('typeDefinition', () => {
@@ -120,18 +138,24 @@ describe('locations', () => {
       }))
     })
 
-    it('should get declarations', async () => {
+    it('should get type definition', async () => {
       currLocations = [createLocation('foo', 0, 0, 0, 0), createLocation('bar', 0, 0, 0, 0)]
       let res = await locations.typeDefinitions() as Location[]
       expect(res.length).toBe(2)
     })
 
-    it('should jump to declaration', async () => {
+    it('should jump to type definition', async () => {
       currLocations = [createLocation('foo', 0, 0, 0, 0)]
       let res = await locations.gotoTypeDefinition('edit')
       expect(res).toBe(true)
       let name = await nvim.call('bufname', ['%'])
       expect(name).toBe('test://foo')
+    })
+
+    it('should return false when type definition not found', async () => {
+      currLocations = []
+      let res = await locations.gotoTypeDefinition('edit')
+      expect(res).toBe(false)
     })
   })
 
@@ -144,18 +168,24 @@ describe('locations', () => {
       }))
     })
 
-    it('should get declarations', async () => {
+    it('should get implementations', async () => {
       currLocations = [createLocation('foo', 0, 0, 0, 0), createLocation('bar', 0, 0, 0, 0)]
       let res = await locations.implementations() as Location[]
       expect(res.length).toBe(2)
     })
 
-    it('should jump to declaration', async () => {
+    it('should jump to implementation', async () => {
       currLocations = [createLocation('foo', 0, 0, 0, 0)]
       let res = await locations.gotoImplementation('edit')
       expect(res).toBe(true)
       let name = await nvim.call('bufname', ['%'])
       expect(name).toBe('test://foo')
+    })
+
+    it('should return false when implementation not found', async () => {
+      currLocations = []
+      let res = await locations.gotoImplementation('edit')
+      expect(res).toBe(false)
     })
   })
 

--- a/src/__tests__/handler/outline.test.ts
+++ b/src/__tests__/handler/outline.test.ts
@@ -139,7 +139,7 @@ describe('symbols outline', () => {
       await createBuffer()
       await symbols.showOutline(1)
       await helper.edit('unnamed')
-      await helper.wait(200)
+      await helper.wait(300)
       let buf = await getOutlineBuffer()
       let lines = await buf.lines
       expect(lines).toEqual(['Document symbol provider not found'])
@@ -322,7 +322,11 @@ describe('symbols outline', () => {
       await helper.wait(200)
       buf = await getOutlineBuffer()
       let lines = await buf.lines
-      expect(lines).toEqual(['OUTLINE'])
+      expect(lines).toEqual([
+        'No results',
+        '',
+        'OUTLINE'
+      ])
     })
   })
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -183,6 +183,18 @@ export class CommandManager implements Disposable {
       }
     }, false, 'open output buffer to show output from languageservers or extensions.')
     this.register({
+      id: 'document.showIncomingCalls',
+      execute: async () => {
+        await plugin.cocAction('showIncomingCalls')
+      }
+    }, false, 'show incoming calls in tree view.')
+    this.register({
+      id: 'document.showOutgoingCalls',
+      execute: async () => {
+        await plugin.cocAction('showOutgoingCalls')
+      }
+    }, false, 'show outgoing calls in tree view.')
+    this.register({
       id: 'document.echoFiletype',
       execute: async () => {
         let bufnr = await nvim.call('bufnr', '%')
@@ -243,6 +255,13 @@ export class CommandManager implements Disposable {
         await window.moveTo(ranges[0].start)
       }
     }, false, 'Jump to next symbol highlight position.')
+    this.register({
+      id: 'workspace.openLocation',
+      execute: async (winid: number, loc: Location, openCommand?: string) => {
+        if (winid) await nvim.call('win_gotoid', [winid])
+        await workspace.jumpTo(loc.uri, loc.range.start, openCommand)
+      }
+    }, true)
     this.register({
       id: 'document.jumpToPrevSymbol',
       execute: async () => {

--- a/src/handler/callHierarchy.ts
+++ b/src/handler/callHierarchy.ts
@@ -1,7 +1,24 @@
 import { Neovim } from '@chemzqm/neovim'
-import { CallHierarchyIncomingCall, Range, CallHierarchyItem, CallHierarchyOutgoingCall, CancellationTokenSource } from 'vscode-languageserver-protocol'
+import { CallHierarchyIncomingCall, Position, Range, CallHierarchyItem, CallHierarchyOutgoingCall, CancellationTokenSource, SymbolKind, SymbolTag, Location, Disposable, CancellationToken } from 'vscode-languageserver-protocol'
 import languages from '../languages'
-import { HandlerDelegate } from '../types'
+import workspace from '../workspace'
+import { ConfigurationChangeEvent, HandlerDelegate } from '../types'
+import BasicTreeView from '../tree/TreeView'
+import { TreeDataProvider, TreeItem, TreeItemCollapsibleState, TreeItemIcon } from '../tree/index'
+import { getSymbolKind } from '../util/convert'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import { disposeAll } from '../util'
+const logger = require('../util/logger')('Handler-callHierarchy')
+
+interface CallHierarchyDataItem extends CallHierarchyItem {
+  fromRanges?: Range[]
+  children?: CallHierarchyItem[]
+}
+
+interface CallHierarchyConfig {
+  splitCommand: string
+  openCommand: string
+}
 
 function isCallHierarchyItem(item: any): item is CallHierarchyItem {
   if (item.name && item.kind && Range.is(item.range) && item.uri) return true
@@ -9,30 +26,127 @@ function isCallHierarchyItem(item: any): item is CallHierarchyItem {
 }
 
 export default class CallHierarchyHandler {
+  private config: CallHierarchyConfig
+  private labels: { [key: string]: string }
+  private disposables: Disposable[] = []
   constructor(private nvim: Neovim, private handler: HandlerDelegate) {
+    this.loadConfiguration()
+    workspace.onDidChangeConfiguration(this.loadConfiguration, this, this.disposables)
   }
 
-  private async prepare(): Promise<CallHierarchyItem> {
-    const { doc, position } = await this.handler.getCurrentState()
-    this.handler.checkProvier('callHierarchy', doc.textDocument)
-    await doc.synchronize()
-    const source = new CancellationTokenSource()
-    const res = await languages.prepareCallHierarchy(doc.textDocument, position, source.token)
-    if (!res || source.token.isCancellationRequested) return undefined
-    return Array.isArray(res) ? res[0] : res
+  private loadConfiguration(e?: ConfigurationChangeEvent): void {
+    if (!e || e.affectsConfiguration('callHierarchy')) {
+      this.labels = workspace.getConfiguration('suggest').get<any>('completionItemKindLabels', {})
+      let c = workspace.getConfiguration('callHierarchy')
+      this.config = {
+        splitCommand: c.get<string>('splitCommand'),
+        openCommand: c.get<string>('openCommand')
+      }
+    }
+  }
+
+  private getIcon(kind: SymbolKind): TreeItemIcon {
+    let { labels } = this
+    let kindText = getSymbolKind(kind)
+    let defaultIcon = typeof labels['default'] === 'string' ? labels['default'] : kindText[0].toLowerCase()
+    let text = kindText == 'Unknown' ? '' : labels[kindText[0].toLowerCase() + kindText.slice(1)]
+    if (!text || typeof text !== 'string') text = defaultIcon
+    return {
+      text,
+      hlGroup: kindText == 'Unknown' ? 'CocSymbolDefault' : `CocSymbol${kindText}`
+    }
+  }
+
+  private createProvider(doc: TextDocument, winid: number, position: Position, kind: 'incoming' | 'outgoing'): TreeDataProvider<CallHierarchyDataItem> {
+    return {
+      getTreeItem: element => {
+        let item = new TreeItem(element.name, element.children ? TreeItemCollapsibleState.Expanded : TreeItemCollapsibleState.Collapsed)
+        item.tooltip = element.detail
+        item.deprecated = element.tags?.includes(SymbolTag.Deprecated)
+        item.icon = this.getIcon(element.kind)
+        item.command = {
+          command: 'workspace.openLocation',
+          title: 'open location',
+          arguments: [winid, Location.create(element.uri, element.selectionRange), this.config.openCommand]
+        }
+        return item
+      },
+      getChildren: async element => {
+        const source = new CancellationTokenSource()
+        if (!element) {
+          let items = await this.prepare(doc, position, source.token) as CallHierarchyDataItem[]
+          if (!items || !items.length) {
+            throw new Error('No results.')
+          }
+          for (let o of items) {
+            let children = await this.getChildren(doc, o, kind, source.token)
+            if (source.token.isCancellationRequested) break
+            o.children = children
+          }
+          return items
+        }
+        if (element.children) return element.children
+        let items = await this.getChildren(doc, element, kind, source.token)
+        element.children = items
+        return items
+      }
+    }
+  }
+
+  private async getChildren(doc: TextDocument, item: CallHierarchyItem, kind: 'incoming' | 'outgoing', token: CancellationToken): Promise<CallHierarchyDataItem[]> {
+    let items: CallHierarchyDataItem[] = []
+    if (kind == 'incoming') {
+      let res = await languages.provideIncomingCalls(doc, item, token)
+      if (res) items = res.map(o => Object.assign(o.from, o.fromRanges))
+    } else if (kind == 'outgoing') {
+      let res = await languages.provideOutgoingCalls(doc, item, token)
+      if (res) items = res.map(o => Object.assign(o.to, o.fromRanges))
+    }
+    return items
+  }
+
+  private async prepare(doc: TextDocument, position: Position, token: CancellationToken): Promise<CallHierarchyItem[]> {
+    this.handler.checkProvier('callHierarchy', doc)
+    const res = await languages.prepareCallHierarchy(doc, position, token)
+    if (!res || token.isCancellationRequested) return undefined
+    return isCallHierarchyItem(res) ? [res] : res
   }
 
   public async getIncoming(item?: CallHierarchyItem): Promise<CallHierarchyIncomingCall[]> {
-    if (!item) item = await this.prepare()
-    if (!isCallHierarchyItem(item)) throw new Error('Not a CallHierarchyItem')
+    const { doc, position } = await this.handler.getCurrentState()
     const source = new CancellationTokenSource()
-    return await languages.provideIncomingCalls(item, source.token)
+    if (!item) {
+      await doc.synchronize()
+      let res = await this.prepare(doc.textDocument, position, source.token)
+      item = res ? res[0] : undefined
+    }
+    if (!isCallHierarchyItem(item)) throw new Error('Not a CallHierarchyItem')
+    return await languages.provideIncomingCalls(doc.textDocument, item, source.token)
   }
 
   public async getOutgoing(item?: CallHierarchyItem): Promise<CallHierarchyOutgoingCall[]> {
-    if (!item) item = await this.prepare()
-    if (!isCallHierarchyItem(item)) throw new Error('Not a CallHierarchyItem')
+    const { doc, position } = await this.handler.getCurrentState()
     const source = new CancellationTokenSource()
-    return await languages.provideOutgoingCalls(item, source.token)
+    if (!item) {
+      await doc.synchronize()
+      let res = await this.prepare(doc.textDocument, position, source.token)
+      item = res ? res[0] : undefined
+    }
+    if (!isCallHierarchyItem(item)) throw new Error('Not a CallHierarchyItem')
+    return await languages.provideOutgoingCalls(doc.textDocument, item, source.token)
+  }
+
+  public async showCallHierarchyTree(kind: 'incoming' | 'outgoing'): Promise<void> {
+    const { doc, position, winid } = await this.handler.getCurrentState()
+    await doc.synchronize()
+    let provider = this.createProvider(doc.textDocument, winid, position, kind)
+    let treeView = new BasicTreeView(`${kind.toUpperCase()} CALLS`, {
+      treeDataProvider: provider
+    })
+    await treeView.show(this.config.splitCommand)
+  }
+
+  public dispose(): void {
+    disposeAll(this.disposables)
   }
 }

--- a/src/handler/callHierarchy.ts
+++ b/src/handler/callHierarchy.ts
@@ -228,9 +228,10 @@ export default class CallHierarchyHandler {
     const { doc, position, winid } = await this.handler.getCurrentState()
     await doc.synchronize()
     let provider = this.createProvider(doc.textDocument, winid, position, kind)
-    let treeView = new BasicTreeView(`${kind.toUpperCase()} CALLS`, {
+    let treeView = new BasicTreeView('calls', {
       treeDataProvider: provider
     })
+    treeView.title = `${kind.toUpperCase()} CALLS`
     provider.onDidChangeTreeData(e => {
       if (!e) treeView.title = `${provider.kind.toUpperCase()} CALLS`
     })

--- a/src/handler/callHierarchy.ts
+++ b/src/handler/callHierarchy.ts
@@ -1,23 +1,31 @@
 import { Neovim } from '@chemzqm/neovim'
-import { CallHierarchyIncomingCall, Position, Range, CallHierarchyItem, CallHierarchyOutgoingCall, CancellationTokenSource, SymbolKind, SymbolTag, Location, Disposable, CancellationToken } from 'vscode-languageserver-protocol'
-import languages from '../languages'
-import workspace from '../workspace'
-import { ConfigurationChangeEvent, HandlerDelegate } from '../types'
-import BasicTreeView from '../tree/TreeView'
-import { TreeDataProvider, TreeItem, TreeItemCollapsibleState, TreeItemIcon } from '../tree/index'
-import { getSymbolKind } from '../util/convert'
+import path from 'path'
+import { CallHierarchyIncomingCall, CallHierarchyItem, CallHierarchyOutgoingCall, CancellationToken, CancellationTokenSource, Disposable, Emitter, Position, Range, SymbolKind, SymbolTag } from 'vscode-languageserver-protocol'
 import { TextDocument } from 'vscode-languageserver-textdocument'
+import { URI } from 'vscode-uri'
+import commands from '../commands'
+import languages from '../languages'
+import { TreeDataProvider, TreeItem, TreeItemCollapsibleState, TreeItemIcon } from '../tree/index'
+import BasicTreeView from '../tree/TreeView'
+import { ConfigurationChangeEvent, HandlerDelegate } from '../types'
 import { disposeAll } from '../util'
+import { getSymbolKind } from '../util/convert'
+import workspace from '../workspace'
 const logger = require('../util/logger')('Handler-callHierarchy')
 
 interface CallHierarchyDataItem extends CallHierarchyItem {
-  fromRanges?: Range[]
+  ranges?: Range[]
   children?: CallHierarchyItem[]
 }
 
 interface CallHierarchyConfig {
   splitCommand: string
   openCommand: string
+}
+
+interface CallHierarchyProvider extends TreeDataProvider<CallHierarchyDataItem> {
+  kind: 'incoming' | 'outgoing'
+  dispose: () => void
 }
 
 function isCallHierarchyItem(item: any): item is CallHierarchyItem {
@@ -29,9 +37,22 @@ export default class CallHierarchyHandler {
   private config: CallHierarchyConfig
   private labels: { [key: string]: string }
   private disposables: Disposable[] = []
+  public static commandId = 'callHierarchy.reveal'
+  public static rangesHighlight = 'CocHoverRange'
   constructor(private nvim: Neovim, private handler: HandlerDelegate) {
     this.loadConfiguration()
     workspace.onDidChangeConfiguration(this.loadConfiguration, this, this.disposables)
+    this.disposables.push(commands.registerCommand(CallHierarchyHandler.commandId, async (winid: number, item: CallHierarchyDataItem) => {
+      let { nvim } = this
+      await nvim.call('win_gotoid', [winid])
+      await workspace.jumpTo(item.uri, item.selectionRange.start, this.config.openCommand)
+      let win = await nvim.window
+      win.highlightRanges('CocHighlightText', [item.selectionRange], 10, true)
+      if (item.ranges) {
+        win.clearMatchGroup(CallHierarchyHandler.rangesHighlight)
+        win.highlightRanges(CallHierarchyHandler.rangesHighlight, item.ranges, 100, true)
+      }
+    }, null, true))
   }
 
   private loadConfiguration(e?: ConfigurationChangeEvent): void {
@@ -57,50 +78,71 @@ export default class CallHierarchyHandler {
     }
   }
 
-  private createProvider(doc: TextDocument, winid: number, position: Position, kind: 'incoming' | 'outgoing'): TreeDataProvider<CallHierarchyDataItem> {
-    return {
+  private createProvider(doc: TextDocument, winid: number, position: Position, kind: 'incoming' | 'outgoing'): CallHierarchyProvider {
+    let _onDidChangeTreeData = new Emitter<void | CallHierarchyDataItem>()
+    let source: CancellationTokenSource | undefined
+    let rootItems: CallHierarchyDataItem[] | undefined
+    const cancel = () => {
+      if (source) {
+        source.cancel()
+        source.dispose()
+        source = null
+      }
+    }
+    let provider: CallHierarchyProvider = {
+      kind,
+      onDidChangeTreeData: _onDidChangeTreeData.event,
       getTreeItem: element => {
         let item = new TreeItem(element.name, element.children ? TreeItemCollapsibleState.Expanded : TreeItemCollapsibleState.Collapsed)
+        item.tooltip = path.relative(workspace.cwd, URI.parse(element.uri).fsPath)
         item.description = element.detail
         item.deprecated = element.tags?.includes(SymbolTag.Deprecated)
         item.icon = this.getIcon(element.kind)
         item.command = {
-          command: 'workspace.openLocation',
+          command: CallHierarchyHandler.commandId,
           title: 'open location',
-          arguments: [winid, Location.create(element.uri, element.selectionRange), this.config.openCommand]
+          arguments: [winid, element]
         }
         return item
       },
       getChildren: async element => {
-        const source = new CancellationTokenSource()
+        cancel()
+        source = new CancellationTokenSource()
         if (!element) {
-          let items = await this.prepare(doc, position, source.token) as CallHierarchyDataItem[]
-          if (!items || !items.length) {
-            throw new Error('No results.')
+          if (!rootItems) {
+            rootItems = await this.prepare(doc, position, source.token) as CallHierarchyDataItem[]
+            if (!rootItems || !rootItems.length) {
+              throw new Error('No results.')
+            }
           }
-          for (let o of items) {
-            let children = await this.getChildren(doc, o, kind, source.token)
+          for (let o of rootItems) {
+            let children = await this.getChildren(doc, o, provider.kind, source.token)
             if (source.token.isCancellationRequested) break
             o.children = children
           }
-          return items
+          return rootItems
         }
         if (element.children) return element.children
-        let items = await this.getChildren(doc, element, kind, source.token)
+        let items = await this.getChildren(doc, element, provider.kind, source.token)
         element.children = items
         return items
+      },
+      dispose: () => {
+        cancel()
+        _onDidChangeTreeData.dispose()
       }
     }
+    return provider
   }
 
   private async getChildren(doc: TextDocument, item: CallHierarchyItem, kind: 'incoming' | 'outgoing', token: CancellationToken): Promise<CallHierarchyDataItem[]> {
     let items: CallHierarchyDataItem[] = []
     if (kind == 'incoming') {
       let res = await languages.provideIncomingCalls(doc, item, token)
-      if (res) items = res.map(o => Object.assign(o.from, o.fromRanges))
+      if (res) items = res.map(o => Object.assign(o.from, { ranges: o.fromRanges }))
     } else if (kind == 'outgoing') {
       let res = await languages.provideOutgoingCalls(doc, item, token)
-      if (res) items = res.map(o => Object.assign(o.to, o.fromRanges))
+      if (res) items = res.map(o => o.to)
     }
     return items
   }
@@ -142,6 +184,14 @@ export default class CallHierarchyHandler {
     let provider = this.createProvider(doc.textDocument, winid, position, kind)
     let treeView = new BasicTreeView(`${kind.toUpperCase()} CALLS`, {
       treeDataProvider: provider
+    })
+    provider.onDidChangeTreeData(e => {
+      if (!e) treeView.title = `${provider.kind.toUpperCase()} CALLS`
+    })
+    treeView.onDidChangeVisibility(e => {
+      if (!e.visible) {
+        provider.dispose()
+      }
     })
     await treeView.show(this.config.splitCommand)
   }

--- a/src/handler/callHierarchy.ts
+++ b/src/handler/callHierarchy.ts
@@ -61,7 +61,7 @@ export default class CallHierarchyHandler {
     return {
       getTreeItem: element => {
         let item = new TreeItem(element.name, element.children ? TreeItemCollapsibleState.Expanded : TreeItemCollapsibleState.Collapsed)
-        item.tooltip = element.detail
+        item.description = element.detail
         item.deprecated = element.tags?.includes(SymbolTag.Deprecated)
         item.icon = this.getIcon(element.kind)
         item.command = {

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -86,6 +86,7 @@ export default class Handler {
     this.selectionRange = new SelectionRange(nvim, this)
     this.disposables.push({
       dispose: () => {
+        this.callHierarchy.dispose()
         this.codeLens.dispose()
         this.refactor.dispose()
         this.signature.dispose()

--- a/src/handler/symbols/index.ts
+++ b/src/handler/symbols/index.ts
@@ -26,7 +26,7 @@ export default class Symbols {
       if (doc.buftype != '') return undefined
       return new SymbolsBuffer(doc.bufnr)
     })
-    this.outline = new Outline(nvim, this.buffers)
+    this.outline = new Outline(nvim, this.buffers, handler)
     events.on('CursorHold', async (bufnr: number) => {
       if (!this.functionUpdate || !this.buffers.getItem(bufnr)) return
       await this.getCurrentFunctionSymbol(bufnr)

--- a/src/handler/symbols/outline.ts
+++ b/src/handler/symbols/outline.ts
@@ -245,44 +245,44 @@ export default class SymbolsOutline {
   /**
    * Create outline view.
    */
-    public async show(keep?: number): Promise<void> {
-      await workspace.document
-      let [bufnr, winid] = await this.nvim.eval('[bufnr("%"),win_getid()]') as [number, number]
-      let buf = this.buffers.getItem(bufnr)
-      if (!buf) throw new Error('Document not attached')
-      let provider = this.providersMap.get(bufnr)
-      if (!provider) {
-        provider = this.createProvider(buf)
-        this.providersMap.set(bufnr, provider)
-      }
-      let treeView = new BasicTreeView('OUTLINE', {
-        enableFilter: true,
-        treeDataProvider: provider,
-      })
-      this.originalWins.set(treeView, winid)
-      let arr = this.treeViews.get(provider) || []
-      arr.push(treeView)
-      this.treeViews.set(provider, arr)
-      treeView.onDidChangeVisibility(({ visible }) => {
-        if (visible || !this.treeViews.has(provider)) return
-        let arr = this.treeViews.get(provider) || []
-        arr = arr.filter(s => s !== treeView)
-        if (arr.length) {
-          this.treeViews.set(provider, arr)
-          return
-        }
-        provider.dispose()
-        this.treeViews.delete(provider)
-      })
-      await treeView.show(this.config.splitCommand)
-      if (treeView.windowId) {
-        let win = this.nvim.createWindow(treeView.windowId)
-        win.setVar('target_bufnr', bufnr, true)
-      }
-      if (keep == 1 || (keep === undefined && this.config.keepWindow)) {
-        await this.nvim.command('wincmd p')
-      }
+  public async show(keep?: number): Promise<void> {
+    await workspace.document
+    let [bufnr, winid] = await this.nvim.eval('[bufnr("%"),win_getid()]') as [number, number]
+    let buf = this.buffers.getItem(bufnr)
+    if (!buf) throw new Error('Document not attached')
+    let provider = this.providersMap.get(bufnr)
+    if (!provider) {
+      provider = this.createProvider(buf)
+      this.providersMap.set(bufnr, provider)
     }
+    let treeView = new BasicTreeView('OUTLINE', {
+      enableFilter: true,
+      treeDataProvider: provider,
+    })
+    this.originalWins.set(treeView, winid)
+    let arr = this.treeViews.get(provider) || []
+    arr.push(treeView)
+    this.treeViews.set(provider, arr)
+    treeView.onDidChangeVisibility(({ visible }) => {
+      if (visible || !this.treeViews.has(provider)) return
+      let arr = this.treeViews.get(provider) || []
+      arr = arr.filter(s => s !== treeView)
+      if (arr.length) {
+        this.treeViews.set(provider, arr)
+        return
+      }
+      provider.dispose()
+      this.treeViews.delete(provider)
+    })
+    await treeView.show(this.config.splitCommand)
+    if (treeView.windowId) {
+      let win = this.nvim.createWindow(treeView.windowId)
+      win.setVar('target_bufnr', bufnr, true)
+    }
+    if (keep == 1 || (keep === undefined && this.config.keepWindow)) {
+      await this.nvim.command('wincmd p')
+    }
+  }
 
   public has(bufnr: number): boolean {
     return this.providersMap.has(bufnr)

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -445,12 +445,12 @@ class Languages {
     return this.callHierarchyManager.prepareCallHierarchy(document, position, token)
   }
 
-  public async provideIncomingCalls(item: CallHierarchyItem, token: CancellationToken): Promise<CallHierarchyIncomingCall[]> {
-    return this.callHierarchyManager.provideCallHierarchyIncomingCalls(item, token)
+  public async provideIncomingCalls(document: TextDocument, item: CallHierarchyItem, token: CancellationToken): Promise<CallHierarchyIncomingCall[]> {
+    return this.callHierarchyManager.provideCallHierarchyIncomingCalls(document, item, token)
   }
 
-  public async provideOutgoingCalls(item: CallHierarchyItem, token: CancellationToken): Promise<CallHierarchyOutgoingCall[]> {
-    return this.callHierarchyManager.provideCallHierarchyOutgoingCalls(item, token)
+  public async provideOutgoingCalls(document: TextDocument, item: CallHierarchyItem, token: CancellationToken): Promise<CallHierarchyOutgoingCall[]> {
+    return this.callHierarchyManager.provideCallHierarchyOutgoingCalls(document, item, token)
   }
 
   public getLegend(document: TextDocument, range?: boolean): SemanticTokensLegend | undefined {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -275,6 +275,8 @@ export default class Plugin extends EventEmitter {
     this.addAction('codeActionRange', (start, end, only) => this.handler.codeActions.codeActionRange(start, end, only))
     this.addAction('incomingCalls', (item?: CallHierarchyItem) => this.handler.callHierarchy.getIncoming(item))
     this.addAction('outgoingCalls', (item?: CallHierarchyItem) => this.handler.callHierarchy.getOutgoing(item))
+    this.addAction('showIncomingCalls', () => this.handler.callHierarchy.showCallHierarchyTree('incoming'))
+    this.addAction('showOutgoingCalls', () => this.handler.callHierarchy.showCallHierarchyTree('outgoing'))
     this.addAction('semanticHighlight', () => this.handler.semanticHighlighter.highlightCurrent())
     this.addAction('showSemanticHighlightInfo', () => this.handler.semanticHighlighter.showHiglightInfo())
   }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -351,7 +351,7 @@ export default class Plugin extends EventEmitter {
     return res
   }
 
-  public getHandler(): any {
+  public getHandler(): Handler {
     return this.handler
   }
 

--- a/src/provider/callHierarchyManager.ts
+++ b/src/provider/callHierarchyManager.ts
@@ -27,18 +27,15 @@ export default class CallHierarchyManager extends Manager<CallHierarchyProvider>
     return await Promise.resolve(provider.prepareCallHierarchy(document, position, token))
   }
 
-  public async provideCallHierarchyOutgoingCalls(item: CallHierarchyItem, token: CancellationToken): Promise<CallHierarchyOutgoingCall[]> {
-    let { document } = await workspace.getCurrentState()
+  public async provideCallHierarchyOutgoingCalls(document: TextDocument, item: CallHierarchyItem, token: CancellationToken): Promise<CallHierarchyOutgoingCall[]> {
     let providerItem = this.getProvider(document)
     if (!providerItem) return null
     let { provider } = providerItem
     if (provider.provideCallHierarchyOutgoingCalls === null) return null
-
     return await Promise.resolve(provider.provideCallHierarchyOutgoingCalls(item, token))
   }
 
-  public async provideCallHierarchyIncomingCalls(item: CallHierarchyItem, token: CancellationToken): Promise<CallHierarchyIncomingCall[]> {
-    let { document } = await workspace.getCurrentState()
+  public async provideCallHierarchyIncomingCalls(document: TextDocument, item: CallHierarchyItem, token: CancellationToken): Promise<CallHierarchyIncomingCall[]> {
     let providerItem = this.getProvider(document)
     if (!providerItem) return null
     let { provider } = providerItem

--- a/src/provider/callHierarchyManager.ts
+++ b/src/provider/callHierarchyManager.ts
@@ -1,6 +1,5 @@
 import { CallHierarchyIncomingCall, CallHierarchyItem, CallHierarchyOutgoingCall, CancellationToken, Disposable, DocumentSelector, Position } from 'vscode-languageserver-protocol'
 import { TextDocument } from 'vscode-languageserver-textdocument'
-import workspace from '../workspace'
 import { CallHierarchyProvider } from './index'
 import Manager, { ProviderItem } from './manager'
 import { v4 as uuid } from 'uuid'

--- a/src/tree/TreeItem.ts
+++ b/src/tree/TreeItem.ts
@@ -40,6 +40,7 @@ export enum TreeItemCollapsibleState {
 export class TreeItem {
   public label: string | TreeItemLabel
   public id?: string
+  public description?: string
   public icon?: TreeItemIcon
   public resourceUri?: URI
   public command?: Command

--- a/src/tree/TreeView.ts
+++ b/src/tree/TreeView.ts
@@ -168,7 +168,9 @@ export default class BasicTreeView<T> implements TreeView<T> {
         return filterText
       }
     })
-    this.provider.onDidChangeTreeData(this.onDataChange, this, this.disposables)
+    if (this.provider.onDidChangeTreeData) {
+      this.provider.onDidChangeTreeData(this.onDataChange, this, this.disposables)
+    }
     events.on('BufUnload', bufnr => {
       if (bufnr != this.bufnr) return
       this.winid = undefined

--- a/src/tree/TreeView.ts
+++ b/src/tree/TreeView.ts
@@ -628,7 +628,7 @@ export default class BasicTreeView<T> implements TreeView<T> {
   private getRenderedLine(treeItem: TreeItem, lnum: number, level: number): { line: string, highlights: HighlightItem[] } {
     let { openedIcon, closedIcon } = this.config
     const highlights: HighlightItem[] = []
-    const { label, deprecated } = treeItem
+    const { label, deprecated, description } = treeItem
     let prefix = '  '.repeat(level)
     const addHighlight = (text: string, hlGroup: string) => {
       let colStart = byteLength(prefix)
@@ -674,6 +674,11 @@ export default class BasicTreeView<T> implements TreeView<T> {
       addHighlight(labelText, 'CocDeprecatedHighlight')
     }
     prefix += labelText
+    if (description && description.indexOf('\n') == -1) {
+      prefix += ' '
+      addHighlight(description, 'CocTreeDescription')
+      prefix += description
+    }
     return { line: prefix, highlights }
   }
 

--- a/src/tree/TreeView.ts
+++ b/src/tree/TreeView.ts
@@ -829,9 +829,13 @@ export default class BasicTreeView<T> implements TreeView<T> {
       let level = 0
       let lnum = startLnum
       let renderedItems: RenderedItem<T>[] = []
-      for (let node of nodes || []) {
-        let n = await this.appendTreeNode(node, level, lnum, renderedItems, highlights)
-        lnum += n
+      if (!nodes?.length) {
+        this.message = 'No results'
+      } else {
+        for (let node of nodes) {
+          let n = await this.appendTreeNode(node, level, lnum, renderedItems, highlights)
+          lnum += n
+        }
       }
       lines.push(...renderedItems.map(o => o.line))
       this.renderedItems = renderedItems
@@ -950,6 +954,7 @@ export default class BasicTreeView<T> implements TreeView<T> {
   }
 
   public dispose(): void {
+    if (!this.provider) return
     if (this.timer) {
       clearTimeout(this.timer)
       this.timer = undefined

--- a/src/tree/TreeView.ts
+++ b/src/tree/TreeView.ts
@@ -394,17 +394,22 @@ export default class BasicTreeView<T> implements TreeView<T> {
     await commandManager.execute(item.command)
   }
 
-  private async invokeActions(element: T, selection?: T[]): Promise<void> {
+  private async invokeActions(element: T): Promise<void> {
     this.selectItem(element)
-    let actions = this.opts.actions
-    if (!actions) {
+    if (typeof this.provider.resolveActions !== 'function') {
+      await window.showWarningMessage('No actions')
+      return
+    }
+    let obj = this.nodesMap.get(element)
+    let actions = await Promise.resolve(this.provider.resolveActions(obj.item, element))
+    if (!actions || actions.length == 0) {
       await window.showWarningMessage('No actions available')
       return
     }
-    let keys = Object.keys(actions)
+    let keys = actions.map(o => o.title)
     let res = await window.showMenuPicker(keys, 'Choose action')
     if (res == -1) return
-    await Promise.resolve(actions[keys[res]](element, selection))
+    await Promise.resolve(actions[res].handler(element))
   }
 
   private async onDataChange(node: T | undefined): Promise<void> {
@@ -898,7 +903,7 @@ export default class BasicTreeView<T> implements TreeView<T> {
       if (element) await this.invokeCommand(element)
     }, true)
     actions && regist('n', actions, async element => {
-      if (element) await this.invokeActions(element, this.selection.length > 1 ? this.selection : undefined)
+      if (element) await this.invokeActions(element)
     }, true)
     toggle && regist('n', toggle, async element => {
       if (element) await this.toggleExpand(element)

--- a/src/tree/TreeView.ts
+++ b/src/tree/TreeView.ts
@@ -102,7 +102,7 @@ export default class BasicTreeView<T> implements TreeView<T> {
   private readonly canSelectMany: boolean
   private readonly leafIndent: boolean
   private readonly winfixwidth: boolean
-  constructor(private viewId: string, private opts: TreeViewOptions<T>) {
+  constructor(private viewId: string, opts: TreeViewOptions<T>) {
     this.loadConfiguration()
     workspace.onDidChangeConfiguration(this.loadConfiguration, this, this.disposables)
     if (opts.enableFilter) {

--- a/src/tree/TreeView.ts
+++ b/src/tree/TreeView.ts
@@ -14,7 +14,6 @@ import window from '../window'
 import Filter, { sessionKey } from './filter'
 import { TreeDataProvider, TreeView, TreeViewExpansionEvent, TreeViewOptions, TreeViewSelectionChangeEvent, TreeViewVisibilityChangeEvent } from './index'
 import { TreeItem, TreeItemCollapsibleState, TreeItemLabel } from './TreeItem'
-import Menu from '../model/menu'
 const logger = require('../util/logger')('BasicTreeView')
 const highlightNamespace = 'tree'
 const signOffset = 3000
@@ -97,18 +96,18 @@ export default class BasicTreeView<T> implements TreeView<T> {
   private tooltipFactory: FloatFactory
   private resolveTokenSource: CancellationTokenSource | undefined
   private lineState: LineState = { titleCount: 0, messageCount: 0 }
-  private filter: Filter<T>
+  private filter: Filter<T> | undefined
   private filterText: string | undefined
   private itemsToFilter: T[] | undefined
   private readonly canSelectMany: boolean
   private readonly leafIndent: boolean
   private readonly winfixwidth: boolean
-  private readonly enableFilter: boolean
   constructor(private viewId: string, private opts: TreeViewOptions<T>) {
     this.loadConfiguration()
     workspace.onDidChangeConfiguration(this.loadConfiguration, this, this.disposables)
-    this.enableFilter = opts.enableFilter == true
-    this.filter = new Filter(this.nvim, [this.keys.selectNext, this.keys.selectPrevious, this.keys.invoke])
+    if (opts.enableFilter) {
+      this.filter = new Filter(this.nvim, [this.keys.selectNext, this.keys.selectPrevious, this.keys.invoke])
+    }
     this.tooltipFactory = new FloatFactory(workspace.nvim)
     this.canSelectMany = !!opts.canSelectMany
     this.provider = opts.treeDataProvider
@@ -186,7 +185,7 @@ export default class BasicTreeView<T> implements TreeView<T> {
       this.cancelResolve()
     }, null, this.disposables)
     events.on('WinEnter', winid => {
-      if (winid != this.windowId || !this.filter.activated) return
+      if (winid != this.windowId || !this.filter?.activated) return
       let buf = this.nvim.createBuffer(this.bufnr)
       let line = this.startLnum - 1
       let len = this.filterText ? this.filterText.length : 0
@@ -196,49 +195,51 @@ export default class BasicTreeView<T> implements TreeView<T> {
       this.redraw()
     }, null, this.disposables)
     events.on('WinLeave', winid => {
-      if (winid != this.windowId || !this.filter.activated) return
+      if (winid != this.windowId || !this.filter?.activated) return
       let buf = this.nvim.createBuffer(this.bufnr)
       this.nvim.call('coc#prompt#stop_prompt', [sessionKey], true)
       buf.clearNamespace(highlightNamespace, this.startLnum - 1, this.startLnum)
     }, null, this.disposables)
     this.disposables.push(this._onDidChangeVisibility, this._onDidChangeSelection, this._onDidCollapseElement, this._onDidExpandElement)
-    this.filter.onDidExit(node => {
-      this.nodesMap.clear()
-      this.filterText = undefined
-      this.itemsToFilter = undefined
-      if (node && typeof this.provider.getParent === 'function') {
-        this.renderedItems = []
-        void this.reveal(node, { focus: true })
-      } else {
-        this.clearSelection()
-        void this.render()
-      }
-    })
-    this.filter.onDidUpdate(text => {
-      this.filterText = text
-    })
-    this.filter.onDidKeyPress(async character => {
-      let items = this.renderedItems
-      if (!items?.length) return
-      let curr = this.selection[0]
-      if (character == '<up>' || character == this.keys.selectPrevious) {
-        let idx = items.findIndex(o => o.node == curr)
-        let index = idx == -1 || idx == 0 ? items.length - 1 : idx - 1
-        let node = items[index]?.node
-        if (node) this.selectItem(node, true)
-      }
-      if (character == '<down>' || character == this.keys.selectNext) {
-        let idx = items.findIndex(o => o.node == curr)
-        let index = idx == -1 || idx == items.length - 1 ? 0 : idx + 1
-        let node = items[index]?.node
-        if (node) this.selectItem(node, true)
-      }
-      if (character == '<cr>' || character == this.keys.invoke) {
-        if (!curr) return
-        await this.invokeCommand(curr)
-        this.filter.deactivate(curr)
-      }
-    })
+    if (this.filter) {
+      this.filter.onDidExit(node => {
+        this.nodesMap.clear()
+        this.filterText = undefined
+        this.itemsToFilter = undefined
+        if (node && typeof this.provider.getParent === 'function') {
+          this.renderedItems = []
+          void this.reveal(node, { focus: true })
+        } else {
+          this.clearSelection()
+          void this.render()
+        }
+      })
+      this.filter.onDidUpdate(text => {
+        this.filterText = text
+      })
+      this.filter.onDidKeyPress(async character => {
+        let items = this.renderedItems
+        if (!items?.length) return
+        let curr = this.selection[0]
+        if (character == '<up>' || character == this.keys.selectPrevious) {
+          let idx = items.findIndex(o => o.node == curr)
+          let index = idx == -1 || idx == 0 ? items.length - 1 : idx - 1
+          let node = items[index]?.node
+          if (node) this.selectItem(node, true)
+        }
+        if (character == '<down>' || character == this.keys.selectNext) {
+          let idx = items.findIndex(o => o.node == curr)
+          let index = idx == -1 || idx == items.length - 1 ? 0 : idx + 1
+          let node = items[index]?.node
+          if (node) this.selectItem(node, true)
+        }
+        if (character == '<cr>' || character == this.keys.invoke) {
+          if (!curr) return
+          await this.invokeCommand(curr)
+          this.filter.deactivate(curr)
+        }
+      })
+    }
   }
 
   public get windowId(): number | undefined {
@@ -407,7 +408,7 @@ export default class BasicTreeView<T> implements TreeView<T> {
   }
 
   private async onDataChange(node: T | undefined): Promise<void> {
-    if (this.filter.activated) {
+    if (this.filter?.activated) {
       this.itemsToFilter = undefined
       await this.doFilter(this.filterText)
       return
@@ -709,7 +710,7 @@ export default class BasicTreeView<T> implements TreeView<T> {
   }
 
   public async reveal(element: T, options: { select?: boolean; focus?: boolean; expand?: number | boolean } = {}): Promise<void> {
-    if (this.filter.activated) return
+    if (this.filter?.activated) return
     let isShown = this.getItemLnum(element) != null
     let { select, focus, expand } = options
     let curr = element
@@ -885,7 +886,7 @@ export default class BasicTreeView<T> implements TreeView<T> {
     regist('n', '<LeftRelease>', async element => {
       if (element) await this.onClick(element)
     })
-    this.enableFilter && activeFilter && regist('n', activeFilter, async () => {
+    this.filter && activeFilter && regist('n', activeFilter, async () => {
       this.nvim.command(`exe ${this.startLnum}`, true)
       this.filter.active()
       this.filterText = ''
@@ -926,7 +927,7 @@ export default class BasicTreeView<T> implements TreeView<T> {
   }
 
   private redraw(): void {
-    if (workspace.isVim || this.filter.activated) {
+    if (workspace.isVim || this.filter?.activated) {
       this.nvim.command('redraw', true)
     }
   }
@@ -943,7 +944,7 @@ export default class BasicTreeView<T> implements TreeView<T> {
       clearTimeout(this.timer)
       this.timer = undefined
     }
-    this.filter.dispose()
+    this.filter?.dispose()
     this._selection = []
     this.hide()
     this.itemsToFilter = []

--- a/src/tree/index.ts
+++ b/src/tree/index.ts
@@ -4,11 +4,18 @@ import { TreeItem, TreeItemIcon, TreeItemCollapsibleState } from './TreeItem'
 
 export { TreeItem, TreeItemIcon, TreeItemCollapsibleState }
 
+export interface TreeItemAction<T> {
+  /**
+   * Label text in menu.
+   */
+  title: string
+  handler: (item: T) => ProviderResult<void>
+}
+
 /**
  * Options for creating a {@link TreeView}
  */
 export interface TreeViewOptions<T> {
-  actions?: { [name: string]: (node: T, nodes?: T[]) => ProviderResult<void> }
   /**
    * Fixed width for window, default to true
    */
@@ -202,4 +209,13 @@ export interface TreeDataProvider<T> {
    * `item`. When no result is returned, the given `item` will be used.
    */
   resolveTreeItem?(item: TreeItem, element: T, token: CancellationToken): ProviderResult<TreeItem>
+
+  /**
+   * Called with current element to resolve actions.
+   * Called when user press 'actions' key.
+   *
+   * @param item Resolved item.
+   * @param element The object under cursor.
+   */
+  resolveActions?(item: TreeItem, element: T): ProviderResult<TreeItemAction<T>[]>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 // vim: set sw=2 ts=2 sts=2 et foldmarker={{,}} foldmethod=marker foldlevel=0 nofen:
 import { Neovim, Window, Buffer } from '@chemzqm/neovim'
-import { CancellationToken, CreateFile, CreateFileOptions, DeleteFile, DeleteFileOptions, Disposable, DocumentSelector, Event, FormattingOptions, Location, Position, Range, RenameFile, RenameFileOptions, TextDocumentEdit, TextDocumentSaveReason, TextEdit, WorkspaceEdit, WorkspaceFolder } from 'vscode-languageserver-protocol'
+import { CancellationToken, CreateFile, CreateFileOptions, DeleteFile, DeleteFileOptions, Disposable, DocumentSelector, Event, FormattingOptions, Location, Position, Range, RenameFile, RenameFileOptions, SymbolKind, TextDocumentEdit, TextDocumentSaveReason, TextEdit, WorkspaceEdit, WorkspaceFolder } from 'vscode-languageserver-protocol'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { URI } from 'vscode-uri'
 import Configurations from './configuration'
@@ -33,6 +33,7 @@ export interface HandlerDelegate {
   withRequestToken: <T> (name: string, fn: (token: CancellationToken) => Thenable<T>, checkEmpty?: boolean) => Promise<T>
   getCurrentState: () => Promise<CurrentState>
   addDisposable: (disposable: Disposable) => void
+  getIcon(kind: SymbolKind): { text: string, hlGroup: string }
 }
 
 /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -5213,6 +5213,11 @@ declare module 'coc.nvim' {
     label?: string | TreeItemLabel
 
     /**
+     * Description rendered less prominently after label.
+     */
+    description?: string
+
+    /**
      * The icon path or {@link ThemeIcon} for the tree item.
      * When `falsy`, {@link ThemeIcon.Folder Folder Theme Icon} is assigned, if item is collapsible otherwise {@link ThemeIcon.File File Theme Icon}.
      * When a file or folder {@link ThemeIcon} is specified, icon is derived from the current file icon theme for the specified theme icon using {@link TreeItem.resourceUri resourceUri} (if provided).

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -5267,13 +5267,20 @@ declare module 'coc.nvim' {
   }
 
   /**
+   * Action resolved by {@link TreeDataProvider}
+   */
+  export interface TreeItemAction<T> {
+    /**
+     * Label text in menu.
+     */
+    title: string
+    handler: (item: T) => ProviderResult<void>
+  }
+
+  /**
    * Options for creating a {@link TreeView}
    */
   export interface TreeViewOptions<T> {
-    /**
-     * Custom actions
-     */
-    actions?: { [name: string]: (node: T, nodes?: T[]) => ProviderResult<void> }
     /**
      * Fixed width for window, default to true
      */
@@ -5478,6 +5485,15 @@ declare module 'coc.nvim' {
      * `item`. When no result is returned, the given `item` will be used.
      */
     resolveTreeItem?(item: TreeItem, element: T, token: CancellationToken): ProviderResult<TreeItem>
+
+    /**
+     * Called with current element to resolve actions.
+     * Called when user press 'actions' key.
+     *
+     * @param item Resolved item.
+     * @param element The object under cursor.
+     */
+    resolveActions?(item: TreeItem, element: T): ProviderResult<TreeItemAction<T>[]>
   }
   // }}
 


### PR DESCRIPTION
Could works now, closes #1649

Added actions:

- `showIncomingCalls`
- `showOutgoingCalls`

Added commands:

- `document.showIncomingCalls`
- `document.showOutgoingCalls`

Todos:

- [x] Actions of tree item.
- [x] Show `containerName` after label like VSCode.
- [x] Highlight range after location jump.
- [ ] Tests