### PR TITLE
fix(snippet.vim): fix select error when placeholder value end of '\n'

### DIFF
--- a/autoload/coc/snippet.vim
+++ b/autoload/coc/snippet.vim
@@ -112,11 +112,11 @@ function! coc#snippet#select(position, text) abort
     call feedkeys("\<Esc>", 'in')
   endif
   let cursor = coc#snippet#to_cursor(a:position)
-  call cursor([cursor[0], cursor[1] - (&selection !~# 'exclusive')])
   let len = strchars(a:text) - (&selection !~# 'exclusive')
+  call cursor([cursor[0], cursor[1] - (&selection !~# 'exclusive') - len])
   let cmd = ''
   let cmd .= mode()[0] ==# 'i' ? "\<Esc>l" : ''
-  let cmd .= printf('v%s', len > 0 ? len . 'h' : '')
+  let cmd .= printf('v%s', len > 0 ? len . 'l' : '')
   let cmd .= "o\<C-g>"
   call feedkeys(cmd, 'n')
 endfunction


### PR DESCRIPTION
![屏幕录制2022-05-25 18 43 47](https://user-images.githubusercontent.com/33375307/170246597-7a470527-edeb-4a9a-a8c7-e2753e089206.gif)
${1:FOO} ends of '\n', which caused this problem
```snippet ifdef
	#ifdef ${1:FOO}
		${2:#define }
	#endif
```
I don't know why coc#snippet#select selects the placeholder value from end to begin, I changed it to select value from begin to end to fix this problem.
