### PR TITLE
fix(textedit): merge overlap textedits

### DIFF
--- a/src/__tests__/modules/document.test.ts
+++ b/src/__tests__/modules/document.test.ts
@@ -276,20 +276,20 @@ describe('Document', () => {
 
     it('should apply merged edits', async () => {
       let doc = await workspace.document
-      await nvim.setLine('foo')
+      await nvim.setLine("import {A } from './a'")
       await doc.patchChange()
       let edits: TextEdit[] = []
       edits.push({
-        range: Range.create(0, 0, 0, 3),
+        range: Range.create(0, 0, 1, 0),
         newText: ''
       })
       edits.push({
-        range: Range.create(0, 0, 0, 0),
-        newText: 'bar'
+        range: Range.create(0, 22, 0, 22),
+        newText: "\nimport { A } from './a'"
       })
       await doc.applyEdits(edits)
       let line = await nvim.line
-      expect(line).toBe('bar')
+      expect(line).toBe("import { A } from './a'")
     })
 
     it('should move cursor', async () => {

--- a/src/util/textedit.ts
+++ b/src/util/textedit.ts
@@ -140,7 +140,7 @@ export function applyEdits(document: LinesTextDocument, edits: TextEdit[]): stri
     return [...lines.slice(0, start.line), ...content.split('\n'), ...lines.slice(end.line + 1)]
   }
   let text = document.getText()
-  let lastModifiedOffset = 0
+  let lastModifiedOffset = -1
   const spans = []
   for (const e of edits) {
     let startOffset = document.offsetAt(e.range.start)
@@ -148,12 +148,12 @@ export function applyEdits(document: LinesTextDocument, edits: TextEdit[]): stri
       throw new Error('Overlapping edit')
     }
     else if (startOffset > lastModifiedOffset) {
-      spans.push(text.substring(lastModifiedOffset, startOffset))
+      spans.push(text.substring(lastModifiedOffset + 1, startOffset))
     }
     if (e.newText.length) {
       spans.push(e.newText)
     }
-    lastModifiedOffset = document.offsetAt(e.range.end)
+    lastModifiedOffset = document.offsetAt(e.range.end) - 1
   }
   spans.push(text.substring(lastModifiedOffset))
   let result = spans.join('')


### PR DESCRIPTION
Fixes #3742

#3742 still occurs after d13d38c0f34e9032d536acbe5d0c1a8fa8bbd4f8, I think this PR would fix it.

I also update test to use real response from lsp server.