### PR TITLE
feat(esbuild): add commit date to CocInfo

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -3,8 +3,8 @@ const fs = require('fs')
 const path = require('path')
 let revision = ''
 try {
-  let res = cp.execSync('git rev-parse HEAD', {encoding: 'utf8'})
-  revision = res.trim().slice(0, 10)
+  let res = cp.execSync(`git log -1 --date=iso --pretty=format:'"%h","%ad"'`, {encoding: 'utf8'})
+  revision = res.replaceAll('"', '').replace(',', ' ')
 } catch (e) {
   // ignore
 }


### PR DESCRIPTION
old: `coc.nvim version: 0.0.80-ccd0b050`
new: `coc.nvim version: 0.0.80-ccd0b050 2022-03-08 15:06:47 +0800`

Easy way to let users to know they're using an old version.