### PR TITLE
fix(float.vim): prompt canceled in neovim will move cursor

### DIFF
--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -565,17 +565,12 @@ function! coc#float#create_prompt_win(title, default, opts) abort
     call nvim_set_current_win(winid)
     inoremap <buffer> <C-a> <Home>
     inoremap <buffer><expr><C-e> pumvisible() ? "\<C-e>" : "\<End>"
-    exe 'inoremap <silent><buffer> <esc> <C-r>=coc#float#close_i('.winid.')<CR><esc>'
+    exe 'imap <silent><buffer> <esc> <esc><esc>'
     exe 'nnoremap <silent><buffer> <esc> :call coc#float#close('.winid.')<CR>'
     exe 'inoremap <silent><expr><nowait><buffer> <cr> "\<C-r>=coc#float#prompt_insert(getline(''.''))\<cr>\<esc>"'
     call feedkeys('A', 'in')
   endif
   return [bufnr, winid]
-endfunction
-
-function! coc#float#close_i(winid) abort
-  call coc#float#close(a:winid)
-  return ''
 endfunction
 
 function! coc#float#prompt_insert(text) abort


### PR DESCRIPTION
When using `<esc>` to cancel the prompt window and go back to the previous window,
cursor shift one left.

Look like it's a bug for closing floating window in insert mode.