### PR TITLE
Add option to show border on diagnostic float/popup window

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -668,6 +668,16 @@
       "default": true,
       "description": "Show deprecated variables"
     },
+    "diagnostic.floatBorder": {
+      "type": "boolean",
+      "description": "Show border on diagnostic float window.",
+      "default": false
+    },
+    "diagnostic.floatHighlight": {
+      "type": "string",
+      "default": "CocFloating",
+      "description": "Highlight group for diagnostic window/popup, default to 'CocFloating'"
+    },
     "signature.enable": {
       "type": "boolean",
       "description": "Enable signature help when trigger character typed, require restart service on change.",

--- a/src/diagnostic/buffer.ts
+++ b/src/diagnostic/buffer.ts
@@ -53,6 +53,8 @@ export interface DiagnosticConfig {
   showUnused?: boolean
   showDeprecated?: boolean
   format?: string
+  floatBorder: boolean
+  floatHighlight: string
 }
 
 interface DiagnosticInfo {

--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -462,7 +462,13 @@ export class DiagnosticManager implements Disposable {
     })
     if (useFloat) {
       let { maxWindowHeight, maxWindowWidth } = this.config
-      await this.floatFactory.show(docs, { maxWidth: maxWindowWidth, maxHeight: maxWindowHeight, modes: ['n'] })
+      await this.floatFactory.show(docs, {
+        maxWidth: maxWindowWidth,
+        maxHeight: maxWindowHeight,
+        modes: ['n'],
+        border: this.config.floatBorder ? [1, 1, 1, 1] : undefined,
+        highlight: this.config.floatHighlight
+      })
     } else {
       let lines = docs.map(d => d.content).join('\n').split(/\r?\n/)
       if (lines.length) {
@@ -552,6 +558,8 @@ export class DiagnosticManager implements Disposable {
       showUnused: config.get<boolean>('showUnused', true),
       showDeprecated: config.get<boolean>('showDeprecated', true),
       format: config.get<string>('format', '[%source%code] [%severity] %message'),
+      floatBorder: config.get<boolean>('floatBorder', false),
+      floatHighlight: config.get<string>('floatHighlight', 'CocFloating')
     }
     this.enabled = config.get<boolean>('enable', true)
     this.defineSigns()


### PR DESCRIPTION
Added an option to show borders in the suggest window, similar to #3325 and #3326.

![CleanShot 2021-09-02 at 08 48 56](https://user-images.githubusercontent.com/5423775/131759886-1e6b651d-7e5e-4062-9ebc-49d25b083b73.png)
