### PR TITLE
fix(TreeView): silent exe

### DIFF
--- a/src/tree/TreeView.ts
+++ b/src/tree/TreeView.ts
@@ -604,7 +604,7 @@ export default class BasicTreeView<T> implements TreeView<T> {
     if (!this.opts.canSelectMany || forceSingle) {
       buf.unplaceSign({ group: 'CocTree' })
     }
-    let cmd = `exe ${row + 1}'|normal! zz'`
+    let cmd = `silent exe ${row + 1}'|normal! zz'`
     nvim.call('coc#compat#execute', [this.winid, cmd], true)
     buf.placeSign({ id: signOffset + row, lnum: row + 1, name: 'CocTreeSelected', group: 'CocTree' })
     if (!noRedraw) this.redraw()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/47070852/157418028-547c97fb-3361-4978-9c20-598b8140dbdf.png)
Always output the content of the selected node before