### PR TITLE
fix(format): onTypeFormatting position

### DIFF
--- a/src/__tests__/handler/format.test.ts
+++ b/src/__tests__/handler/format.test.ts
@@ -196,7 +196,7 @@ describe('format handler', () => {
       await nvim.input('o')
       await helper.wait(100)
       let lines = await buf.lines
-      expect(lines).toEqual(['  foo', ''])
+      expect(lines).toEqual(['foo', '  '])
     })
 
     it('should adjust cursor after format on type', async () => {

--- a/src/handler/format.ts
+++ b/src/handler/format.ts
@@ -67,6 +67,7 @@ export default class FormatHandler {
     }))
     handler.addDisposable(events.on('CursorMovedI', async bufnr => {
       if (bufnr == enterBufnr && Date.now() - enterTs < 100) {
+        enterBufnr = undefined
         await this.handleEnter(bufnr)
       }
     }))
@@ -129,15 +130,14 @@ export default class FormatHandler {
       let origLine = doc.getline(position.line - 1)
       // not format for empty line.
       if (newLine && /^\s*$/.test(origLine)) return
-      let pos: Position = newLine ? { line: position.line - 1, character: origLine.length } : position
       await doc.synchronize()
-      return await languages.provideDocumentOnTypeEdits(ch, doc.textDocument, pos, token)
+      return await languages.provideDocumentOnTypeEdits(ch, doc.textDocument, position, token)
     })
     if (!edits || !edits.length) return
     let changed = getChangedFromEdits(position, edits)
     await doc.applyEdits(edits)
     let to = changed ? Position.create(position.line + changed.line, position.character + changed.character) : null
-    if (to && !newLine) await window.moveTo(to)
+    if (to) await window.moveTo(to)
   }
 
   public async formatCurrentBuffer(): Promise<boolean> {


### PR DESCRIPTION
https://github.com/neoclide/coc-yaml/issues/51

I think the position used in `onTypeFormatting` is incorrect, in this fix, coc.nvim always uses the current position to request.

I've tested with rust-analyzer/yaml, works as expected. But this fix introduced an unexpected behavior for TS with tsserver:

```ts
if (obj) {
  console.log(obj);
}
```

Put cursor on `if`, fire `cw`, the `if` will be removed and enter insert mode, tsserver returns onTypeFormatting, after applied the edits, you got:

```
(obj) {
  console.log(obj);
}
```

the **space** after `if` is deleted too.

The reason:

1. coc will check `InsertEnter` and `TextChangedI`, try to do onTypeFormatting for `o` action
2. `cw` also fires these two event, and tsserver reposed to do formatting
