### PR TITLE
make counting method of Position.character offsets configurable

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -1205,6 +1205,16 @@
       "default": true,
       "description": "Enable tooltip to show relative filepath of call hierarchy."
     },
+    "coc.preferences.positionEncoding": {
+      "type": "string",
+      "default": "utf16",
+      "enum": [
+        "utf8",
+        "utf16",
+        "codepoint"
+      ],
+      "description": "counting method of Position.character offsets"
+    },
     "coc.preferences.enableMessageDialog": {
       "type": "boolean",
       "default": false,

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -106,13 +106,13 @@ export default class Handler implements HandlerDelegate {
 
   public async getCurrentState(): Promise<CurrentState> {
     let { nvim } = this
-    let [bufnr, [line, character], winid, mode] = await nvim.eval("[bufnr('%'),coc#cursor#position(),win_getid(),mode()]") as [number, [number, number], number, string]
+    let [bufnr, winid, mode] = await nvim.eval("[bufnr('%'),win_getid(),mode()]") as [number, number, string]
     let doc = workspace.getDocument(bufnr)
     if (!doc || !doc.attached) throw new Error(`current buffer ${bufnr} not attached`)
     return {
       doc,
       mode,
-      position: Position.create(line, character),
+      position: await window.getCursorPosition(),
       winid
     }
   }


### PR DESCRIPTION
I go through https://github.com/microsoft/language-server-protocol/issues/376 and I found that there are some language servers that do not treat `Position.Character` as utf16 unit, but as utf8 byte or codepoint. so I make this change.

For neovim, [doc](https://neovim.io/doc/user/mbyte.html#:~:text=Nvim%20always%20uses%20UTF-8%20internally.%20Thus%20%27encoding%27%20option%20is%20always%20set%0Ato%20%22utf-8%22%20and%20cannot%20be%20changed.) says that: 
> Nvim always uses UTF-8 internally. Thus 'encoding' option is always set to "utf-8" and cannot be changed.

For vim, `encoding` is adjustable. so there is more work to be done.