### PR TITLE
feat(list): expose listItems for extensions

### DIFF
--- a/src/list/manager.ts
+++ b/src/list/manager.ts
@@ -22,6 +22,7 @@ import OutlineList from './source/outline'
 import ServicesList from './source/services'
 import SourcesList from './source/sources'
 import SymbolsList from './source/symbols'
+import commands from '../commands'
 const logger = require('../util/logger')('list-manager')
 
 const mouseKeys = ['<LeftMouse>', '<LeftDrag>', '<LeftRelease>', '<2-LeftMouse>']
@@ -69,6 +70,9 @@ export class ListManager implements Disposable {
         debounced.clear()
       }
     })
+    this.disposables.push(commands.registerCommand('list.loadItems', async (name: string) => {
+      return await this.loadItems(name)
+    }, null, true))
     // filter history on input
     this.prompt.onDidChangeInput(() => {
       let { session } = this


### PR DESCRIPTION
Every extension can register a source for list, but other extensions
must call `CocAction('listLoadItems', name)` to get the list items by
name. However, some sources like `symbols` may return a ton of data.
For a extension to get data, Neo/Vim and nodeJS must encode & decode
for the data which is very inefficient.

Solution:
We can expose a internal command for the extension, which is
efficient and more friendly to pure Typescript.