### PR TITLE
feat(document): use `latex` language ID instead of `tex` (#757)

### DIFF
--- a/src/__tests__/list/basicList.test.ts
+++ b/src/__tests__/list/basicList.test.ts
@@ -52,6 +52,7 @@ describe('getFiletype()', () => {
   it('should get filetype', async () => {
     expect(getFiletype('javascriptreact')).toBe('javascript')
     expect(getFiletype('typescriptreact')).toBe('typescript')
+    expect(getFiletype('latex')).toBe('tex')
     expect(getFiletype('foo.bar')).toBe('foo')
     expect(getFiletype('foo')).toBe('foo')
   })

--- a/src/__tests__/modules/document.test.ts
+++ b/src/__tests__/modules/document.test.ts
@@ -165,6 +165,20 @@ describe('properties', () => {
     expect(winid != -1).toBe(true)
     expect(previewwindow).toBe(false)
   })
+
+  it('should set filetype', async () => {
+    let doc = await helper.createDocument()
+    doc.setFiletype('javascript.jsx')
+    expect(doc.filetype).toBe('javascriptreact')
+    doc.setFiletype('typescript.jsx')
+    expect(doc.filetype).toBe('typescriptreact')
+    doc.setFiletype('typescript.tsx')
+    expect(doc.filetype).toBe('typescriptreact')
+    doc.setFiletype('tex')
+    expect(doc.filetype).toBe('latex')
+    doc.setFiletype('foo')
+    expect(doc.filetype).toBe('foo')
+  })
 })
 
 describe('synchronize', () => {

--- a/src/list/basic.ts
+++ b/src/list/basic.ts
@@ -294,8 +294,16 @@ export default abstract class BasicList implements IList, Disposable {
 }
 
 export function getFiletype(filetype: string): string {
-  if (filetype == 'javascriptreact') return 'javascript'
-  if (filetype == 'typescriptreact') return 'typescript'
-  if (filetype.indexOf('.') !== -1) return filetype.split('.')[0]
-  return filetype
+  switch (filetype) {
+    case 'javascriptreact':
+      return 'javascript'
+    case 'typescriptreact':
+      return 'typescript'
+    case 'latex':
+      // LaTeX (LSP language ID 'latex') has Vim filetype 'tex'
+      return 'tex'
+    default:
+      if (filetype.indexOf('.') !== -1) return filetype.split('.')[0]
+      return filetype
+  }
 }

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -137,10 +137,20 @@ export default class Document {
    * Map filetype for languageserver.
    */
   public convertFiletype(filetype: string): string {
-    let map = this.env.filetypeMap
-    if (filetype == 'javascript.jsx') return 'javascriptreact'
-    if (filetype == 'typescript.jsx' || filetype == 'typescript.tsx') return 'typescriptreact'
-    return map[filetype] || filetype
+    switch (filetype) {
+      case 'javascript.jsx':
+        return 'javascriptreact'
+      case 'typescript.jsx':
+      case 'typescript.tsx':
+        return 'typescriptreact'
+      case 'tex':
+        // Vim filetype 'tex' means LaTeX, which has LSP language ID 'latex'
+        return 'latex'
+      default: {
+        let map = this.env.filetypeMap
+        return map[filetype] || filetype
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Use `latex` as LSP language ID for L<sup>A</sup>T<sub>E</sub>X documents (instead of `tex`) as recommended by the [LSP specification](https://microsoft.github.io/language-server-protocol/specification#textDocumentItem). This allows using LSP servers that act on L<sup>A</sup>T<sub>E</sub>X documents, but not on plain T<sub>E</sub>X documents. The LSP language ID/Vim filetype `plaintex` for plain T<sub>E</sub>X documents is left unchanged.

I'm not quite sure if I did it right in `list/basic.ts`. Having a function `getFiletype(filetype: string): string` is pretty confusing (why would I get a filetype, if I have to pass it as a argument...). The code would benefit from naming variables for Vim filetypes and variables for LSP language IDs differently (not both `filetype`), but that's outside the scope of the issue/of this PR.

Linted and tested according to the contribution guidelines (although a lot of tests currently fail on `master`), plus manually E2E-tested with my language server [LT<sub>E</sub>X LS](https://github.com/valentjn/ltex-ls).

See #757