### PR TITLE
fix(highlight.vim): use default value for compose_hlgroup

### DIFF
--- a/autoload/coc/highlight.vim
+++ b/autoload/coc/highlight.vim
@@ -364,6 +364,9 @@ function! coc#highlight#compose_hlgroup(fgGroup, bgGroup) abort
   elseif underline
     let cmd .= ' cterm=underline gui=underline'
   endif
+  if cmd ==# 'silent hi ' . hlGroup
+      return 'Normal'
+  endif
   execute cmd
   return hlGroup
 endfunction


### PR DESCRIPTION
If two hightlight groups both are empty or single reverse attribute,
`coc#highlight#compose_hlgroup` can't build new highlight group.

Such as:
```vim
hi Group1 gui=reverse
hi clear Group2
echo coc#highlight#compose_hlgroup('Group1', 'Group2')
```
will throw E411: highlight group not found: FgGroup1BgGroup2