### PR TITLE
feat(menu): add more mappings to confirm selection

### DIFF
--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -3696,7 +3696,7 @@ dialog.
 Supported key-mappings:
 
 <Esc> <C-c>          - cancel selection.
-<cr>                 - confirm selection of current item.
+<cr> o <C-o> <C-y>   - confirm selection of current item.
 1-9                  - select item with 1 based index.
 g                    - move to first item.
 G                    - move to last item.

--- a/src/model/menu.ts
+++ b/src/model/menu.ts
@@ -71,7 +71,7 @@ export default class Menu {
       this._onDidClose.fire(-1)
       this.dispose()
     })
-    this.addKeys(['\r', '<cr>'], () => {
+    this.addKeys(['\r', '<cr>', 'o', '<C-o>', '<C-y>'], () => {
       this.selectCurrent()
     })
     let setCursorIndex = idx => {


### PR DESCRIPTION
`o` `<C-y>` `<C-o>` are convenient