### PR TITLE
fix(completion): keep floatwin from redrawing

### DIFF
--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -69,12 +69,7 @@ export class Completion implements Disposable {
     events.on('TextChangedP', this.onTextChangedP, this, this.disposables)
     events.on('TextChangedI', this.onTextChangedI, this, this.disposables)
     let fn = debounce(this.onPumChange.bind(this), 20)
-    this.closeFloat = debounce(async () => {
-      let visible = await this.nvim.call('pumvisible', []) as number
-      if (visible == 0) {
-        this.floating.close()
-      }
-    }, 200)
+    this.closeFloat = debounce(this.stop, 200)
     this.disposables.push({
       dispose: () => {
         fn.clear()


### PR DESCRIPTION
Look like `this.floating.close()` be added after https://github.com/neoclide/coc.nvim/issues/1940. However, I can't reproduce the issue.  Let's use debounce to do defensive programming.

Every call `complete()` will fire `CompleteDone` event.
The fired function will close the floating window at once and create a new one for the suggestion.

Solution: use debounce to close the floating window.

