### PR TITLE
fix(snippets): revert 429826a377dc2d98a19b5f36a75459345b4bcfd4

### DIFF
--- a/src/snippets/session.ts
+++ b/src/snippets/session.ts
@@ -262,6 +262,9 @@ export class SnippetSession {
     if (move_cmd) {
       nvim.call('eval', [`feedkeys("${move_cmd}", 'in')`], true)
     }
+    if (mode == 'i') {
+      nvim.call('coc#_cancel', [], true)
+    }
     nvim.setOption('virtualedit', ve, true)
     if (isFinalTabstop) {
       if (this.snippet.finalCount == 1) {


### PR DESCRIPTION
When popup menu is display, last jump can't hide the popup menu.