### PR TITLE
feat(language-client): InlayHintsFeature

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "eslint-plugin-jsdoc": "^39.2.8",
     "jest": "27.4.5",
     "typescript": "^4.6.3",
-    "vscode-languageserver": "7.0.0"
+    "vscode-languageserver": "^8.0.1"
   },
   "dependencies": {
     "@chemzqm/neovim": "^5.7.9",
@@ -114,11 +114,11 @@
     "unidecode": "^0.1.8",
     "unzip-stream": "^0.3.1",
     "uuid": "^7.0.3",
-    "vscode-jsonrpc": "^6.0.0",
-    "vscode-languageserver-protocol": "^3.16.0",
-    "vscode-languageserver-textdocument": "^1.0.3",
-    "vscode-languageserver-types": "^3.16.0",
-    "vscode-uri": "^2.1.2",
+    "vscode-jsonrpc": "^8.0.1",
+    "vscode-languageserver-protocol": "^3.17.1",
+    "vscode-languageserver-textdocument": "^1.0.4",
+    "vscode-languageserver-types": "^3.17.1",
+    "vscode-uri": "^3.0.3",
     "which": "^2.0.2"
   }
 }

--- a/src/__tests__/client/features.test.ts
+++ b/src/__tests__/client/features.test.ts
@@ -127,6 +127,9 @@ describe('Client integration', () => {
         foldingRangeProvider: true,
         implementationProvider: true,
         selectionRangeProvider: true,
+        inlayHintProvider: {
+          resolveProvider: true
+        },
         typeDefinitionProvider: true,
         callHierarchyProvider: true,
         semanticTokensProvider: {

--- a/src/__tests__/client/server/testServer.js
+++ b/src/__tests__/client/server/testServer.js
@@ -38,6 +38,9 @@ connection.onInitialize(params => {
   assert.equal(params.capabilities.textDocument.publishDiagnostics.tagSupport.valueSet[0], DiagnosticTag.Unnecessary)
   assert.equal(params.capabilities.textDocument.publishDiagnostics.tagSupport.valueSet[1], DiagnosticTag.Deprecated)
   assert.equal(params.capabilities.textDocument.documentLink.tooltipSupport, true)
+  assert.equal(params.capabilities.textDocument.inlayHint.dynamicRegistration, true)
+  assert.equal(params.capabilities.textDocument.inlayHint.resolveSupport.properties[0], 'tooltip')
+
   let valueSet = params.capabilities.textDocument.completion.completionItemKind.valueSet
   assert.equal(valueSet[0], 1)
   assert.equal(valueSet[valueSet.length - 1], CompletionItemKind.TypeParameter)
@@ -74,6 +77,9 @@ connection.onInitialize(params => {
     foldingRangeProvider: true,
     implementationProvider: true,
     selectionRangeProvider: true,
+    inlayHintProvider: {
+      resolveProvider: true
+    },
     typeDefinitionProvider: true,
     callHierarchyProvider: true,
     semanticTokensProvider: {

--- a/src/__tests__/handler/symbols.test.ts
+++ b/src/__tests__/handler/symbols.test.ts
@@ -135,7 +135,7 @@ describe('symbols handler', () => {
       disposables.push(languages.registerDocumentSymbolProvider(['*'], {
         provideDocumentSymbols: () => {
           return [
-            SymbolInformation.create('root', SymbolKind.Function, Range.create(0, 0, 0, 10)),
+            SymbolInformation.create('root', SymbolKind.Function, Range.create(0, 0, 0, 10), ''),
             SymbolInformation.create('child', SymbolKind.Function, Range.create(0, 0, 0, 10), '', 'root')
           ]
         }
@@ -258,7 +258,7 @@ describe('symbols handler', () => {
     it('should get workspace symbols', async () => {
       disposables.push(languages.registerWorkspaceSymbolProvider({
         provideWorkspaceSymbols: (_query, _token) => {
-          return [SymbolInformation.create('far', SymbolKind.Class, Range.create(0, 0, 0, 0))]
+          return [SymbolInformation.create('far', SymbolKind.Class, Range.create(0, 0, 0, 0), '')]
         },
         resolveWorkspaceSymbol: sym => {
           let res = Object.assign({}, sym)
@@ -268,7 +268,7 @@ describe('symbols handler', () => {
       }))
       disposables.push(languages.registerWorkspaceSymbolProvider({
         provideWorkspaceSymbols: (_query, _token) => {
-          return [SymbolInformation.create('bar', SymbolKind.Function, Range.create(0, 0, 0, 0))]
+          return [SymbolInformation.create('bar', SymbolKind.Function, Range.create(0, 0, 0, 0), '')]
         }
       }))
       let res = await symbols.getWorkspaceSymbols('a')

--- a/src/language-client/index.ts
+++ b/src/language-client/index.ts
@@ -22,6 +22,7 @@ import { SelectionRangeFeature } from './selectionRange'
 import ChildProcess = cp.ChildProcess
 import { CallHierarchyFeature } from './callHierarchy'
 import { SemanticTokensFeature } from './semanticTokens'
+import { InlayHintsFeature } from './inlayHint'
 import { LinkedEditingFeature } from './linkedEditingRange'
 import { DidCreateFilesFeature, DidDeleteFilesFeature, DidRenameFilesFeature, WillCreateFilesFeature, WillDeleteFilesFeature, WillRenameFilesFeature } from './fileOperations'
 
@@ -578,6 +579,9 @@ export class LanguageClient extends BaseLanguageClient {
     }
     if (!disabledFeatures.includes('semanticTokens')) {
       this.registerFeature(new SemanticTokensFeature(this))
+    }
+    if (!disabledFeatures.includes('inlayHint')) {
+      this.registerFeature(new InlayHintsFeature(this))
     }
     if (!disabledFeatures.includes('workspaceFolders')) {
       this.registerFeature(new WorkspaceFoldersFeature(this))

--- a/src/language-client/inlayHint.ts
+++ b/src/language-client/inlayHint.ts
@@ -1,0 +1,107 @@
+/* --------------------------------------------------------------------------------------------
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT License. See License.txt in the project root for license information.
+* ------------------------------------------------------------------------------------------ */
+
+import {
+  CancellationToken, ClientCapabilities, Disposable, DocumentSelector, Emitter, InlayHintOptions, InlayHintParams, InlayHintRefreshRequest, InlayHintRegistrationOptions, InlayHintRequest, InlayHintResolveRequest, Range, ServerCapabilities
+} from 'vscode-languageserver-protocol'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import { InlayHint } from '../inlayHint'
+import languages from '../languages'
+import { InlayHintsProvider, ProviderResult } from '../provider'
+import { BaseLanguageClient, ensure, Middleware, TextDocumentFeature } from './client'
+import * as cv from './utils/converter'
+
+export type ProvideInlayHintsSignature = (this: void, document: TextDocument, viewPort: Range, token: CancellationToken) => ProviderResult<InlayHint[]>
+export type ResolveInlayHintSignature = (this: void, item: InlayHint, token: CancellationToken) => ProviderResult<InlayHint>
+
+export interface InlayHintsMiddleware {
+  provideInlayHints?: (this: void, document: TextDocument, viewPort: Range, token: CancellationToken, next: ProvideInlayHintsSignature) => ProviderResult<InlayHint[]>;
+  resolveInlayHint?: (this: void, item: InlayHint, token: CancellationToken, next: ResolveInlayHintSignature) => ProviderResult<InlayHint>;
+}
+
+export interface InlayHintsProviderShape {
+  provider: InlayHintsProvider;
+  onDidChangeInlayHints: Emitter<void>;
+}
+
+export class InlayHintsFeature extends TextDocumentFeature<boolean | InlayHintOptions, InlayHintRegistrationOptions, InlayHintsProviderShape> {
+  constructor(client: BaseLanguageClient) {
+    super(client, InlayHintRequest.type)
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    const inlayHint = ensure(ensure(capabilities, 'textDocument')!, 'inlayHint')!
+    inlayHint.dynamicRegistration = true
+    inlayHint.resolveSupport = {
+      properties: ['tooltip', 'textEdits', 'label.tooltip', 'label.location', 'label.command']
+    }
+    ensure(ensure(capabilities, 'workspace')!, 'inlayHint')!.refreshSupport = true
+  }
+
+  public initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {
+    this._client.onRequest(InlayHintRefreshRequest.type, async () => {
+      for (const provider of this.getAllProviders()) {
+        provider.onDidChangeInlayHints.fire()
+      }
+    })
+
+    const [id, options] = this.getRegistration(documentSelector, capabilities.inlayHintProvider)
+    if (!id || !options) {
+      return
+    }
+    this.register({ id, registerOptions: options })
+  }
+
+  protected registerLanguageProvider(options: InlayHintRegistrationOptions): [Disposable, InlayHintsProviderShape] {
+    const eventEmitter: Emitter<void> = new Emitter<void>()
+    const provider: InlayHintsProvider = {
+      onDidChangeInlayHints: eventEmitter.event,
+      provideInlayHints: (document, range, token) => {
+        const client = this._client
+        const provideInlayHints: ProvideInlayHintsSignature = async (document, range, token) => {
+          const requestParams: InlayHintParams = {
+            textDocument: cv.asTextDocumentIdentifier(document),
+            range
+          }
+          try {
+            const values = await client.sendRequest(InlayHintRequest.type, requestParams, token)
+            if (token.isCancellationRequested) {
+              return []
+            }
+            return values
+          } catch (error) {
+            return client.handleFailedRequest(InlayHintRequest.type, token, error, [])
+          }
+        }
+        const middleware = client.clientOptions.middleware! as Middleware & InlayHintsMiddleware
+        return middleware.provideInlayHints
+          ? middleware.provideInlayHints(document, range, token, provideInlayHints)
+          : provideInlayHints(document, range, token)
+      }
+    }
+    provider.resolveInlayHint = options.resolveProvider === true
+      ? (hint, token) => {
+        const client = this._client
+        const resolveInlayHint: ResolveInlayHintSignature = async (item, token) => {
+          try {
+            const value = await client.sendRequest(InlayHintResolveRequest.type, item, token)
+            if (token.isCancellationRequested) {
+              return null
+            }
+            return value
+          } catch (error) {
+            return client.handleFailedRequest(InlayHintResolveRequest.type, token, error, null)
+          }
+        }
+        const middleware = client.clientOptions.middleware! as Middleware & InlayHintsMiddleware
+        return middleware.resolveInlayHint
+          ? middleware.resolveInlayHint(hint, token, resolveInlayHint)
+          : resolveInlayHint(hint, token)
+      }
+      : undefined
+    const selector = options.documentSelector!
+    return [languages.registerInlayHintsProvider(selector, provider), { provider, onDidChangeInlayHints: eventEmitter }]
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3550,40 +3550,40 @@ v8-to-istanbul@^8.1.0:
     convert-source-map "^1.6.0"
     source-map "^0.7.3"
 
-vscode-jsonrpc@6.0.0, vscode-jsonrpc@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz#108bdb09b4400705176b957ceca9e0880e9b6d4e"
-  integrity sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==
+vscode-jsonrpc@8.0.1, vscode-jsonrpc@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz#f30b0625ebafa0fb3bc53e934ca47b706445e57e"
+  integrity sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ==
 
-vscode-languageserver-protocol@3.16.0, vscode-languageserver-protocol@^3.16.0:
-  version "3.16.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz#34135b61a9091db972188a07d337406a3cdbe821"
-  integrity sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==
+vscode-languageserver-protocol@3.17.1, vscode-languageserver-protocol@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz#e801762c304f740208b6c804a0cf21f2c87509ed"
+  integrity sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==
   dependencies:
-    vscode-jsonrpc "6.0.0"
-    vscode-languageserver-types "3.16.0"
+    vscode-jsonrpc "8.0.1"
+    vscode-languageserver-types "3.17.1"
 
-vscode-languageserver-textdocument@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.3.tgz#879f2649bfa5a6e07bc8b392c23ede2dfbf43eff"
-  integrity sha512-ynEGytvgTb6HVSUwPJIAZgiHQmPCx8bZ8w5um5Lz+q5DjP0Zj8wTFhQpyg8xaMvefDytw2+HH5yzqS+FhsR28A==
+vscode-languageserver-textdocument@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.4.tgz#3cd56dd14cec1d09e86c4bb04b09a246cb3df157"
+  integrity sha512-/xhqXP/2A2RSs+J8JNXpiiNVvvNM0oTosNVmQnunlKvq9o4mupHOBAnnzH0lwIPKazXKvAKsVp1kr+H/K4lgoQ==
 
-vscode-languageserver-types@3.16.0, vscode-languageserver-types@^3.16.0:
-  version "3.16.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz#ecf393fc121ec6974b2da3efb3155644c514e247"
-  integrity sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==
+vscode-languageserver-types@3.17.1, vscode-languageserver-types@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz#c2d87fa7784f8cac389deb3ff1e2d9a7bef07e16"
+  integrity sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ==
 
-vscode-languageserver@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz#49b068c87cfcca93a356969d20f5d9bdd501c6b0"
-  integrity sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==
+vscode-languageserver@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-8.0.1.tgz#56bd7a01f5c88af075a77f1d220edcb30fc4bdc7"
+  integrity sha512-sn7SjBwWm3OlmLtgg7jbM0wBULppyL60rj8K5HF0ny/MzN+GzPBX1kCvYdybhl7UW63V5V5tRVnyB8iwC73lSQ==
   dependencies:
-    vscode-languageserver-protocol "3.16.0"
+    vscode-languageserver-protocol "3.17.1"
 
-vscode-uri@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.1.2.tgz#c8d40de93eb57af31f3c715dd650e2ca2c096f1c"
-  integrity sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==
+vscode-uri@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.3.tgz#a95c1ce2e6f41b7549f86279d19f47951e4f4d84"
+  integrity sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA==
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Works as expected.

Needs `vscode-languageserver` / `vscode-languageserver-protocol` to cut a new release, some vscode-languageserver-types are changed, this make the lint/CI failed.