### PR TITLE
Add recommendation for code lens keybinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ nmap <leader>ac  <Plug>(coc-codeaction)
 " Apply AutoFix to problem on the current line.
 nmap <leader>qf  <Plug>(coc-fix-current)
 
+" Run the Code Lens action on the current line.
+nmap <leader>cl  <Plug>(coc-codelens-action)
+
 " Map function and class text objects
 " NOTE: Requires 'textDocument.documentSymbol' support from the language server.
 xmap if <Plug>(coc-funcobj-i)


### PR DESCRIPTION
add <leader>cl for running code lens actions.

I found it very difficult to find any information on using code lens with coc. This piece of information I got from gitter, and would be nice to be in the documentation somewhere.