### PR TITLE
Add option to show border on hover window

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -766,7 +766,7 @@
       "default": true,
       "description": "Automatically hide hover float window on CursorMove or InsertEnter."
     },
-    "hover.displayBorder": {
+    "hover.floatBorder": {
       "type": "boolean",
       "default": false,
       "description": "Show border on hover float window."

--- a/data/schema.json
+++ b/data/schema.json
@@ -771,6 +771,11 @@
       "default": false,
       "description": "Show border on hover float window."
     },
+    "hover.floatHighlight": {
+      "type": "string",
+      "default": "CocFloating",
+      "description": "Highlight group for hover window/popup, default to 'CocFloating'"
+    },
     "dialog.maxHeight": {
       "type": "number",
       "default": 20,

--- a/data/schema.json
+++ b/data/schema.json
@@ -766,6 +766,11 @@
       "default": true,
       "description": "Automatically hide hover float window on CursorMove or InsertEnter."
     },
+    "hover.displayBorder": {
+      "type": "boolean",
+      "default": false,
+      "description": "Show border on hover float window."
+    },
     "dialog.maxHeight": {
       "type": "number",
       "default": 20,

--- a/src/handler/hover.ts
+++ b/src/handler/hover.ts
@@ -21,6 +21,7 @@ interface HoverConfig {
   floatMaxHeight: number | undefined
   autoHide: boolean
   floatBorder: boolean
+  floatHighlight: string
 }
 
 export default class HoverHandler {
@@ -67,7 +68,8 @@ export default class HoverHandler {
         floatMaxWidth: config.get('floatMaxWidth', 80),
         target: target == 'float' && !workspace.floatSupported ? 'preview' : target,
         previewMaxHeight: config.get<number>('previewMaxHeight', 12),
-        floatBorder: config.get<boolean>('floatBorder', false)
+        floatBorder: config.get<boolean>('floatBorder', false),
+        floatHighlight: config.get<string>('floatHighlight', 'CocFloating')
       }
       if (this.config.target == 'preview') {
         this.registerProvider()
@@ -163,7 +165,8 @@ export default class HoverHandler {
         maxHeight: this.config.floatMaxHeight,
         autoHide: this.config.autoHide,
         excludeImages: this.excludeImages,
-        border: this.config.floatBorder ? [1, 1, 1, 1] : undefined
+        border: this.config.floatBorder ? [1, 1, 1, 1] : undefined,
+        highlight: this.config.floatHighlight
       }
       await this.hoverFactory.show(docs, opts)
       return

--- a/src/handler/hover.ts
+++ b/src/handler/hover.ts
@@ -20,6 +20,7 @@ interface HoverConfig {
   floatMaxWidth: number
   floatMaxHeight: number | undefined
   autoHide: boolean
+  displayBorder: boolean
 }
 
 export default class HoverHandler {
@@ -65,7 +66,8 @@ export default class HoverHandler {
         floatMaxHeight: config.get('floatMaxHeight', undefined),
         floatMaxWidth: config.get('floatMaxWidth', 80),
         target: target == 'float' && !workspace.floatSupported ? 'preview' : target,
-        previewMaxHeight: config.get<number>('previewMaxHeight', 12)
+        previewMaxHeight: config.get<number>('previewMaxHeight', 12),
+        displayBorder: config.get<boolean>('displayBorder', false)
       }
       if (this.config.target == 'preview') {
         this.registerProvider()
@@ -160,7 +162,8 @@ export default class HoverHandler {
         maxWidth: this.config.floatMaxWidth,
         maxHeight: this.config.floatMaxHeight,
         autoHide: this.config.autoHide,
-        excludeImages: this.excludeImages
+        excludeImages: this.excludeImages,
+        border: this.config.displayBorder ? [1, 1, 1, 1] : undefined
       }
       await this.hoverFactory.show(docs, opts)
       return

--- a/src/handler/hover.ts
+++ b/src/handler/hover.ts
@@ -20,7 +20,7 @@ interface HoverConfig {
   floatMaxWidth: number
   floatMaxHeight: number | undefined
   autoHide: boolean
-  displayBorder: boolean
+  floatBorder: boolean
 }
 
 export default class HoverHandler {
@@ -67,7 +67,7 @@ export default class HoverHandler {
         floatMaxWidth: config.get('floatMaxWidth', 80),
         target: target == 'float' && !workspace.floatSupported ? 'preview' : target,
         previewMaxHeight: config.get<number>('previewMaxHeight', 12),
-        displayBorder: config.get<boolean>('displayBorder', false)
+        floatBorder: config.get<boolean>('floatBorder', false)
       }
       if (this.config.target == 'preview') {
         this.registerProvider()
@@ -163,7 +163,7 @@ export default class HoverHandler {
         maxHeight: this.config.floatMaxHeight,
         autoHide: this.config.autoHide,
         excludeImages: this.excludeImages,
-        border: this.config.displayBorder ? [1, 1, 1, 1] : undefined
+        border: this.config.floatBorder ? [1, 1, 1, 1] : undefined
       }
       await this.hoverFactory.show(docs, opts)
       return


### PR DESCRIPTION
Added an option to set the border for the hover window.
I think floating windows with borders are better for viewing information.

The default is false, so I don't think it will affect existing users.

![CleanShot 2021-08-31 at 11 54 16](https://user-images.githubusercontent.com/5423775/131434125-eb3e7cf9-b7a6-4bc0-8bd6-6612fa6265cb.png)
