### PR TITLE
fix(highlight): enable right_gravity for extmark

### DIFF
--- a/autoload/coc/highlight.vim
+++ b/autoload/coc/highlight.vim
@@ -353,7 +353,7 @@ function! coc#highlight#add_highlight(bufnr, src_id, hl_group, line, col_start, 
               \ 'end_col': a:col_end,
               \ 'hl_group': a:hl_group,
               \ 'hl_mode': get(opts, 'combine', 1) ? 'combine' : 'replace',
-              \ 'right_gravity': v:false,
+              \ 'right_gravity': v:true,
               \ 'end_right_gravity': v:false,
               \ 'priority': type(priority) == 0 ?  min([priority, 4096]) : 4096,
               \ })


### PR DESCRIPTION
If `right_gravity` = false, inserting new line above `[row, 0, row, end_col]` extmark will
extend unexpected range which become [row - 1, 0, row, end_col],
and delta will be great than 0.

Press `[v:count]O` under one extmark that range is `[row, 0, row, end_col]` can easy to reproduce the issue.