### PR TITLE
fix: correctly handle globs in 'runtimepath'

### DIFF
--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -149,7 +149,7 @@ function! s:funcs.feedkeys(keys, mode, escape_csi)
 endfunction
 
 function! s:funcs.list_runtime_paths()
-  return split(&runtimepath, ',')
+  return globpath(&runtimepath, '', 0, 1)
 endfunction
 
 function! s:funcs.command_output(cmd)

--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -540,7 +540,7 @@ function! coc#util#vim_info()
         \ 'colorscheme': get(g:, 'colors_name', ''),
         \ 'workspaceFolders': get(g:, 'WorkspaceFolders', v:null),
         \ 'background': &background,
-        \ 'runtimepath': &runtimepath,
+        \ 'runtimepath': join(globpath(&runtimepath, '', 0, 1), ','),
         \ 'locationlist': get(g:,'coc_enable_locationlist', 1),
         \ 'progpath': v:progpath,
         \ 'guicursor': &guicursor,
@@ -557,7 +557,7 @@ function! coc#util#highlight_options()
   return {
         \ 'colorscheme': get(g:, 'colors_name', ''),
         \ 'background': &background,
-        \ 'runtimepath': &runtimepath,
+        \ 'runtimepath': join(globpath(&runtimepath, '', 0, 1), ','),
         \}
 endfunction
 

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -678,7 +678,7 @@ export class Extensions {
   }
 
   private async localExtensionStats(excludes: string[]): Promise<ExtensionInfo[]> {
-    let runtimepath = await workspace.nvim.eval('&runtimepath') as string
+    let runtimepath = await workspace.nvim.eval('join(globpath(&runtimepath, "", 0, 1), ",")') as string
     let paths = runtimepath.split(',')
     let res: ExtensionInfo[] = await Promise.all(paths.map(root => new Promise<ExtensionInfo>(async resolve => {
       try {


### PR DESCRIPTION
# The Issue
Neovim 0.6.0 has started to use globs in its default 'runtimepath' [1]. This prevented CoC from detecting extensions that are installed in `~/.config/nvim/pack/*/start/*`.

[1]: https://github.com/neovim/neovim/commit/9df7e02

# Results
I compared the output of `:CocList extensions` before and after applying the fix.

Before:
<img width="682" alt="before" src="https://user-images.githubusercontent.com/7343721/146232840-0e59e1dd-e414-4ae2-b3e3-fe1f35fac19d.png">

After:
<img width="682" alt="Screen Shot 2021-12-16 at 2 07 47 AM" src="https://user-images.githubusercontent.com/7343721/146232877-5c725e50-aace-4220-99f3-220579d5d4c5.png">

