### PR TITLE
use `os.tmpdir()` if `process.env.TMPDIR` is undefined

### DIFF
--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1253,7 +1253,7 @@ augroup coc_dynamic_autocmd
   ${cmds.join('\n  ')}
 augroup end`
     try {
-      let dir = path.join(process.env.TMPDIR, `coc.nvim-${process.pid}`)
+      let dir = path.join(process.env.TMPDIR || os.tmpdir(), `coc.nvim-${process.pid}`)
       if (!fs.existsSync(dir)) fs.mkdirpSync(dir)
       let filepath = path.join(dir, `coc-${process.pid}.vim`)
       fs.writeFileSync(filepath, content, 'utf8')


### PR DESCRIPTION
Fixes https://github.com/neoclide/coc.nvim/issues/2589, see https://github.com/neoclide/coc.nvim/issues/2589#issuecomment-938061961.
This should be safe and does not require people to define `TMPDIR` in their configs (which I did but node's `process.env` did not pick it up).