### PR TITLE
Enable feature to GoTo definitions using vim tjump

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -179,6 +179,36 @@ function! coc#util#jump(cmd, filepath, ...) abort
   endif
 endfunction
 
+function! coc#util#tjump(cmd, filepath, ...) abort
+  let path = a:filepath
+  if !empty(get(a:, 1, []))
+    let line = a:1[0]
+    let column = a:1[1]
+  else
+    let line = 1
+    let column = 1
+  endif
+  if (has('win32unix'))
+    let path = substitute(a:filepath, '\v\\', '/', 'g')
+  endif
+  " Optimization: Reuse tempfile if already created (speedup)
+  if !exists('s:tempfile')
+    let s:tempfile = tempname()
+  endif
+  let tagname = "tagname"
+  call writefile([tagname."\t".path."\t"."call cursor(".line.",".column.")"], s:tempfile)
+  let old_tags = &tags
+  let old_wildignore = &wildignore
+  try
+    set wildignore=
+    let &tags = s:tempfile
+    exe a:cmd.' '.tagname
+  finally
+    let &tags = old_tags
+    let &wildignore= old_wildignore
+  endtry
+endfunction
+
 function! coc#util#echo_messages(hl, msgs)
   if a:hl !~# 'Error' && (mode() !~# '\v^(i|n)$')
     return

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -827,7 +827,8 @@ Built-in configurations:~
 	Command used for location jump performed for goto definition, goto
 	references etc, default: `"edit"`
 
-	Valid options: ["edit", "split", "vsplit", "tabe", "drop", "tab drop"]
++	Valid options: ["edit","split","vsplit","tabe","drop","tab
++	drop","tjump","stjump","ptjump"]
 
 "coc.preferences.messageLevel":~
 

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -810,7 +810,27 @@ export class Workspace implements IWorkspace {
     let { nvim } = this
     let doc = this.getDocument(uri)
     let bufnr = doc ? doc.bufnr : -1
-    if (bufnr != -1 && jumpCommand == 'edit') {
+    if (jumpCommand == 'tjump' || jumpCommand == 'stjump' || jumpCommand == 'ptjump') {
+      let { fsPath, scheme } = URI.parse(uri)
+      let pos = null
+      if (doc) {
+        if (position) {
+          let line = doc.getline(position.line)
+          let col = byteLength(line.slice(0, position.character)) + 1
+          pos = [position.line + 1, col]
+        }
+      } else {
+        if (position) {
+          pos = [position.line + 1, position.character + 1]
+        }
+      }
+      if (scheme == 'file') {
+        let bufname = fixDriver(path.normalize(fsPath))
+        await this.nvim.call('coc#util#tjump', [jumpCommand, bufname, pos])
+      } else {
+        await this.nvim.call('coc#util#tjump', [jumpCommand, uri, pos])
+      }
+    } else if (bufnr != -1 && jumpCommand == 'edit') {
       // use buffer command since edit command would reload the buffer
       nvim.pauseNotification()
       nvim.command(`silent! normal! m'`, true)


### PR DESCRIPTION
coc.preferences.jumpCommand option can now be set to 'tjump' which
enables using vim's built in tjump function. This enables the
possibility to use the tag stack when jumping and jumping back.