### PR TITLE
Fixed unexpected prefix string for snippets completion when using coc-java

### DIFF
--- a/src/sources/source-language.ts
+++ b/src/sources/source-language.ts
@@ -197,8 +197,10 @@ export default class LanguageSource implements ISource {
     }
     if (isSnippet) {
       let currline = doc.getline(linenr - 1)
+      // the start character should be relocated to the begining of the completion word
+      let startCharacter = option.col
       let endCharacter = currline.length - end.length
-      let r = Range.create(linenr - 1, range.start.character, linenr - 1, endCharacter)
+      let r = Range.create(linenr - 1, startCharacter, linenr - 1, endCharacter)
       // can't select, since additionalTextEdits would break selection
       return await snippetManager.insertSnippet(newText, false, r, item.insertTextMode)
     }


### PR DESCRIPTION
Not sure if this is a valid fix, but it solves my problem (see below), wish to get your feedbacks.

**TLDR**
when performing completion for snippets, the editor should do insertion/replacement at the beginning of the word rather than the current cursor position.

**The Problem**

CocInfo output:
```
## versions

vim version: NVIM v0.5.0
node version: v14.17.4
coc.nvim version: 0.0.80-f6f761c320
coc.nvim directory: /path_to/coc.nvim
term: xterm-256color
platform: linux
```

used java file:
```java
package test.nvim.snippets;

import org.junit.jupiter.api.Test;

class MainTest {

    @Test
    void test_snippets() {
      sysout
    }
}
```

The verbose logs for interacting with the java language server:

When I type in the `sysout` word, I can see the editor sent a completion request:
```
[Trace - 12:06:23 AM] Sending request 'textDocument/completion - (1)'.
Params: {
    "textDocument": {
        "uri": "file:///path_to/MainTest.java"
    },
    "position": {
        "line": 8,
        "character": 7
    },
    "context": {
        "triggerKind": 1
    }
}
```

Note the position, it means the request is sent out immediately after I typed the beginning `s` (of `sysout`) character.

Then I got a response from the language server, which is too long and I'll just skip it here, but the snippet completion for `sysout` is in the result list.

I then noticed a resolving completion request to the language server
```
[Trace - 12:06:28 AM] Sending request 'completionItem/resolve - (2)'.
Params: {
    "label": "sysout",
    "kind": 15,
    "detail": "print to standard out",
    "insertText": "System.out.println(${0});",
    "insertTextFormat": 2,
    "data": {
        "rid": "1",
        "uri": "file:///path_to/MainTest.java",
        "pid": "0"
    }
}
```
And here is the response:

```
[Trace - 12:06:28 AM] Received response 'completionItem/resolve - (2)' in 10ms.
Result: {
    "label": "sysout",
    "kind": 15,
    "detail": "print to standard out",
    "documentation": {
        "kind": "markdown",
        "value": "```java\nSystem.out.println();\n```"
    },
    "insertText": "System.out.println(${0});",
    "insertTextFormat": 2,
    "textEdit": {
        "range": {
            "start": {
                "line": 8,
                "character": 7
            },
            "end": {
                "line": 8,
                "character": 7
            }
        },
        "newText": "System.out.println(${0});"
    }
}
```

If the editor uses the `textEdit` from the language server directly, a additional prefix of `S` will be found in the result content, because the `textEdit` is supposed to take place right after the beginning `s` (of `sysout`):
```java
package test.nvim.snippets;

import org.junit.jupiter.api.Test;

class MainTest {

    @Test
    void test_snippets() {
      SSystem.out.println(); // but `System.out.println()` is expected here.
    }
}

```

(The prefix `S` char is introduced by preview of the `sysout`? I'm not sure about it, but it doesn't matter because the `textEdit`'s position is wrong anyway)

The fix I did in the pr is to change the `textedit` returned by the language server, to include the beginning `s` into the change range.

BTW, I'm also suspecting the correct fix should be done in the language server, so am also investigating the language server now.