### PR TITLE
fix(completion): should clean previous items if empty source result

### DIFF
--- a/src/completion/complete.ts
+++ b/src/completion/complete.ts
@@ -153,6 +153,8 @@ export default class Complete {
             if (empty) this._onDidComplete.fire()
             resolve(undefined)
           } else {
+            let { results } = this
+            this.results = results.filter(res => res.source != name)
             resolve(undefined)
           }
         }, err => {


### PR DESCRIPTION
Some complete sources will return an empty result, but coc.nvim has cache
the previous results and reuse them.

Almost the invalid results will be filtered out later, but edge case
will pass the filter and still show it within the popup menu.

Solution: clean up the cache results earlier if the source return empty

This PR motivion from the below video:

https://user-images.githubusercontent.com/17562139/131810463-260a9b59-011f-4160-a7a9-428dd1bae86f.mp4

