### PR TITLE
perf(semanticTokensHighlights): disable onDidSemanticTokensRefresh

### DIFF
--- a/src/handler/semanticTokensHighlights/index.ts
+++ b/src/handler/semanticTokensHighlights/index.ts
@@ -65,14 +65,14 @@ export default class SemanticTokensHighlights {
     this.highlighters = workspace.registerBufferSync(doc => {
       return new SemanticTokensBuffer(this.nvim, doc.bufnr, this.config)
     })
-    languages.onDidSemanticTokensRefresh(selector => {
-      for (let item of this.highlighters.items) {
-        let doc = workspace.getDocument(item.bufnr)
-        if (doc && workspace.match(selector, doc.textDocument)) {
-          item.highlight()
-        }
-      }
-    }, null, this.disposables)
+    // languages.onDidSemanticTokensRefresh(selector => {
+    //   for (let item of this.highlighters.items) {
+    //     let doc = workspace.getDocument(item.bufnr)
+    //     if (doc && workspace.match(selector, doc.textDocument)) {
+    //       item.highlight()
+    //     }
+    //   }
+    // }, null, this.disposables)
     let fn = debounce(bufnr => {
       let item = this.highlighters.getItem(bufnr)
       if (!item || !item.enabled || !item.rangeProviderOnly) return


### PR DESCRIPTION
The server like clangd will fire onDidSemanticTokensRefresh, but
SemanticTokensRefresh only provide selector instead of document, if we
request semanticTokens concurrently, we will encounter performance
issue.

On the server side:
Multiple semanticTokens request would make completion request lagging.

On the client side(coc.nvim):
After getting the semanticTokens results without cancellation, converting
token to highlights eating nodejs resources and diffHighlight may fail
and then make Neovim 100% cpu usage.

Look like we have enough events to request semanticTokens, no need to
enable onDidSemanticTokensRefresh.