### PR TITLE
Feat(rename.ts): Tweak To Refactor-Rename Floating Window

### DIFF
--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -916,6 +916,12 @@ Built-in configurations:~
 
 	Note: this configuration is expected to change in the future.
 
+"coc.preferences.fillRename"~
+
+	Disable to stop Refactor-Rename float/popup window from populating
+	with old name in the New Name field.
+	Default: `true`
+
 						*coc-config-cursors*
 
 "cursors.cancelKey":~

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -916,7 +916,7 @@ Built-in configurations:~
 
 	Note: this configuration is expected to change in the future.
 
-"coc.preferences.fillRename"~
+"coc.preferences.renameFillCurrent"~
 
 	Disable to stop Refactor-Rename float/popup window from populating
 	with old name in the New Name field.

--- a/src/handler/rename.ts
+++ b/src/handler/rename.ts
@@ -56,7 +56,7 @@ export default class Rename {
         curname = await this.nvim.eval('expand("<cword>")') as string
       }
       const config = workspace.getConfiguration('coc.preferences')
-      if (config.get<boolean>('fillRename', true)) {
+      if (config.get<boolean>('renameFillCurrent', true)) {
         newName = await window.requestInput('New name', curname)
       } else {
         newName = await window.requestInput('New name')

--- a/src/handler/rename.ts
+++ b/src/handler/rename.ts
@@ -55,7 +55,12 @@ export default class Rename {
       } else {
         curname = await this.nvim.eval('expand("<cword>")') as string
       }
-      newName = await window.requestInput('New name', curname)
+      const config = workspace.getConfiguration('coc.preferences')
+      if (config.get<boolean>('fillRename', true)) {
+        newName = await window.requestInput('New name', curname)
+      } else {
+        newName = await window.requestInput('New name')
+      }
     }
     if (!newName) return false
     let edit = await languages.provideRenameEdits(doc.textDocument, position, newName, token)


### PR DESCRIPTION
Hi there all! 

I thought I'd share a small tweak that I've enjoyed having implemented in my own setup for coc.
When renaming, I find it more "natural" for typing to have the user input window display without the previous name. This removes the need to hold delete to remove the old name, before entering a new one.
I decided to add a conditional statement to check for a new config key,`coc.preferences.fillRename`, to decide whether to pass a default value to `window.requestInput()`. 
Default is true, which keeps the functionality the same as currently. False means the floating window is empty and the user can immediately enter a new name!
Would love to hear what you think, and sorry in advanced if anything isn't setup correctly, this is my first official PR for a project!

Many thanks:)