### PR TITLE
fix(hover): shift-left definition content

### DIFF
--- a/src/handler/hover.ts
+++ b/src/handler/hover.ts
@@ -114,7 +114,10 @@ export default class HoverHandler {
         if (!def.targetRange) continue
         const { start, end } = def.targetRange
         const endLine = end.line - start.line >= 100 ? start.line + 100 : (end.character == 0 ? end.line - 1 : end.line)
-        const lines = await readLines(def.targetUri, start.line, endLine)
+        let lines = await readLines(def.targetUri, start.line, endLine)
+        if (lines[0].search(/\S/) > 0) {
+          lines = lines.map(l => l.substring(lines[0].search(/\S/)))
+        }
         hovers.push({ content: lines.join('\n'), filetype: doc.filetype })
       }
     }

--- a/src/handler/hover.ts
+++ b/src/handler/hover.ts
@@ -115,9 +115,9 @@ export default class HoverHandler {
         const { start, end } = def.targetRange
         const endLine = end.line - start.line >= 100 ? start.line + 100 : (end.character == 0 ? end.line - 1 : end.line)
         let lines = await readLines(def.targetUri, start.line, endLine)
-        const indent = lines[0].search(/\S/)
+        const indent = lines[0].length - lines[0].trimStart().length
         if (indent) {
-          lines = lines.map(l => l.search(/\S/) > 0 ? l.substring(indent) : l)
+          lines = lines.map(l => (l.startsWith(' ') || l.startsWith('\t')) ? l.substring(indent) : l)
         }
         hovers.push({ content: lines.join('\n'), filetype: doc.filetype })
       }

--- a/src/handler/hover.ts
+++ b/src/handler/hover.ts
@@ -115,8 +115,9 @@ export default class HoverHandler {
         const { start, end } = def.targetRange
         const endLine = end.line - start.line >= 100 ? start.line + 100 : (end.character == 0 ? end.line - 1 : end.line)
         let lines = await readLines(def.targetUri, start.line, endLine)
-        if (lines[0].search(/\S/) > 0) {
-          lines = lines.map(l => l.substring(lines[0].search(/\S/)))
+        const indent = lines[0].search(/\S/)
+        if (indent) {
+          lines = lines.map(l => l.search(/\S/) > 0 ? l.substring(indent) : l)
         }
         hovers.push({ content: lines.join('\n'), filetype: doc.filetype })
       }


### PR DESCRIPTION
The lines from DefinitionLink maybe indented, I just check the first line whether it starts with space/tab, and shift left all lines if found.

Before:

<img width="715" alt="截屏2021-08-19 下午3 29 23" src="https://user-images.githubusercontent.com/345274/130026612-329a7ca6-814e-4f83-b2bf-19d8ac9ab811.png">

After:

<img width="708" alt="截屏2021-08-19 下午3 28 30" src="https://user-images.githubusercontent.com/345274/130026517-2229b8e6-8901-4a03-a85f-09811872c5b5.png">