### PR TITLE
CocActionAsync called instead of CocAction for OR command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ command! -nargs=0 Format :call CocAction('format')
 command! -nargs=? Fold :call     CocAction('fold', <f-args>)
 
 " Add `:OR` command for organize imports of the current buffer.
-command! -nargs=0 OR   :call     CocAction('runCommand', 'editor.action.organizeImport')
+command! -nargs=0 OR   :call     CocActionAsync('runCommand', 'editor.action.organizeImport')
 
 " Add (Neo)Vim's native statusline support.
 " NOTE: Please see `:h coc-status` for integrations with external plugins that


### PR DESCRIPTION
This fixes #3496 issue. CocActionAsync called instead of CocAction for OR (organize imports) command.