### PR TITLE
fix(sources): getTriggerSources for some matched

### DIFF
--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -337,8 +337,8 @@ export class Sources {
       if (!enable || (filetypes && !intersect(filetypes, languageIds))) {
         return false
       }
-      if (documentSelector && languageIds.every(languageId => workspace.match(documentSelector, { uri, languageId }) == 0)) {
-        return false
+      if (documentSelector && languageIds.some(languageId => workspace.match(documentSelector, { uri, languageId }))) {
+        return true
       }
       return this.checkTrigger(source, pre, character)
     })


### PR DESCRIPTION
The error: 

coc-git and coc-mocword both registered completionProvider for `gitcommit`. The different: `coc-mocword` also registered `triggerCharacters` but `coc-git` not.

When in `gitcommit`, input `f`, coc will try `getTriggerSources`, without the patch, there's only `coc-mocword` returns, coc will use it to trigger completion, with this patch, both are valid sources.

I think it's OK to make the source valid/work if some filetype matches.