### PR TITLE
fix(semanticTokens): don't abandon highlight for region buffer

### DIFF
--- a/src/handler/semanticTokens/buffer.ts
+++ b/src/handler/semanticTokens/buffer.ts
@@ -449,7 +449,9 @@ export default class SemanticTokensBuffer implements SyncItem {
 
   public abandonResult(): void {
     this.previousResults = undefined
-    this._highlights = undefined
+    if (!this.regions) {
+      this._highlights = undefined
+    }
   }
 
   public cancel(rangeOnly = false): void {


### PR DESCRIPTION
For now, onDidSemanticTokensRefresh will abandon highlight for buffers
which highlighted by region.