### PR TITLE
perf(semanticTokens): avoid parsing all returned data

### DIFF
--- a/autoload/coc/window.vim
+++ b/autoload/coc/window.vim
@@ -85,3 +85,18 @@ function! coc#window#visible_range(bufnr) abort
   let info = getwininfo(winid)[0]
   return [info['topline'], info['botline']]
 endfunction
+
+" 0-based, [start, end] start: inclusive, end: exclusive
+" 3 times window's height to be rendered if possible
+function! coc#window#render_range(bufnr) abort
+  let bufinfos = getbufinfo(a:bufnr)
+  if empty(bufinfos)
+    return v:null
+  endif
+  let bufinfo = bufinfos[0]
+  let winid = bufwinid(a:bufnr)
+  let height = winid == -1 ? (&lines - &cmdheight) : winheight(winid)
+  let delta = float2nr(ceil(height * 3 / 2))
+  let lnum = bufinfo.lnum
+  return [max([0, lnum - 1 - delta]), min([lnum + delta, bufinfo.linecount])]
+endfunction

--- a/src/__tests__/modules/window.test.ts
+++ b/src/__tests__/modules/window.test.ts
@@ -428,7 +428,7 @@ describe('diffHighlights', () => {
   })
 
   async function createFile(): Promise<Buffer> {
-    let content = 'foo\nbar'
+    let content = 'foo\nbar\nbaz'
     let file = await createTmpFile(content)
     return await helper.edit(file)
   }
@@ -454,6 +454,39 @@ describe('diffHighlights', () => {
     let markers = await buf.getExtMarks(ns_id, 0, -1, { details: true })
     expect(markers.length).toBe(1)
     expect(markers[0][3].end_col).toBe(3)
+  })
+
+  it('should diff highlights through range', async () => {
+    let buf = await createFile()
+    let items: HighlightItem[] = [{
+      hlGroup: 'Search',
+      lnum: 0,
+      colStart: 0,
+      colEnd: 3
+    }, {
+      hlGroup: 'Search',
+      lnum: 1,
+      colStart: 0,
+      colEnd: 3
+    }, {
+      hlGroup: 'Search',
+      lnum: 2,
+      colStart: 0,
+      colEnd: 3
+    }]
+    await setHighlights(items)
+    items = [{
+      hlGroup: 'Search',
+      lnum: 0,
+      colStart: 0,
+      colEnd: 3
+    }]
+    let res = await window.diffHighlights(buf.id, ns, items, 0, 2)
+    expect(res).toBeDefined()
+    expect(res.removeMarkers.length).toBe(1)
+    res = await window.diffHighlights(buf.id, ns, items, 0, -1)
+    expect(res).toBeDefined()
+    expect(res.removeMarkers.length).toBe(2)
   })
 
   it('should return empty diff', async () => {

--- a/src/handler/semanticTokensHighlights/buffer.ts
+++ b/src/handler/semanticTokensHighlights/buffer.ts
@@ -353,17 +353,11 @@ export default class SemanticTokensBuffer implements SyncItem {
       items = await this.requestAllHighlights(startLine, endLine, tokenSource.token, forceFull)
     }
     // request cancelled or can't work
-    if (!items || tokenSource.token.isCancellationRequested || this.invalid) {
-      this.tokenSource = null
-      return
-    }
+    if (!items || tokenSource.token.isCancellationRequested || this.invalid) return
     let diff = await window.diffHighlights(this.bufnr, NAMESPACE, items, startLine, endLine)
-    if (tokenSource.token.isCancellationRequested || !diff || this.invalid) {
-      this.tokenSource = null
-      return
-    }
-    await window.applyDiffHighlights(this.bufnr, NAMESPACE, priority, diff)
     this.tokenSource = null
+    if (tokenSource.token.isCancellationRequested || !diff || this.invalid) return
+    await window.applyDiffHighlights(this.bufnr, NAMESPACE, priority, diff)
   }
 
   /**

--- a/src/handler/semanticTokensHighlights/buffer.ts
+++ b/src/handler/semanticTokensHighlights/buffer.ts
@@ -141,19 +141,17 @@ export default class SemanticTokensBuffer implements SyncItem {
    */
   public get highlights(): ReadonlyArray<SemanticTokenRange> {
     let pending: SemanticTokenRange[] = []
-    this._pendingHighlights.forEach(absHighlights => {
-      absHighlights.forEach(absHighlight => {
-        let { lnum, startCharacter, endCharacter, tokenType, tokenModifiers } = absHighlight
+    this._pendingHighlights.forEach(absTokens => {
+      absTokens.forEach(absToken => {
+        let { lnum, startCharacter, endCharacter, tokenType, tokenModifiers } = absToken
         let [highlightGroup] = this.getHighlightGroup(tokenType, tokenModifiers)
-        if (highlightGroup) {
-          let range = Range.create(lnum, startCharacter, lnum, endCharacter)
-          pending.push({
-            range,
-            tokenType,
-            hlGroup: highlightGroup,
-            tokenModifiers,
-          })
-        }
+        let range = Range.create(lnum, startCharacter, lnum, endCharacter)
+        pending.push({
+          range,
+          tokenType,
+          hlGroup: highlightGroup,
+          tokenModifiers,
+        })
       })
     })
     return pending.length > 0 ? [...this._highlights, ...pending] : this._highlights

--- a/src/handler/semanticTokensHighlights/buffer.ts
+++ b/src/handler/semanticTokensHighlights/buffer.ts
@@ -294,12 +294,8 @@ export default class SemanticTokensBuffer implements SyncItem {
     let end: number | undefined
     for (let i = startLine - 1; i < endLine; i++) {
       let arr = this._pendingHighlights.get(i)
-      if (!this._pendingHighlights.delete(i) || arr.length == 0) {
-        continue
-      }
-      if (!start) {
-        start = i
-      }
+      if (!this._pendingHighlights.delete(i) || arr.length == 0) continue
+      if (!start) start = i
       for (const o of arr) {
         let { lnum, startCharacter, endCharacter, tokenType, tokenModifiers } = o
         let range = Range.create(lnum, startCharacter, lnum, endCharacter)
@@ -309,7 +305,7 @@ export default class SemanticTokensBuffer implements SyncItem {
     }
     if (items.length > 0) {
       let priority = this.config.highlightPriority
-      await this.nvim.call('coc#highlight#update_highlights', [this.bufnr, NAMESPACE, items, start, end, priority])
+      await this.nvim.call('coc#highlight#update_highlights', [this.bufnr, NAMESPACE, items, start, end + 1, priority])
     }
   }
 

--- a/src/handler/semanticTokensHighlights/buffer.ts
+++ b/src/handler/semanticTokensHighlights/buffer.ts
@@ -353,7 +353,12 @@ export default class SemanticTokensBuffer implements SyncItem {
       items = await this.requestAllHighlights(startLine, endLine, tokenSource.token, forceFull)
     }
     // request cancelled or can't work
-    if (!items || tokenSource.token.isCancellationRequested || this.invalid) return
+    // shouldRangeHighlight need check this.tokenSource
+    if (!items || tokenSource.token.isCancellationRequested || this.invalid) {
+      tokenSource.cancel()
+      this.tokenSource = null
+      return
+    }
     let diff = await window.diffHighlights(this.bufnr, NAMESPACE, items, startLine, endLine)
     this.tokenSource = null
     if (tokenSource.token.isCancellationRequested || !diff || this.invalid) return

--- a/src/handler/semanticTokensHighlights/index.ts
+++ b/src/handler/semanticTokensHighlights/index.ts
@@ -97,11 +97,18 @@ export default class SemanticTokensHighlights {
       let item = this.highlighters.getItem(bufnr)
       if (!item || !item.shouldRangeHighlight) return
       await item.doRangeHighlight()
-    }, global.hasOwnProperty('__TEST__') ? 10 : 300)
+    }, global.hasOwnProperty('__TEST__') ? 15 : 300)
     events.on('CursorMoved', fn, null, this.disposables)
+    let fn1 = debounce(async bufnr => {
+      let item = this.highlighters.getItem(bufnr)
+      if (!item) return
+      await item.doPendingHighlight()
+    }, global.hasOwnProperty('__TEST__') ? 10 : 100)
+    events.on('CursorMoved', fn1, null, this.disposables)
     this.disposables.push({
       dispose: () => {
         fn.clear()
+        fn1.clear()
       }
     })
   }

--- a/src/window.ts
+++ b/src/window.ts
@@ -545,10 +545,12 @@ class Window {
    * @param {number} bufnr Buffer number
    * @param {string} ns Highlight namespace
    * @param {HighlightItem[]} items Highlight items
+   * @param {start} start start range of the current items, default 0, inclusive.
+   * @param {end} end end range of the current items, default -1, exclusive.
    * @returns {Promise<HighlightDiff | null>}
    */
-  public async diffHighlights(bufnr: number, ns: string, items: HighlightItem[]): Promise<HighlightDiff | null> {
-    let curr = await this.nvim.call('coc#highlight#get_highlights', [bufnr, ns]) as HighlightItemResult[]
+  public async diffHighlights(bufnr: number, ns: string, items: HighlightItem[], start = 0, end = -1): Promise<HighlightDiff | null> {
+    let curr = await this.nvim.call('coc#highlight#get_highlights', [bufnr, ns, start, end]) as HighlightItemResult[]
     if (!curr) return null
     items.sort((a, b) => a.lnum - b.lnum)
     let linesToRmove = []

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -7350,9 +7350,11 @@ declare module 'coc.nvim' {
      * @param {number} bufnr Buffer number
      * @param {string} ns Highlight namespace
      * @param {HighlightItem[]} items Highlight items
+     * @param {start} start start range of the current items, default 0, inclusive.
+     * @param {end} end end range of the current items, default -1, exclusive.
      * @returns {Promise<HighlightDiff>}
      */
-    export function diffHighlights(bufnr: number, ns: string, items: ExtendedHighlightItem[]): Promise<HighlightDiff | null>
+    export function diffHighlights(bufnr: number, ns: string, items: ExtendedHighlightItem[], start?: number, end?: number): Promise<HighlightDiff | null>
 
     /**
      * Apply highlight diffs, normally used with `window.diffHighlights`


### PR DESCRIPTION
There're several performance bottlenecks for the semantic token in all projects/files on client side:

Just take Neovim as an example, Vim is similar.

The data returned by the server will be all parsed and asked for total extmarks from Neovim.
If the data is large:
1. coc.nvim will be lagging to handle other services asked from Neovim;
2. Neovim must fetch all extmarks which may be blocking a few hundred milliseconds;
3. Neovim must encode the data also may be blocking;

Solution From this PR:
1. Only parse the relative semantic tokens format to the absolute format.
   This phase is a very small cost for coc.nvim;
2. Centered on the cursor, only render 3 times window height range from the absolute format
   pending semantic tokens, Neovim can understand the line number. 1 window
   height range is not enough, users who move up and down can feel the
   redraw frequently. Scroll the half-page down (`<C-d>`) on the topline
   will span 1.5 times window height range, scroll the half-page up is similar.
   In other words, to achieve less redraw must render 3 times window height
   if users press `<C-d>` or `<C-u>`;
3. Only diff 3 times window height range between semantic token and extmarks;