### PR TITLE
fix(configuration): create config file if not exist

### DIFF
--- a/src/configuration/shape.ts
+++ b/src/configuration/shape.ts
@@ -22,7 +22,7 @@ export default class ConfigurationProxy implements ConfigurationShape {
     let file = workspace.getConfigFile(target)
     if (!file) return
     let formattingOptions: FormattingOptions = { tabSize: 2, insertSpaces: true }
-    let content = fs.readFileSync(file, 'utf8')
+    let content = fs.readFileSync(file, { encoding: 'utf8', flag: 'a+'})
     value = value == null ? undefined : value
     let edits = modify(content, [key], value, { formattingOptions })
     content = applyEdits(content, edits)


### PR DESCRIPTION
If `coc-settings.json` file is not exists, `configuration.update()` will raise exception. This fix will create the file from `readFileSync` if not exists, the default flag is `r`, changed to `a+`:

- `r`: Open file for reading. An exception occurs if the file does not exist.
- `a+`: Open file for reading and appending. The file is created if it does not exist.

https://nodejs.org/api/fs.html#fs_file_system_flags

closes https://github.com/clangd/coc-clangd/issues/344