### PR TITLE
fix(completion): preselect item at once

### DIFF
--- a/autoload/coc.vim
+++ b/autoload/coc.vim
@@ -54,6 +54,8 @@ function! coc#_complete() abort
   if s:select_api && len(items) && preselect != -1
     noa call complete(startcol, items)
     call nvim_select_popupmenu_item(preselect, v:false, v:false, {})
+    " use <cmd> specific key to preselect item at once
+    call feedkeys("\<Cmd>\<CR>" , 'i')
   else
     call complete(startcol, items)
   endif


### PR DESCRIPTION
Call `nvim_select_popupmenu_item` only change pum_want struct, it means
that make preselect effective later which may delay or dither, or even
can't preselect correctly until the next event.

Known from the upstream source code, we can use `<Cmd>` or fire an event
manually to make preselect effective at once.

FYI:
- [nvim_select_popupmenu_item change pum_want](https://github.com/neovim/neovim/blob/5f8518b3f04c2295be24912dba78d3e34ca74b91/src/nvim/edit.c#L4757-L4766)
- [when to fire preselect](https://github.com/neovim/neovim/blob/5f8518b3f04c2295be24912dba78d3e34ca74b91/src/nvim/edit.c#L1031-L1052)
- [nvim_select_popupmenu_item test case](https://github.com/neovim/neovim/blob/5f8518b3f04c2295be24912dba78d3e34ca74b91/test/functional/ui/popupmenu_spec.lua#L260-L293)