### PR TITLE
Fix markdown rendering of horizontal rule (hr)

### DIFF
--- a/src/markdown/renderer.ts
+++ b/src/markdown/renderer.ts
@@ -250,7 +250,13 @@ class Renderer {
   }
 
   public hr(): string {
-    return `---\n\n`
+    // NOTE: the '─' character is conveniently translated into a window-wide
+    // horizontal rule by coc.nvim/autoload/coc/float.vim. Using this character
+    // causes the horizontal rule to appear like a proper hr separator. In case
+    // the user isn't benefiting from a floating window, we provide three
+    // characters so that the hr doesn't deviate too significantly from
+    // Markdown's normal '-'.
+    return `───\n`
   }
 
   public list(body, ordered): string {


### PR DESCRIPTION
Resolves https://github.com/neoclide/coc.nvim/issues/3479

Old output:

![image](https://user-images.githubusercontent.com/3723671/143286549-e6e871c2-7462-4db8-8d25-a108154a15ef.png)

New output:

![image](https://user-images.githubusercontent.com/3723671/143286467-f99466d6-6008-4bcb-bbd5-992d76cba889.png)