### PR TITLE
chore: Correcting verbiage of install message

### DIFF
--- a/src/model/installBuffer.ts
+++ b/src/model/installBuffer.ts
@@ -105,7 +105,7 @@ export default class InstallBuffer extends EventEmitter implements Disposable {
   // draw frame
   private draw(nvim: Neovim, buffer: Buffer): void {
     let { remains } = this
-    let first = remains == 0 ? `${this.isUpdate ? 'Update' : 'Install'} finished` : `Installing, ${remains} remains...`
+    let first = remains == 0 ? `${this.isUpdate ? 'Update' : 'Install'} finished` : `Installing, ${remains} remaining...`
     let lines = [first, '', ...this.getLines()]
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     buffer.setLines(lines, { start: 0, end: -1, strictIndexing: false }, true)


### PR DESCRIPTION
"remains" isn't the correct form of the word.

I elected to only change the form of the word in the message, rather than also correct the method and variable declaration. I'm not super familiar with what pieces might be a public API, and correcting them would serve no functional purpose.

Let me know if you want these updated and are safe to do so.