### PR TITLE
Fix wording 'Not exists'

### DIFF
--- a/autoload/coc/compat.vim
+++ b/autoload/coc/compat.vim
@@ -167,7 +167,7 @@ function! coc#compat#buf_del_keymap(bufnr, mode, lhs) abort
     try
       call nvim_buf_del_keymap(a:bufnr, a:mode, a:lhs)
     catch /^Vim\%((\a\+)\)\=:E5555/
-      " ignore keymap not exists.
+      " ignore keymap doesn't exist
     endtry
     return
   endif
@@ -231,7 +231,7 @@ function! coc#compat#execute(winid, command, ...) abort
     endif
     noa keepalt call nvim_set_current_win(curr)
   else
-    throw 'win_execute not exists, please upgrade vim.'
+    throw 'win_execute does not exist, please upgrade vim.'
   endif
 endfunc
 

--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -4,7 +4,7 @@ let s:borderchars = get(g:, 'coc_borderchars', ['─', '│', '─', '│', '┌
 let s:rounded_borderchars = s:borderchars[0:3] + ['╭', '╮', '╯', '╰']
 let s:borderjoinchars = get(g:, 'coc_border_joinchars', ['┬', '┤', '┴', '├'])
 let s:popup_list_api = exists('*popup_list')
-" Popup ids, used when popup_list() not exists
+" Popup ids, used when popup_list() doesn't exist
 let s:popup_list = []
 let s:pad_bufnr = -1
 

--- a/autoload/coc/window.vim
+++ b/autoload/coc/window.vim
@@ -1,7 +1,7 @@
 let g:coc_max_treeview_width = get(g:, 'coc_max_treeview_width', 40)
 let s:is_vim = !has('nvim')
 
-" Get tabpagenr of winid, return -1 if window not exists
+" Get tabpagenr of winid, return -1 if window doesn't exist
 function! coc#window#tabnr(winid) abort
   if exists('*nvim_win_get_tabpage')
     try
@@ -18,7 +18,7 @@ function! coc#window#tabnr(winid) abort
     let info = getwininfo(a:winid)
     return empty(info) ? -1 : info[0]['tabnr']
   else
-    throw 'win_execute() not exists, please upgrade your vim.'
+    throw 'win_execute() does not exist, please upgrade your vim.'
   endif
 endfunction
 
@@ -41,7 +41,7 @@ function! coc#window#visible(winid) abort
   return coc#window#tabnr(a:winid) == tabpagenr()
 endfunction
 
-" Return v:null when name or window not exists,
+" Return v:null when name or window doesn't exist,
 " 'getwinvar' only works on window of current tab
 function! coc#window#get_var(winid, name, ...) abort
   if !s:is_vim

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -2145,7 +2145,7 @@ coc#_select_confirm()					*coc#_select_confirm()*
 	confirm the completion.
 
 	Note: for this function to work as expected, either |CompleteChanged|
-	autocmd should exists or only <C-n> and <C-p> should be used to select
+	autocmd should exist or only <C-n> and <C-p> should be used to select
 	a completion item.
 
 coc#util#api_version() 					 *coc#util#api_version()*
@@ -2402,7 +2402,7 @@ Acceptable {action} names for |CocAction()| and |CocActionAsync|.
 "diagnosticRefresh" [{bufnr}] 			*CocAction('diagnosticRefresh')*
 
 	Force refresh diagnostics for special buffer with {bufnr} or all buffers
-	when {bufnr} not exists, returns `v:null` before diagnostics are shown.
+	when {bufnr} doesn't exist, returns `v:null` before diagnostics are shown.
 
 	NOTE: Will refresh in any mode.
 

--- a/history.md
+++ b/history.md
@@ -841,7 +841,7 @@
 
 - **Break change** sources excluding `around`, `buffer` or `file` are extracted
   as extensions.
-- **Break change** custom source not exists any more.
+- **Break change** custom source doesn't exist any more.
 - Add `coc.preferences.preferCompleteThanJumpPlaceholder` to make jump
   placeholder behavior as confirm completion when possible.
 - Add `CocDiagnosticChange` autocmd for force statusline update.
@@ -1229,7 +1229,7 @@
 - Add support filetype change of buffer.
 - Add basic test for completion.
 - Improve loading speed, use child process to initialize vim sources.
-- Improve install.sh, install node when not exists.
+- Improve install.sh, install node when it doesn't exist.
 - Improve interface of workspace.
 - Fix loading of configuration content.
 

--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -157,7 +157,7 @@ function! s:OpenConfig()
   let home = coc#util#get_config_home()
   if !isdirectory(home)
     echohl MoreMsg
-    echom 'Config directory "'.home.'" not exists, create? (y/n)'
+    echom 'Config directory "'.home.'" does not exist, create? (y/n)'
     echohl None
     let confirm = nr2char(getchar())
     redraw!

--- a/src/__tests__/core/autocmds.test.ts
+++ b/src/__tests__/core/autocmds.test.ts
@@ -58,7 +58,7 @@ describe('setupDynamicAutocmd()', () => {
 })
 
 describe('doAutocmd()', () => {
-  it('should not throw when command id not exists', async () => {
+  it('should not throw when command id does not exist', async () => {
     await workspace.autocmds.doAutocmd(999, [])
   })
 

--- a/src/__tests__/core/fileSystemWatcher.test.ts
+++ b/src/__tests__/core/fileSystemWatcher.test.ts
@@ -363,7 +363,7 @@ describe('fileSystemWatcher', () => {
 })
 
 describe('create FileSystemWatcherManager', () => {
-  it('should attach to exists workspace folder', async () => {
+  it('should attach to existing workspace folder', async () => {
     let workspaceFolder = new WorkspaceFolderController(configurations)
     workspaceFolder.addWorkspaceFolder(cwd, false)
     let watcherManager = new FileSystemWatcherManager(workspaceFolder, '')

--- a/src/__tests__/core/files.test.ts
+++ b/src/__tests__/core/files.test.ts
@@ -163,7 +163,7 @@ describe('applyEdits()', () => {
     await nvim.command('silent! %bwipeout!')
   })
 
-  it('should apply edits when file not exists', async () => {
+  it('should apply edits when file does not exist', async () => {
     let filepath = path.join(__dirname, 'not_exists')
     disposables.push({
       dispose: () => {
@@ -320,7 +320,7 @@ describe('applyEdits()', () => {
 })
 
 describe('createFile()', () => {
-  it('should create file if parent folder not exists', async () => {
+  it('should create file if parent folder does not exist', async () => {
     const folder = path.join(__dirname, 'foo')
     const filepath = path.join(folder, 'bar')
     await workspace.createFile(filepath)
@@ -337,7 +337,7 @@ describe('createFile()', () => {
     expect(content).toBe('foo')
   })
 
-  it('should create file if not exists', async () => {
+  it('should create file if does not exist', async () => {
     await helper.edit()
     let filepath = path.join(__dirname, 'foo')
     await workspace.createFile(filepath, { ignoreIfExists: true })
@@ -346,7 +346,7 @@ describe('createFile()', () => {
     fs.unlinkSync(filepath)
   })
 
-  it('should create folder if not exists', async () => {
+  it('should create folder if it does not exist', async () => {
     let filepath = path.join(__dirname, 'bar/')
     await workspace.createFile(filepath)
     expect(fs.existsSync(filepath)).toBe(true)
@@ -363,7 +363,7 @@ describe('createFile()', () => {
 })
 
 describe('renameFile', () => {
-  it('should rename if file not exists', async () => {
+  it('should rename if file does not exist', async () => {
     let filepath = path.join(__dirname, 'foo')
     let newPath = path.join(__dirname, 'bar')
     await workspace.createFile(filepath)
@@ -451,7 +451,7 @@ describe('openTextDocument()', () => {
     expect(curr.uri).toBe(doc.uri)
   })
 
-  it('should throw when file not exists', async () => {
+  it('should throw when file does not exist', async () => {
     let err
     try {
       await workspace.openTextDocument('/a/b/c')

--- a/src/__tests__/handler/callHierarchy.test.ts
+++ b/src/__tests__/handler/callHierarchy.test.ts
@@ -36,7 +36,7 @@ function createCallItem(name: string, kind: SymbolKind, uri: string, range: Rang
 }
 
 describe('CallHierarchy', () => {
-  it('should throw for when provider not exists', async () => {
+  it('should throw for when provider does not exist', async () => {
     let err
     try {
       await callHierarchy.getIncoming()
@@ -89,7 +89,7 @@ describe('CallHierarchy', () => {
     expect(res.length).toBe(1)
   })
 
-  it('should show message when provider not exists', async () => {
+  it('should show message when provider does not exist', async () => {
     await callHierarchy.showCallHierarchyTree('incoming')
     let buf = await nvim.buffer
     let lines = await buf.lines

--- a/src/__tests__/handler/codeActions.test.ts
+++ b/src/__tests__/handler/codeActions.test.ts
@@ -333,7 +333,7 @@ describe('handler codeActions', () => {
   })
 
   describe('doQuickfix', () => {
-    it('should throw when quickfix action not exists', async () => {
+    it('should throw when quickfix action does not exist', async () => {
       let err
       currActions = []
       await helper.createDocument()

--- a/src/__tests__/handler/colors.test.ts
+++ b/src/__tests__/handler/colors.test.ts
@@ -167,7 +167,7 @@ describe('Colors', () => {
   })
 
   describe('hasColor()', () => {
-    it('should return false when bufnr not exists', async () => {
+    it('should return false when bufnr does not exist', async () => {
       let res = colors.hasColor(99)
       colors.clearHighlight(99)
       expect(res).toBe(false)
@@ -175,7 +175,7 @@ describe('Colors', () => {
   })
 
   describe('getColorInformation()', () => {
-    it('should return null when highlighter not exists', async () => {
+    it('should return null when highlighter does not exist', async () => {
       let res = await colors.getColorInformation(99)
       expect(res).toBe(null)
     })
@@ -192,21 +192,21 @@ describe('Colors', () => {
   })
 
   describe('hasColorAtPosition()', () => {
-    it('should return false when bufnr not exists', async () => {
+    it('should return false when bufnr does not exist', async () => {
       let res = colors.hasColorAtPosition(99, Position.create(0, 0))
       expect(res).toBe(false)
     })
   })
 
   describe('pickPresentation()', () => {
-    it('should show warning when color not exists', async () => {
+    it('should show warning when color does not exist', async () => {
       await helper.createDocument()
       await colors.pickPresentation()
       let msg = await helper.getCmdline()
       expect(msg).toMatch('Color not found')
     })
 
-    it('should not throw when presentations not exists', async () => {
+    it('should not throw when presentations do not exist', async () => {
       colorPresentations = []
       let doc = await helper.createDocument()
       await nvim.setLine('#ffffff')
@@ -232,7 +232,7 @@ describe('Colors', () => {
   })
 
   describe('pickColor()', () => {
-    it('should show warning when color not exists', async () => {
+    it('should show warning when color does not exist', async () => {
       await helper.createDocument()
       await colors.pickColor()
       let msg = await helper.getCmdline()

--- a/src/__tests__/handler/fold.test.ts
+++ b/src/__tests__/handler/fold.test.ts
@@ -29,7 +29,7 @@ afterEach(async () => {
 })
 
 describe('Folds', () => {
-  it('should return null when provider not exists', async () => {
+  it('should return null when provider does not exist', async () => {
     let doc = await workspace.document
     let token = (new CancellationTokenSource()).token
     expect(await languages.provideFoldingRanges(doc.textDocument, {}, token)).toBe(null)

--- a/src/__tests__/handler/format.test.ts
+++ b/src/__tests__/handler/format.test.ts
@@ -109,7 +109,7 @@ describe('format handler', () => {
   })
 
   describe('rangeFormat', () => {
-    it('should return null when provider not exists', async () => {
+    it('should return null when provider does not exist', async () => {
       let doc = (await workspace.document).textDocument
       let range = Range.create(0, 0, 1, 0)
       let options = await workspace.getFormatOptions()

--- a/src/__tests__/handler/highlights.test.ts
+++ b/src/__tests__/handler/highlights.test.ts
@@ -64,7 +64,7 @@ describe('document highlights', () => {
     }))
   }
 
-  it('should return null when highlights provide not exists', async () => {
+  it('should return null when highlights provide does not exist', async () => {
     let doc = await helper.createDocument()
     let res = await highlights.getHighlights(doc, Position.create(0, 0))
     expect(res).toBeNull()

--- a/src/__tests__/handler/locations.test.ts
+++ b/src/__tests__/handler/locations.test.ts
@@ -40,7 +40,7 @@ function createLocation(name: string, sl: number, sc: number, el: number, ec: nu
 
 describe('locations', () => {
   describe('no provider', () => {
-    it('should return null when provider not exists', async () => {
+    it('should return null when provider does not exist', async () => {
       let doc = (await workspace.document).textDocument
       let pos = Position.create(0, 0)
       let tokenSource = new CancellationTokenSource()
@@ -205,12 +205,12 @@ describe('locations', () => {
   })
 
   describe('getTagList', () => {
-    it('should return null when cword not exists', async () => {
+    it('should return null when cword does not exist', async () => {
       let res = await locations.getTagList()
       expect(res).toBe(null)
     })
 
-    it('should return null when provider not exists', async () => {
+    it('should return null when provider does not exist', async () => {
       await nvim.setLine('foo')
       await nvim.command('normal! ^')
       let res = await locations.getTagList()

--- a/src/__tests__/handler/outline.test.ts
+++ b/src/__tests__/handler/outline.test.ts
@@ -312,7 +312,7 @@ describe('symbols outline', () => {
       await symbols.showOutline(1)
     })
 
-    it('should not throw when provider not exists', async () => {
+    it('should not throw when provider does not exist', async () => {
       await symbols.showOutline(1)
       let buf = await getOutlineBuffer()
       expect(buf).toBeDefined()
@@ -445,7 +445,7 @@ describe('symbols outline', () => {
       expect(buf).toBeUndefined()
     })
 
-    it('should not throw when outline not exists', async () => {
+    it('should not throw when outline does not exist', async () => {
       await symbols.hideOutline()
       let buf = await getOutlineBuffer()
       expect(buf).toBeUndefined()

--- a/src/__tests__/handler/refactor.test.ts
+++ b/src/__tests__/handler/refactor.test.ts
@@ -104,7 +104,7 @@ describe('refactor', () => {
   })
 
   describe('getFileRange()', () => {
-    it('should throw when range not exists', async () => {
+    it('should throw when range does not exist', async () => {
       let uri = URI.file(__filename).toString()
       let locations = [{ uri, range: Range.create(0, 0, 0, 6) }]
       let buf = await refactor.fromLocations(locations)

--- a/src/__tests__/handler/selectionRange.test.ts
+++ b/src/__tests__/handler/selectionRange.test.ts
@@ -29,7 +29,7 @@ afterEach(async () => {
 
 describe('selectionRange', () => {
   describe('getSelectionRanges()', () => {
-    it('should throw error when selectionRange provider not exists', async () => {
+    it('should throw error when selectionRange provider does not exist', async () => {
       let doc = await helper.createDocument()
       await doc.synchronize()
       let err

--- a/src/__tests__/handler/semanticTokens.test.ts
+++ b/src/__tests__/handler/semanticTokens.test.ts
@@ -396,7 +396,7 @@ describe('semanticTokens', () => {
   })
 
   describe('rangeProvider', () => {
-    it('should invoke range provider first time when both kind exists', async () => {
+    it('should invoke range provider first time when both kinds exist', async () => {
       let fn = jest.fn()
       disposables.push(registerRangeProvider('rust', () => {
         fn()

--- a/src/__tests__/handler/symbols.test.ts
+++ b/src/__tests__/handler/symbols.test.ts
@@ -117,7 +117,7 @@ describe('symbols handler', () => {
       expect(res).toBe('')
     })
 
-    it('should reset coc_current_function when symbols not exists', async () => {
+    it('should reset coc_current_function when symbols do not exist', async () => {
       let code = `class myClass {
       fun1() {
       }
@@ -149,7 +149,7 @@ describe('symbols handler', () => {
   })
 
   describe('selectSymbolRange', () => {
-    it('should show warning when no symbols exists', async () => {
+    it('should show warning when no symbols exist', async () => {
       disposables.push(languages.registerDocumentSymbolProvider(['*'], {
         provideDocumentSymbols: () => {
           return []

--- a/src/__tests__/handler/workspace.test.ts
+++ b/src/__tests__/handler/workspace.test.ts
@@ -46,7 +46,7 @@ describe('Workspace handler', () => {
   })
 
   describe('doKeymap()', () => {
-    it('should return default value when key mapping not exists', async () => {
+    it('should return default value when key mapping does not exist', async () => {
       let res = await handler.doKeymap('not_exists', '', '<C-a')
       expect(res).toBe('')
     })

--- a/src/__tests__/list/manager.test.ts
+++ b/src/__tests__/list/manager.test.ts
@@ -323,7 +323,7 @@ describe('list', () => {
       expect(msg).toMatch('Invalid list option')
     })
 
-    it('should show error for option not exists', async () => {
+    it('should show error for option that does not exist', async () => {
       manager.parseArgs(['-xyz', 'location'])
       let msg = await helper.getCmdline()
       expect(msg).toMatch('Invalid option')

--- a/src/__tests__/list/mappings.test.ts
+++ b/src/__tests__/list/mappings.test.ts
@@ -283,10 +283,10 @@ describe('doAction()', () => {
     let fn = async () => {
       await mappings.doAction('foo:bar')
     }
-    await expect(fn()).rejects.toThrow(/not exists/)
+    await expect(fn()).rejects.toThrow(/doesn't exist/)
   })
 
-  it('should not throw when session not exists', async () => {
+  it('should not throw when session does not exist', async () => {
     let mappings = manager.mappings
     await mappings.doAction('do:selectall')
     await mappings.doAction('do:help')
@@ -298,7 +298,7 @@ describe('doAction()', () => {
     await mappings.doAction('do:refresh')
   })
 
-  it('should not throw when action name not exists', async () => {
+  it('should not throw when action name does not exist', async () => {
     await helper.mockFunction('MyExpr', '')
     let mappings = manager.mappings
     await mappings.doAction('expr', 'MyExpr')

--- a/src/__tests__/list/session.test.ts
+++ b/src/__tests__/list/session.test.ts
@@ -59,7 +59,7 @@ afterEach(async () => {
 
 describe('list session', () => {
   describe('doDefaultAction()', () => {
-    it('should throw error when default action not exists', async () => {
+    it('should throw error when default action does not exist', async () => {
       labels = ['a', 'b', 'c']
       let list = new SimpleList(nvim)
       list.defaultAction = 'foo'

--- a/src/__tests__/modules/extensions.test.ts
+++ b/src/__tests__/modules/extensions.test.ts
@@ -21,7 +21,7 @@ jest.setTimeout(30000)
 
 describe('extensions', () => {
 
-  it('should create root when not exists', async () => {
+  it('should create root when it does not exist', async () => {
     let root = path.join(os.tmpdir(), 'foo-bar')
     let res = extensions.checkRoot(root)
     expect(res).toBe(true)

--- a/src/__tests__/modules/fs.test.ts
+++ b/src/__tests__/modules/fs.test.ts
@@ -40,7 +40,7 @@ describe('fs', () => {
       fs.unlinkSync(dest)
     })
 
-    it('should throw when file not exists', async () => {
+    it('should throw when file does not exist', async () => {
       let err
       try {
         await renameAsync('/foo/bar', '/a')
@@ -52,7 +52,7 @@ describe('fs', () => {
   })
 
   describe('getFileLineCount', () => {
-    it('should throw when file not exists', async () => {
+    it('should throw when file does not exist', async () => {
       let err
       try {
         await getFileLineCount('/foo/bar')
@@ -75,7 +75,7 @@ describe('fs', () => {
       expect(res).toBeDefined()
     })
 
-    it('should throw when file not exists', async () => {
+    it('should throw when file does not exist', async () => {
       const fn = async () => {
         await readFileLine(__filename + 'fooobar', 1)
       }
@@ -84,7 +84,7 @@ describe('fs', () => {
   })
 
   describe('readFileLines', () => {
-    it('should throw when file not exists', async () => {
+    it('should throw when file does not exist', async () => {
       const fn = async () => {
         await readFileLines(__filename + 'fooobar', 0, 3)
       }

--- a/src/__tests__/modules/memos.test.ts
+++ b/src/__tests__/modules/memos.test.ts
@@ -23,13 +23,13 @@ describe('Memos', () => {
     expect(res).toBe('memo')
   })
 
-  it('should get value for key not exists', async () => {
+  it('should get value for key if it does not exist', async () => {
     let memo = memos.createMemento('y')
     let res = memo.get<any>('xyz')
     expect(res).toBeUndefined()
   })
 
-  it('should use defaultValue when not exists', async () => {
+  it('should use defaultValue when it does not exist', async () => {
     let memo = memos.createMemento('y')
     let res = memo.get<any>('f.o.o', 'default')
     expect(res).toBe('default')

--- a/src/__tests__/modules/mru.test.ts
+++ b/src/__tests__/modules/mru.test.ts
@@ -24,7 +24,7 @@ describe('Mru', () => {
     await mru.clean()
   })
 
-  it('should add when file not exists', async () => {
+  it('should add when file it does not exist', async () => {
     let mru = new Mru('test', root)
     await mru.clean()
     await mru.add('a')

--- a/src/__tests__/modules/window.test.ts
+++ b/src/__tests__/modules/window.test.ts
@@ -195,7 +195,7 @@ describe('window', () => {
       expect(res).toEqual(['foo'])
     })
 
-    it('should throw when workspace folder not exists', async () => {
+    it('should throw when workspace folder does not exist', async () => {
       helper.updateConfiguration('coc.preferences.rootPatterns', [])
       await nvim.command('enew')
       let err

--- a/src/__tests__/modules/workspace.test.ts
+++ b/src/__tests__/modules/workspace.test.ts
@@ -136,7 +136,7 @@ describe('workspace methods', () => {
     })
   })
 
-  it('should get format options when uri not exists', async () => {
+  it('should get format options when uri does not exist', async () => {
     let uri = URI.file('/tmp/foo').toString()
     let opts = await workspace.getFormatOptions(uri)
     expect(opts.insertSpaces).toBe(true)
@@ -253,7 +253,7 @@ describe('workspace methods', () => {
     expect(res).toBeTruthy()
   })
 
-  it('should not resolve module if not exists', async () => {
+  it('should not resolve module if it does not exist', async () => {
     let res = await workspace.resolveModule('foo')
     res = await workspace.resolveModule('foo')
     expect(res).toBeFalsy()

--- a/src/__tests__/tree/basicProvider.test.ts
+++ b/src/__tests__/tree/basicProvider.test.ts
@@ -210,7 +210,7 @@ describe('BasicDataProvider', () => {
   })
 
   describe('getParent()', () => {
-    it('should get undefined when data not exists', async () => {
+    it('should get undefined when data does not exist', async () => {
       let node = createNode('a')
       let provider = new BasicDataProvider({
         provideData: () => {

--- a/src/__tests__/tree/treeView.test.ts
+++ b/src/__tests__/tree/treeView.test.ts
@@ -600,7 +600,7 @@ describe('TreeView', () => {
   })
 
   describe('invokeActions', () => {
-    it('should show warning when resolveActions not exists', async () => {
+    it('should show warning when resolveActions does not exist', async () => {
       createTreeView(defaultDef)
       await treeView.show()
       await helper.wait(50)
@@ -877,7 +877,7 @@ describe('TreeView', () => {
   })
 
   describe('reveal()', () => {
-    it('should throw error when getParent not exists', async () => {
+    it('should throw error when getParent does not exist', async () => {
       createTreeView(defaultDef)
       provider.getParent = undefined
       await treeView.show()

--- a/src/attach.ts
+++ b/src/attach.ts
@@ -67,7 +67,7 @@ export default (opts: Attach, requestApi = true): Plugin => {
       default: {
         let exists = plugin.hasAction(method)
         if (!exists) {
-          console.error(`action "${method}" not exists`)
+          console.error(`action "${method}" does not exist`)
           return
         }
         try {

--- a/src/core/files.ts
+++ b/src/core/files.ts
@@ -60,7 +60,7 @@ export default class Files {
     }
     const scheme = uri.scheme
     if (scheme == 'file') {
-      if (!fs.existsSync(uri.fsPath)) throw new Error(`${uri.fsPath} not exists.`)
+      if (!fs.existsSync(uri.fsPath)) throw new Error(`${uri.fsPath} doesn't exist.`)
       fs.accessSync(uri.fsPath, fs.constants.R_OK)
     }
     if (scheme == 'untitled') {
@@ -246,7 +246,7 @@ export default class Files {
       return
     }
     if (!stat && !ignoreIfNotExists) {
-      ui.showMessage(this.nvim, `${filepath} not exists`, 'Error')
+      ui.showMessage(this.nvim, `${filepath} doesn't exist`, 'Error')
       return
     }
     if (stat == null) return

--- a/src/core/watchman.ts
+++ b/src/core/watchman.ts
@@ -159,7 +159,7 @@ export default class Watchman {
     try {
       watchman = new Watchman(binaryPath, channel)
       let valid = await watchman.checkCapability()
-      if (!valid) throw new Error('required capabilities not exists.')
+      if (!valid) throw new Error('required capabilities do not exist.')
       let watching = await watchman.watchProject(root)
       if (!watching) throw new Error('unable to watch')
       return watchman

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -606,7 +606,7 @@ export class Extensions {
   }
 
   /**
-   * Activate extension, throw error if disabled or not exists
+   * Activate extension, throw error if disabled or doesn't exist.
    * Returns true if extension successfully activated.
    */
   public async activate(id): Promise<boolean> {

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -133,7 +133,7 @@ export default class Handler implements HandlerDelegate {
   }
 
   /**
-   * Throw error when provider not exists.
+   * Throw error when provider doesn't exist.
    */
   public checkProvier(id: ProviderName, document: TextDocument): void {
     if (!languages.hasProvider(id, document)) {

--- a/src/handler/semanticTokens/index.ts
+++ b/src/handler/semanticTokens/index.ts
@@ -221,7 +221,7 @@ export default class SemanticTokens {
         }
         hl.addLine('')
       } else {
-        hl.addLine('No token modifiers exists', 'Comment')
+        hl.addLine('No token modifiers exist', 'Comment')
         hl.addLine('')
       }
     } catch (e) {

--- a/src/list/mappings.ts
+++ b/src/list/mappings.ts
@@ -299,7 +299,7 @@ export default class Mappings {
 
   public async doAction(key: string, expr?: string): Promise<void> {
     let fn = this.actions.get(key)
-    if (!fn) throw new Error(`Action ${key} not exists`)
+    if (!fn) throw new Error(`Action ${key} doesn't exist`)
     await Promise.resolve(fn(expr))
   }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -228,7 +228,7 @@ export default class Plugin extends EventEmitter {
 
   public async cocAction(method: string, ...args: any[]): Promise<any> {
     let fn = this.actions.get(method)
-    if (!fn) throw new Error(`Action "${method}" not exists`)
+    if (!fn) throw new Error(`Action "${method}" doesn't exist`)
     let ts = Date.now()
     let res = await Promise.resolve(fn.apply(null, args))
     let dt = Date.now() - ts

--- a/src/window.ts
+++ b/src/window.ts
@@ -623,7 +623,7 @@ class Window {
   /**
    * Create a {@link TreeView} instance.
    *
-   * @param viewId Id of the view, used as title of TreeView when title not exists.
+   * @param viewId Id of the view, used as title of TreeView when title doesn't exist.
    * @param options Options for creating the {@link TreeView}
    * @returns a {@link TreeView}.
    */

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -314,7 +314,7 @@ export class Workspace implements IWorkspace {
 
   /**
    * Get attached document by uri or bufnr.
-   * Throw error when document not exists or not attached.
+   * Throw error when document doesn't exist or isn't attached.
    */
   public getAttachedDocument(uri: number | string): Document {
     let doc = this.getDocument(uri)

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2505,7 +2505,7 @@ declare module 'coc.nvim' {
     notify(name: string, args?: VimValue[]): void
 
     /**
-     * Retrieves scoped variable, returns null when value not exists.
+     * Retrieves scoped variable, returns null when value doesn't exist.
      */
     getVar(name: string): Promise<VimValue | null>
 
@@ -2529,17 +2529,17 @@ declare module 'coc.nvim' {
     deleteVar(name: string): void
 
     /**
-     * Retrieves a scoped option, not exists for tabpage.
+     * Retrieves a scoped option, doesn't exist for tabpage.
      */
     getOption(name: string): Promise<VimValue>
 
     /**
-     * Set scoped option by request, not exists for tabpage.
+     * Set scoped option by request, doesn't exist for tabpage.
      */
     setOption(name: string, value: VimValue): Promise<void>
 
     /**
-     * Set scoped  variable by notification, not exists for tabpage.
+     * Set scoped  variable by notification, doesn't exist for tabpage.
      */
     setOption(name: string, value: VimValue, isNotify: true): void
   }
@@ -7280,7 +7280,7 @@ declare module 'coc.nvim' {
     export function registerBufferSync<T extends BufferSyncItem>(create: (doc: Document) => T | undefined): BufferSync<T>
 
     /**
-     * Create a FileSystemWatcher instance, when watchman not exists, the
+     * Create a FileSystemWatcher instance, when watchman doesn't exist, the
      * returned FileSystemWatcher can still be used, but not work at all.
      */
     export function createFileSystemWatcher(globPattern: string, ignoreCreate?: boolean, ignoreChange?: boolean, ignoreDelete?: boolean): FileSystemWatcher
@@ -7861,7 +7861,7 @@ declare module 'coc.nvim' {
      */
     export const terminals: readonly Terminal[]
     /**
-     * onDidChangeTerminalState not exists since we can't detect window resize on vim.
+     * onDidChangeTerminalState doesn't exist since we can't detect window resize on vim.
      */
     /**
      * Event fired after terminal created, only fired with Terminal that
@@ -7992,7 +7992,7 @@ declare module 'coc.nvim' {
     /**
      * Create a {@link TreeView} instance, call `show()` method to render.
      *
-     * @param viewId Id of the view, used as title of TreeView when title not exists.
+     * @param viewId Id of the view, used as title of TreeView when title doesn't exist.
      * @param options Options for creating the {@link TreeView}
      * @returns a {@link TreeView}.
      */
@@ -8336,7 +8336,7 @@ declare module 'coc.nvim' {
 
     /**
      * The absolute directory path for extension to download persist data.
-     * The directory could be not exists.
+     * The directory might not exist.
      */
     storagePath: string
 
@@ -8453,7 +8453,7 @@ declare module 'coc.nvim' {
      */
     spans: [number, number][]
     /**
-     * `list.matchHighlightGroup` is used when not exists.
+     * `list.matchHighlightGroup` is used when it doesn't exist.
      */
     hlGroup?: string
   }


### PR DESCRIPTION
The wording "not exists" is not valid english, and pops up frequently in error messages and documentation.
Every instance of it (outside of code) was fixed and updated with proper english grammar. 