### PR TITLE
fix(sources): respect ignoreGitignore for buffer

### DIFF
--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -38,7 +38,6 @@ export interface ChangeInfo {
 // getText, positionAt, offsetAt
 export default class Document {
   public buftype: string
-  public isIgnored = false
   public chars: Chars
   private eol = true
   private _disposed = false

--- a/src/sources/native/buffer.ts
+++ b/src/sources/native/buffer.ts
@@ -2,6 +2,8 @@ import { Disposable } from 'vscode-languageserver-protocol'
 import Source from '../source'
 import { CompleteOption, CompleteResult, ISource } from '../../types'
 import workspace from '../../workspace'
+import { isGitIgnored } from '../../util/fs'
+import { URI } from 'vscode-uri'
 const logger = require('../../util/logger')('sources-buffer')
 
 export default class Buffer extends Source {
@@ -13,6 +15,7 @@ export default class Buffer extends Source {
   }
 
   public get ignoreGitignore(): boolean {
+    if (global.__TEST__) return false
     return this.getConfig('ignoreGitignore', true)
   }
 
@@ -21,7 +24,7 @@ export default class Buffer extends Source {
     let words: string[] = []
     workspace.documents.forEach(document => {
       if (document.bufnr == bufnr) return
-      if (ignoreGitignore && document.isIgnored) return
+      if (ignoreGitignore && isGitIgnored(URI.parse(document.uri).fsPath)) return
       for (let word of document.words) {
         if (!words.includes(word)) {
           words.push(word)


### PR DESCRIPTION
I came this issue when opening x.log in another buffer, words from x.log were provided by buffer source .

The *.log files should be ignored, I found this was removed in  abb0232824e1e66f5884afff9c074279bc1b19f1, `document.isIgnored` is always false now. Should we add this back? @chemzqm 