### PR TITLE
Add diagnostic.messageTarget none

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -611,7 +611,7 @@
       "type": "string",
       "description": "Diagnostic message target.",
       "default": "float",
-      "enum": ["echo", "float"]
+      "enum": ["echo", "float", "none"]
     },
     "diagnostic.messageDelay": {
       "type": "number",

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -433,7 +433,7 @@ Built-in configurations:~
 
 	Diagnostic message target, default: `"float"`
 
-	Valid options: ["echo", "float"]
+	Valid options: ["echo", "float", "none"]
 
 "diagnostic.refreshOnInsertMode":~
 

--- a/src/__tests__/modules/diagnosticManager.test.ts
+++ b/src/__tests__/modules/diagnosticManager.test.ts
@@ -436,6 +436,17 @@ describe('diagnostic manager', () => {
       config.update('messageTarget', 'float')
     })
 
+    it('should not echo messages on cursor hold', async () => {
+      let config = workspace.getConfiguration('diagnostic')
+      config.update('messageTarget', 'none')
+      await createDocument()
+      await nvim.call('cursor', [1, 3])
+      await helper.wait(600)
+      let line = await helper.getCmdline()
+      expect(line.length).toBe(0)
+      config.update('messageTarget', 'float')
+    })
+
     it('should show diagnostics of current line', async () => {
       let config = workspace.getConfiguration('diagnostic')
       config.update('checkCurrentLine', true)

--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -433,6 +433,7 @@ export class DiagnosticManager implements Disposable {
     if (!this.enabled || config.displayByAle) return
     if (this.timer) clearTimeout(this.timer)
     let useFloat = config.messageTarget == 'float'
+    let noMessageTarget = config.messageTarget == 'none'
     // echo
     let [filetype, mode] = await this.nvim.eval(`[&filetype,mode()]`) as [string, string]
     if (mode != 'n') return
@@ -476,7 +477,7 @@ export class DiagnosticManager implements Disposable {
       await this.floatFactory.show(docs, config)
     } else {
       let lines = docs.map(d => d.content).join('\n').split(/\r?\n/)
-      if (lines.length) {
+      if (lines.length && !noMessageTarget) {
         await this.nvim.command('echo ""')
         await window.echoLines(lines, truncate)
       }


### PR DESCRIPTION
Adds a third option `none` to `diagnostic.messageTarget`

This makes browsing files with diagnostic errors/warnings less noisy or jarring, especially when there are multiple diagnostics on a single line.

Makes for a much better experience especially when combined with the following:

vimrc:
```
set mouse=a
```

coc-settings.json:
```
"diagnostic.virtualText": true,
"diagnostic.virtualTextCurrentLineOnly": false,
"diagnostic.checkCurrentLine": true,
```
