### PR TITLE
feat: add "ignoreRegexps" for built-in sources

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -1600,6 +1600,22 @@
         "type": "string"
       }
     },
+    "coc.source.around.ignoreRegexps": {
+      "type": "array",
+      "default": [],
+      "description": "Ignore around completion matched by regexps",
+      "items": {
+        "type": "string"
+      }
+    },
+    "coc.source.buffer.ignoreRegexps": {
+      "type": "array",
+      "default": [],
+      "description": "Ignore buffer completion matched by regexps",
+      "items": {
+        "type": "string"
+      }
+    },
     "languageserver": {
       "type": "object",
       "default": {},

--- a/src/sources/native/around.ts
+++ b/src/sources/native/around.ts
@@ -29,6 +29,9 @@ export default class Around extends Source {
     let needle = fuzzy ? getCharCodes(input) : []
     let checkInput = true
     let checkCword = true
+    let ignoreRegexps = this.getConfig('ignoreRegexps', []).map(p => {
+        return new RegExp(p)
+    })
     for (let word of words) {
       let len = word.length
       if (len < min) continue
@@ -47,7 +50,12 @@ export default class Around extends Source {
         if (ch === first) res.push(word)
       }
     }
-    return res
+    return res.filter(f => {
+        for (let p of ignoreRegexps) {
+            if (p.test(f)) return false
+        }
+        return true
+    })
   }
 
   public async doComplete(opt: CompleteOption): Promise<CompleteResult> {

--- a/src/sources/native/buffer.ts
+++ b/src/sources/native/buffer.ts
@@ -30,6 +30,9 @@ export default class Buffer extends Source {
     let ignoreCase = code >= 97 && code <= 122
     let needle = fuzzy ? getCharCodes(opt.input) : []
     let ts = Date.now()
+    let ignoreRegexps = this.getConfig('ignoreRegexps', []).map(p => {
+        return new RegExp(p)
+    })
     for (let item of this.keywords.items) {
       if (item.bufnr === bufnr) continue
       if (ignoreGitignore && item.gitIgnored) continue
@@ -48,7 +51,12 @@ export default class Buffer extends Source {
         }
       }
     }
-    return Array.from(words)
+    return Array.from(words).filter(f => {
+        for (let p of ignoreRegexps) {
+            if (p.test(f)) return false
+        }
+        return true
+    })
   }
 
   public async doComplete(opt: CompleteOption, token: CancellationToken): Promise<CompleteResult> {


### PR DESCRIPTION
Added a simple way to ignore suggestions for `around` and `buffer` sources. I did not find tests for a similar `ignorePatterns` feature for the `file` source, so I assumed they were not necessary. An example use case would be to ignore number suggestions with `"^[0-9]*$"` for writing code with a lot of random numbers like tests.