### PR TITLE
refactor(completion): latestInsertChar alwayes to be true

### DIFF
--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -356,10 +356,7 @@ export class Completion implements Disposable {
       return
     }
     // Check commit character
-    if (pretext
-      && this.selectedItem
-      && this.config.acceptSuggestionOnCommitCharacter
-      && latestInsertChar) {
+    if (pretext && this.selectedItem && this.config.acceptSuggestionOnCommitCharacter) {
       let resolvedItem = this.getCompleteItem(this.selectedItem)
       let last = pretext[pretext.length - 1]
       if (sources.shouldCommit(resolvedItem, last)) {


### PR DESCRIPTION
https://github.com/neoclide/coc.nvim/blob/77fb25aa6bd48061f78b91b99c10981843c9949a/src/completion/index.ts#L354-L357

Remove `latestInsertChar` checking.