### PR TITLE
fix(snippets): shift range to left as far as possible

### DIFF
--- a/src/snippets/session.ts
+++ b/src/snippets/session.ts
@@ -129,7 +129,7 @@ export class SnippetSession {
     let edit: TextEdit = { range: (change as any).range, newText: change.text }
     let { snippet } = this
     // change outside range
-    let adjusted = snippet.adjustTextEdit(edit)
+    let adjusted = snippet.adjustTextEdit(edit, changedLine)
     if (adjusted) return
     let currRange = this.placeholder.range
     if (changedLine != null


### PR DESCRIPTION
coc can't obtain the changing byte event for buffer and use its
`getChange` function as a workaround. The function may get the wrong
range at some edge cases so that it makes `adjustTextEdit` work
unexpected.

Let me explain what issue I'm talking about. The column is 1-index at
the below assumption:

1. The raw text is `foo0bar1`, and then type `.` to trigger the completion menu, **the postfix candidate with an additional TextEdit.del** is showed and preselected;
2. After selecting the postfix candidate, the text line becomes `foo0bar1.foo = foo0bar1`;
3. After applying additional edit which deletes text range from column 1 to 9 meaning `foo0bar1.` from the head, the text line become `foo = foo0bar1` that is the final text;
4. But coc generate the changed range from column 4 to 12, the changed text is `0bar1.foo` instead of `foo0bar1.`;
5. `adjustTextEdit` function misunderstand the range;

