### PR TITLE
feat(float): add autocmd for floating prompts

### DIFF
--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -619,6 +619,7 @@ function! coc#float#create_prompt_win(title, default, opts) abort
     exe 'inoremap <silent><expr><nowait><buffer> <cr> "\<C-r>=coc#float#prompt_insert(getline(''.''))\<cr>\<esc>"'
     call feedkeys('A', 'in')
   endif
+  call coc#util#do_autocmd('CocOpenFloatPrompt')
   return [bufnr, winid]
 endfunction
 

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -2679,6 +2679,13 @@ AUTOCMD							*coc-autocmds*
 	Triggered when a floating window is opened.  The window is not
 	focused, use |g:coc_last_float_win| to get window id.
 
+							*CocOpenFloatPrompt*
+
+:autocmd User CocOpenFloatPrompt {command}
+
+	Triggered when a floating prompt window is opened (triggered after
+	CocOpenFloat).
+
 							*CocTerminalOpen*
 :autocmd User CocTerminalOpen {command}
 


### PR DESCRIPTION
When a float prompt is opened by coc, it currently changes several mappings and enters insert mode. It can be helpful to allow custom mappings or state changes (for example, I would like the prompt to start in normal mode instead). The `CocOpenFloat` autocmd already exists for all floating windows, but this PR adds `CocOpenFloatPrompt` to allow actions specific to prompt windows.