### PR TITLE
chore(ui): change character used to create lines

### DIFF
--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -517,8 +517,6 @@ function! coc#float#create_cursor_float(winid, bufnr, lines, config) abort
   return [currbuf, pos, winid, bufnr, alignTop]
 endfunction
 
-
-
 " Create float window for input
 function! coc#float#create_prompt_win(title, default, opts) abort
   call coc#float#close_auto_hide_wins()

--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -500,7 +500,7 @@ function! coc#float#create_cursor_float(winid, bufnr, lines, config) abort
     return v:null
   endif
   let width = dimension['width']
-  let lines = map(a:lines, {_, s -> s =~# '^—' ? repeat('—', width) : s})
+  let lines = map(a:lines, {_, s -> s =~# '^─' ? repeat('─', width) : s})
   let config = extend(extend({'lines': lines, 'relative': 'cursor'}, a:config), dimension)
   call coc#float#close_auto_hide_wins(a:winid)
   let res = coc#float#create_float_win(a:winid, a:bufnr, config)
@@ -516,6 +516,8 @@ function! coc#float#create_cursor_float(winid, bufnr, lines, config) abort
   endif
   return [currbuf, pos, winid, bufnr, alignTop]
 endfunction
+
+
 
 " Create float window for input
 function! coc#float#create_prompt_win(title, default, opts) abort
@@ -903,7 +905,7 @@ function! coc#float#create_pum_float(winid, bufnr, lines, config) abort
   endfor
   let width = float2nr(coc#helper#min(maxWidth, width))
   let height = float2nr(coc#helper#min(maxHeight, ch))
-  let lines = map(a:lines, {_, s -> s =~# '^—' ? repeat('—', width - 2 + (s:is_vim && ch > height ? -1 : 0)) : s})
+  let lines = map(a:lines, {_, s -> s =~# '^─' ? repeat('─', width - 2 + (s:is_vim && ch > height ? -1 : 0)) : s})
   let opts = {
         \ 'lines': lines,
         \ 'relative': 'editor',

--- a/src/__tests__/markdown/index.test.ts
+++ b/src/__tests__/markdown/index.test.ts
@@ -100,7 +100,7 @@ describe('parseDocuments', () => {
     let res = parseDocuments(docs)
     expect(res.lines).toEqual([
       'Error text',
-      '—',
+      '─',
       'Warning text'
     ])
     expect(res.codes).toEqual([
@@ -120,7 +120,7 @@ describe('parseDocuments', () => {
     let res = parseDocuments(docs)
     expect(res.lines).toEqual([
       'const workspace',
-      '—',
+      '─',
       'header'
     ])
     expect(res.highlights).toEqual([{

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -67,7 +67,7 @@ export function parseDocuments(docs: Documentation[], opts: MarkdownParseOptions
       if (arr.length) highlights.push(...arr)
     }
     if (idx != docs.length - 1) {
-      lines.push('—') // separate line
+      lines.push('─') // separate line
     }
     idx = idx + 1
   }


### PR DESCRIPTION
Some terminals don't render the previous characters very well

**alacritty**
![image](https://user-images.githubusercontent.com/47070852/132115181-7c8f2f90-b314-4c96-83a0-69382479cb60.png)
**windows terminal**
![image](https://user-images.githubusercontent.com/47070852/132115196-579670c4-3500-403f-bab2-514a5b5a74aa.png)

It's the character that makes the border