### PR TITLE
fix(semanticTokens): replace data instead of delete

### DIFF
--- a/src/handler/semanticTokensHighlights/buffer.ts
+++ b/src/handler/semanticTokensHighlights/buffer.ts
@@ -234,7 +234,7 @@ export default class SemanticTokensBuffer implements SyncItem {
       tokens = previousResult.tokens
       result.edits.forEach(e => {
         if (e.deleteCount > 0) {
-          tokens.splice(e.start, e.deleteCount)
+          tokens.splice(e.start, e.deleteCount, ...e.data)
         } else {
           tokens.splice(e.start, 0, ...e.data)
         }


### PR DESCRIPTION
fix https://github.com/clangd/coc-clangd/issues/298

FYI from: https://microsoft.github.io/language-server-protocol/specification
>The delta is now expressed on these number arrays without any form of interpretation what these numbers mean. This is comparable to the text document edits send from the server to the client to modify the content of a file. Those are character based and don’t make any assumption about the meaning of the characters. So [ 2,5,3,0,3, 0,5,4,1,0, 3,2,7,2,0 ] can be transformed into [ 3,5,3,0,3, 0,5,4,1,0, 3,2,7,2,0] using the following edit description: { start: 0, deleteCount: 1, data: [3] } which tells the client to simply **replace** the first number (e.g. 2) in the array with 3