### PR TITLE
fix: contentProvider uri

### DIFF
--- a/src/core/autocmds.ts
+++ b/src/core/autocmds.ts
@@ -63,7 +63,7 @@ export default class Autocmds implements Disposable {
     let schemes = this.contentProvider.schemes
     let cmds: string[] = []
     for (let scheme of schemes) {
-      cmds.push(`autocmd BufReadCmd,FileReadCmd,SourceCmd ${scheme}:/* call coc#rpc#request('CocAutocmd', ['BufReadCmd','${scheme}', expand('<amatch>')])`)
+      cmds.push(`autocmd BufReadCmd,FileReadCmd,SourceCmd ${scheme}:/* call coc#rpc#request('CocAutocmd', ['BufReadCmd','${scheme}', expand('<afile>')])`)
     }
     for (let [id, autocmd] of this.autocmds.entries()) {
       let args = autocmd.arglist && autocmd.arglist.length ? ', ' + autocmd.arglist.join(', ') : ''


### PR DESCRIPTION
Fixed kotlin-language-server content provider uri.

kls jar uri is `kls:file:///path/to/jarFile.jar!/path/to/jvmClass.class`.

reference 
- lsp: https://github.com/fwcd/kotlin-language-server/blob/main/server/src/main/kotlin/org/javacs/kt/externalsources/KlsURI.kt#L26
- coc-kotlin: https://github.com/weirongxu/coc-kotlin/blob/master/src/languageSetup.ts#L109

When using `<amatch>`, resolved uri is `/home/user/repos/project/kls:file:///path/to/jarFile.jar!/path/to/jvmClass.class`  
When using `<afile>`, it can solve both `coc-java` and `coc-kotlin` problem.