### PR TITLE
fix(highlight): fix regression in highlight colour when only one colour has a "reverse"

### DIFF
--- a/autoload/coc/highlight.vim
+++ b/autoload/coc/highlight.vim
@@ -331,10 +331,12 @@ function! coc#highlight#compose_hlgroup(fgGroup, bgGroup) abort
   endif
   let fgId = synIDtrans(hlID(a:fgGroup))
   let bgId = synIDtrans(hlID(a:bgGroup))
-  let guifg = synIDattr(fgId, 'reverse', 'gui') !=# '1' ? synIDattr(fgId, 'fg', 'gui') : synIDattr(fgId, 'bg', 'gui')
-  let guibg = synIDattr(bgId, 'reverse', 'gui') !=# '1' ? synIDattr(bgId, 'bg', 'gui') : synIDattr(bgId, 'fg', 'gui')
-  let ctermfg = synIDattr(fgId, 'reverse', 'cterm') !=# '1' ? synIDattr(fgId, 'fg', 'cterm') : synIDattr(fgId, 'bg', 'cterm')
-  let ctermbg = synIDattr(bgId, 'reverse', 'cterm') !=# '1' ? synIDattr(bgId, 'bg', 'cterm') : synIDattr(bgId, 'fg', 'cterm')
+  let isGuiReversed = synIDattr(fgId, 'reverse', 'gui') !=# '1' || synIDattr(bgId, 'reverse', 'gui') !=# '1'
+  let guifg = isGuiReversed ? synIDattr(fgId, 'fg', 'gui') : synIDattr(fgId, 'bg', 'gui')
+  let guibg = isGuiReversed ? synIDattr(bgId, 'bg', 'gui') : synIDattr(bgId, 'fg', 'gui')
+  let isCtermReversed = synIDattr(fgId, 'reverse', 'cterm') !=# '1' || synIDattr(bgId, 'reverse', 'cterm') !=# '1'
+  let ctermfg = isCtermReversed ? synIDattr(fgId, 'fg', 'cterm') : synIDattr(fgId, 'bg', 'cterm')
+  let ctermbg = isCtermReversed ? synIDattr(bgId, 'bg', 'cterm') : synIDattr(bgId, 'fg', 'cterm')
   let bold = synIDattr(fgId, 'bold') ==# '1'
   let italic = synIDattr(fgId, 'italic') ==# '1'
   let underline = synIDattr(fgId, 'underline') ==# '1'


### PR DESCRIPTION
Fix: #3473
This regression was introduced in 5f423c4a81698aac3c83adea7c1adad1549cb853
It affects users of https://github.com/altercation/vim-colors-solarized
Minimal reproduction can be found in the issue, in this comment: https://github.com/neoclide/coc.nvim/issues/3473#issuecomment-974731723

The issue is that there is only one reverse (in CocFloating -> Pmenu), and not in CocInfoSign as per this comment: https://github.com/neoclide/coc.nvim/issues/3473#issuecomment-974746261

## Result

|               | CocInfoSign cterm | CocErrorSign cterm | CocInfoSign gui | CocErrorSign gui |
| -- | -- | -- | -- | -- |
| Before regression | ![image](https://user-images.githubusercontent.com/4915682/142769938-230adcf4-0883-465a-9110-89f9038049c6.png) | ![image](https://user-images.githubusercontent.com/4915682/142769920-cd95526b-cdae-4334-953b-d1e85c931ef4.png) | ![image](https://user-images.githubusercontent.com/4915682/142769969-ba2fda23-468c-4987-97d7-0a0b61465229.png) | ![image](https://user-images.githubusercontent.com/4915682/142769988-355ff0e2-bcf4-4765-a2fc-0f413de3d288.png) |
| After regression | ![image](https://user-images.githubusercontent.com/4915682/142769776-0cc3252b-1b5f-421a-b511-69bd2621716d.png) | ![image](https://user-images.githubusercontent.com/4915682/142769825-703b9c3a-3d53-4e76-b1b1-a658bdf94763.png) | ![image](https://user-images.githubusercontent.com/4915682/142769880-2a9febe7-a033-4a8c-a80d-3703ac81bef4.png) | ![image](https://user-images.githubusercontent.com/4915682/142769856-261e5c9f-8edd-4a00-bcaf-336420543895.png) |
| After fix | ![image](https://user-images.githubusercontent.com/4915682/142770019-8cf2d2fb-be0c-42ec-8c30-6f393e79834f.png) | ![image](https://user-images.githubusercontent.com/4915682/142770044-58c26d6e-ce95-40ae-b301-1395005e3c10.png) | ![image](https://user-images.githubusercontent.com/4915682/142770072-2e758dbf-7087-4fd6-8b56-17c0fec12253.png) | ![image](https://user-images.githubusercontent.com/4915682/142770093-66dd3180-9c1e-4f61-a648-a97e528547f5.png) |
