### PR TITLE
funcs.buf_clear_namespace should treat endLine as exclusive

### DIFF
--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -310,7 +310,7 @@ function! s:funcs.buf_clear_namespace(bufnr, srcId, startLine, endLine) abort
   endif
   let bufnr = a:bufnr == 0 ? bufnr('%') : a:bufnr
   let start = a:startLine + 1
-  let end = a:endLine == -1 ? len(getbufline(bufnr, 1, '$')) : a:endLine;
+  let end = a:endLine == -1 ? len(getbufline(bufnr, 1, '$')) : a:endLine
   if a:srcId == -1
     call prop_clear(start, end, {'bufnr' : bufnr})
   else

--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -310,7 +310,7 @@ function! s:funcs.buf_clear_namespace(bufnr, srcId, startLine, endLine) abort
   endif
   let bufnr = a:bufnr == 0 ? bufnr('%') : a:bufnr
   let start = a:startLine + 1
-  let end = a:endLine == -1 ? len(getbufline(bufnr, 1, '$')) : a:endLine + 1
+  let end = a:endLine == -1 ? len(getbufline(bufnr, 1, '$')) : a:endLine;
   if a:srcId == -1
     call prop_clear(start, end, {'bufnr' : bufnr})
   else


### PR DESCRIPTION
I noticed that diagnostic messages cancel the semantic highlight on the next line. I haven't figured out why diagnostic affects semantic highlighting, but it seems that funcs.buf_clear_namespace is wrongly treating endLine as inclusive (VIM textprop ranges are 1-based end-inclusive, while LSP ranges are 0-based end-exclusive).

buf_clear_namespace  is used by

- coc#highlight#update_highlights
- coc#highlight#clear_highlight

Both seems to accept end-exclusive ranges.