### PR TITLE
Documentation improvement in schema.json

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -1185,7 +1185,7 @@
     },
     "coc.preferences.formatOnType": {
       "type": "boolean",
-      "description": "Set to true to enable format on type",
+      "description": "Set to true to enable formatting on typing",
       "default": false
     },
     "coc.preferences.formatOnTypeFiletypes": {


### PR DESCRIPTION
Reword "format on type" to be clearer: "formatting on typing"