### PR TITLE
fix(sources): extend file sources regex

### DIFF
--- a/src/sources/native/file.ts
+++ b/src/sources/native/file.ts
@@ -10,7 +10,7 @@ import { byteSlice } from '../../util/string'
 import { isWindows } from '../../util/platform'
 import workspace from '../../workspace'
 const logger = require('../../util/logger')('sources-file')
-const pathRe = /(?:\.{0,2}|~|\$HOME|([\w]+)|[a-zA-Z]:|)(\/|\\)(?:[\u4e00-\u9fa5\w.@()-]+(\/|\\))*(?:[\u4e00-\u9fa5\w.@()-])*$/
+const pathRe = /(?:\.{0,2}|~|\$HOME|([\w]+)|[a-zA-Z]:|)(\/|\\)(?:[\u4E00-\u9FA5\u00A0-\u024F\w.@()-]+(\/|\\))*(?:[\u4E00-\u9FA5\u00A0-\u024F\w.@()-])*$/
 
 interface PathOption {
   pathstr: string


### PR DESCRIPTION
1. `\u4E00-\u9FA5` for Chinese
2. `\u00A0-\u024F` for Latin-1 and Latin Extended-A/B https://en.wikipedia.org/wiki/List_of_Unicode_characters#Latin-1_Supplement
3.` \w` for word character

closes #3539