### PR TITLE
chore(README): fix show_documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ function! s:show_documentation()
   elseif (coc#rpc#ready())
     call CocActionAsync('doHover')
   else
-    execute '!' . &keywordprg . " " . expand('<cword>')
+    execute &keywordprg . " " . expand('<cword>')
   endif
 endfunction
 


### PR DESCRIPTION
&keywordprg expands to `:Man`.  
If prepended by `!`, causes:  
`bash: line 1: :Man: command not found`