### PR TITLE
fix(window.vim): don't swallow WinClosed event

### DIFF
--- a/autoload/coc/window.vim
+++ b/autoload/coc/window.vim
@@ -30,26 +30,26 @@ function! coc#window#gotoid(winid) abort
   endif
 endfunction
 
-" Avoid autocmd & errors
+" Avoid errors
 function! coc#window#close(winid) abort
   if empty(a:winid) || a:winid == -1
     return
   endif
   if exists('*nvim_win_is_valid') && exists('*nvim_win_close')
     if nvim_win_is_valid(a:winid)
-      noa call nvim_win_close(a:winid, 1)
+      call nvim_win_close(a:winid, 1)
     endif
   elseif exists('*win_execute')
     call coc#compat#execute(a:winid, 'noa close!', 'silent!')
   else
     let curr = win_getid()
     if curr == a:winid
-      noa silent! close!
+      silent! close!
     else
       let res = win_gotoid(a:winid)
       if res
-        noa silent! close!
-        noa call win_gotoid(curr)
+        silent! close!
+        call win_gotoid(curr)
       endif
     endif
   endif


### PR DESCRIPTION
I have a plan to separate out `nvim-bqf`'s `magic window` module which stabilizes window layout. https://github.com/kevinhwang91/nvim-bqf/issues/40

`magic window` needs Winclosed event to restore the original winview. Unfortunately, coclist has swallowed the event when canceling the prompt.

the demo has patched this PR:
![coc-winclosed](https://user-images.githubusercontent.com/17562139/137921065-151d6601-58e8-40fe-9782-b7788b16ab60.gif)

`cat coc-win.vim`
```vim
set nu
pa coc.nvim
pa nvim-bqf
au FileType list lua require('bqf.magicwin.handler').attach()
```


