### PR TITLE
fix(document): document did changed event could be lost

### DIFF
--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -451,12 +451,11 @@ export default class Document {
     if (o) {
       this._changedtick = o.changedtick
       this.lines = o.lines
-      if (sync) {
-        this._forceSync()
-      } else {
-        this.fireContentChanges()
-      }
+      this.fireContentChanges()
     }
+    // we must force sync even when o == null because fireContentChanges could
+    // have been scheduled
+    if (sync) this._forceSync()
   }
 
   /**


### PR DESCRIPTION
If we config coc to format typescript file with prettier on save

```ts
let x = 1
```

type `o<esc>ix<esc>:w<cr>` quickly

-> the last line got deleted.