### PR TITLE
fix(highlight): remove most problematic usage of &winhl

### DIFF
--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -147,7 +147,12 @@ function! coc#float#create_float_win(winid, bufnr, config) abort
       return []
     endif
     let hlgroup = get(a:config, 'highlight', 'CocFloating')
-    call setwinvar(winid, '&winhl', 'Normal:'.hlgroup.',NormalNC:'.hlgroup.',FoldColumn:'.hlgroup)
+    call coc#compat#execute(winid, [
+          \ 'hi! link Normal '.hlgroup,
+          \ 'hi! link NormalNC '.hlgroup,
+          \ 'hi! link FoldColumn '.hlgroup,
+          \ 'hi! link NormalFloat '.hlgroup
+          \ ])
     call setwinvar(winid, '&signcolumn', 'no')
     call setwinvar(winid, '&foldenable', 0)
     " cursorline highlight not work on old neovim
@@ -257,14 +262,22 @@ function! coc#float#nvim_border_win(config, winid, border, title, hasbtn, hlgrou
   endif
   if winid
     call nvim_win_set_config(winid, opt)
-    call setwinvar(winid, '&winhl', 'Normal:'.a:hlgroup.',NormalNC:'.a:hlgroup)
+    call coc#compat#execute(winid, [
+          \ 'hi! link Normal '.a:hlgroup,
+          \ 'hi! link NormalNC '.a:hlgroup,
+          \ 'hi! link NormalFloat '.a:hlgroup
+          \ ])
   else
     noa let winid = nvim_open_win(bufnr, 0, opt)
     if winid
       if a:winblend
         call setwinvar(winid, '&winblend', a:winblend)
       endif
-      call setwinvar(winid, '&winhl', 'Normal:'.a:hlgroup.',NormalNC:'.a:hlgroup)
+      call coc#compat#execute(winid, [
+            \ 'hi! link Normal '.a:hlgroup,
+            \ 'hi! link NormalNC '.a:hlgroup,
+            \ 'hi! link NormalFloat '.a:hlgroup
+            \ ])
       call setwinvar(winid, 'target_winid', a:winid)
       call setwinvar(winid, 'kind', 'border')
       call add(a:related, winid)
@@ -293,7 +306,11 @@ function! coc#float#nvim_close_btn(config, winid, border, hlgroup, winblend, rel
     let bufnr = coc#float#create_buf(0, ['X'])
     noa let winid = nvim_open_win(bufnr, 0, config)
     if winid
-      call setwinvar(winid, '&winhl', 'Normal:'.a:hlgroup.',NormalNC:'.a:hlgroup)
+      call coc#compat#execute(winid, [
+            \ 'hi! link Normal '.a:hlgroup,
+            \ 'hi! link NormalNC '.a:hlgroup,
+            \ 'hi! link NormalFloat '.a:hlgroup
+            \ ])
       call setwinvar(winid, 'target_winid', a:winid)
       call setwinvar(winid, 'kind', 'close')
       if a:winblend
@@ -339,7 +356,11 @@ function! coc#float#nvim_right_pad(config, winid, hlgroup, winblend, related) ab
     if a:winblend
       call setwinvar(winid, '&winblend', a:winblend)
     endif
-    call setwinvar(winid, '&winhl', 'Normal:'.a:hlgroup.',NormalNC:'.a:hlgroup)
+    call coc#compat#execute(winid, [
+          \ 'hi! link Normal '.a:hlgroup,
+          \ 'hi! link NormalNC '.a:hlgroup,
+          \ 'hi! link NormalFloat '.a:hlgroup
+          \ ])
     call setwinvar(winid, 'target_winid', a:winid)
     call setwinvar(winid, 'kind', 'pad')
     call add(a:related, winid)
@@ -373,7 +394,11 @@ function! coc#float#nvim_buttons(config, winid, buttons, borderbottom, pad, hlgr
     let bufnr = s:create_btns_buffer(0, width, a:buttons, a:borderbottom)
     noa let winid = nvim_open_win(bufnr, 0, config)
     if winid
-      call setwinvar(winid, '&winhl', 'Normal:'.a:hlgroup.',NormalNC:'.a:hlgroup)
+      call coc#compat#execute(winid, [
+            \ 'hi! link Normal '.a:hlgroup,
+            \ 'hi! link NormalNC '.a:hlgroup,
+            \ 'hi! link NormalFloat '.a:hlgroup
+            \ ])
       call setwinvar(winid, 'target_winid', a:winid)
       call setwinvar(winid, 'kind', 'buttons')
       if a:winblend

--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -262,22 +262,14 @@ function! coc#float#nvim_border_win(config, winid, border, title, hasbtn, hlgrou
   endif
   if winid
     call nvim_win_set_config(winid, opt)
-    call coc#compat#execute(winid, [
-          \ 'hi! link Normal '.a:hlgroup,
-          \ 'hi! link NormalNC '.a:hlgroup,
-          \ 'hi! link NormalFloat '.a:hlgroup
-          \ ])
+    call setwinvar(winid, '&winhl', 'Normal:'.a:hlgroup.',NormalNC:'.a:hlgroup)
   else
     noa let winid = nvim_open_win(bufnr, 0, opt)
     if winid
       if a:winblend
         call setwinvar(winid, '&winblend', a:winblend)
       endif
-      call coc#compat#execute(winid, [
-            \ 'hi! link Normal '.a:hlgroup,
-            \ 'hi! link NormalNC '.a:hlgroup,
-            \ 'hi! link NormalFloat '.a:hlgroup
-            \ ])
+      call setwinvar(winid, '&winhl', 'Normal:'.a:hlgroup.',NormalNC:'.a:hlgroup)
       call setwinvar(winid, 'target_winid', a:winid)
       call setwinvar(winid, 'kind', 'border')
       call add(a:related, winid)
@@ -306,11 +298,7 @@ function! coc#float#nvim_close_btn(config, winid, border, hlgroup, winblend, rel
     let bufnr = coc#float#create_buf(0, ['X'])
     noa let winid = nvim_open_win(bufnr, 0, config)
     if winid
-      call coc#compat#execute(winid, [
-            \ 'hi! link Normal '.a:hlgroup,
-            \ 'hi! link NormalNC '.a:hlgroup,
-            \ 'hi! link NormalFloat '.a:hlgroup
-            \ ])
+      call setwinvar(winid, '&winhl', 'Normal:'.a:hlgroup.',NormalNC:'.a:hlgroup)
       call setwinvar(winid, 'target_winid', a:winid)
       call setwinvar(winid, 'kind', 'close')
       if a:winblend
@@ -356,11 +344,7 @@ function! coc#float#nvim_right_pad(config, winid, hlgroup, winblend, related) ab
     if a:winblend
       call setwinvar(winid, '&winblend', a:winblend)
     endif
-    call coc#compat#execute(winid, [
-          \ 'hi! link Normal '.a:hlgroup,
-          \ 'hi! link NormalNC '.a:hlgroup,
-          \ 'hi! link NormalFloat '.a:hlgroup
-          \ ])
+    call setwinvar(winid, '&winhl', 'Normal:'.a:hlgroup.',NormalNC:'.a:hlgroup)
     call setwinvar(winid, 'target_winid', a:winid)
     call setwinvar(winid, 'kind', 'pad')
     call add(a:related, winid)
@@ -394,11 +378,7 @@ function! coc#float#nvim_buttons(config, winid, buttons, borderbottom, pad, hlgr
     let bufnr = s:create_btns_buffer(0, width, a:buttons, a:borderbottom)
     noa let winid = nvim_open_win(bufnr, 0, config)
     if winid
-      call coc#compat#execute(winid, [
-            \ 'hi! link Normal '.a:hlgroup,
-            \ 'hi! link NormalNC '.a:hlgroup,
-            \ 'hi! link NormalFloat '.a:hlgroup
-            \ ])
+      call setwinvar(winid, '&winhl', 'Normal:'.a:hlgroup.',NormalNC:'.a:hlgroup)
       call setwinvar(winid, 'target_winid', a:winid)
       call setwinvar(winid, 'kind', 'buttons')
       if a:winblend


### PR DESCRIPTION
NeoVim-only winhighlight feature is very prone to "misuse", as it essentially breaks Vim's highlighting linking system, making it hard to be ever employed with success.

winhl overrides accept built-in highlighting groups only, but even if that's followed (set winhl=Normal:MyGroup) to get a floating window's main text changed, one may get scrambled highlighting in case the floating windows contains text highlighted by custom groups linked to Normal (typescriptParens for example), these groups will still link to the original Normal highlight instead of the override, which equates to getting mixed "MyGroup Normal"/"Original Normal" content. Meaning, it leads to some parts of the text getting overridden highlight but other parts strangely not.

The current fix replaces occurrences for setting winhl with window local highlight links.

The highlight links are simple and directly forcibly created (without any highlight clear, etc.), this relies on a very clever feature of Vim highlighting links where having cycles isn't a problem at all, so there's no risk having NormalFloat linked to CocFloating which itself links to NormalFloat. Such kind of cycle ends up in having NormalFloat's original highlight, which is just what we want if the cycle happens.

Another solution instead of window local highlight exec's is to make use of syntax clusters, and it works, but as this requires an additional syntax file with the highlighting overrides to be loaded, I've dropped it.

Fixes #1251

neobones from [zenbones.nvim](https://github.com/mcchrish/zenbones.nvim):
![img-2021-11-26-194208](https://user-images.githubusercontent.com/1269815/143659479-93c8a611-4a6f-42d9-a7e1-a663911768d5.png)

[rose-pine](https://github.com/rose-pine/neovim):
![img-2021-11-26-195143](https://user-images.githubusercontent.com/1269815/143659790-1df9acde-f91b-4ee4-943e-e2bf8cbf01e1.png)
