### PR TITLE
fix(schema.json): Added schema for coc.preference.renameFillCurrent

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -1368,6 +1368,11 @@
       "maximum": 5000,
       "description": "Will save handler timeout"
     },
+    "coc.preferences.renameFillCurrent": {
+      "type": "boolean",
+      "default": true,
+      "description": "Disable to stop Refactor-Rename float/popup window from populating with old name in the New Name field."
+    },
     "coc.source.around.enable": {
       "type": "boolean",
       "default": true


### PR DESCRIPTION
I tweaked the functionality to the rename feature in this PR (#3528).
It relies on the coc.preferences.renameFillCurrent setting in coc-preferences.json.
I missed adding this new key to `schema.json` so LSP support wasn't
working while editing `coc-preferences.json`. Hopefully this fixes that.
Thanks