### PR TITLE
fix(snippet.vim): fix placeholder value select error

### DIFF
--- a/autoload/coc/snippet.vim
+++ b/autoload/coc/snippet.vim
@@ -112,11 +112,12 @@ function! coc#snippet#select(position, text) abort
     call feedkeys("\<Esc>", 'in')
   endif
   let cursor = coc#snippet#to_cursor(a:position)
-  call cursor([cursor[0], cursor[1] - (&selection !~# 'exclusive')])
   let len = strchars(a:text) - (&selection !~# 'exclusive')
+  call cursor([cursor[0], cursor[1] - (&selection !~# 'exclusive') - len])
   let cmd = ''
-  let cmd .= mode()[0] ==# 'i' ? "\<Esc>l" : ''
-  let cmd .= printf('v%s', len > 0 ? len . 'h' : '')
+  let mv = getcurpos()[2] == 1 ? "\<Esc>" : "\<Esc>l"
+  let cmd .= mode()[0] ==# 'i' ? mv : ''
+  let cmd .= printf('v%s', len > 0 ? len . 'l' : '')
   let cmd .= "o\<C-g>"
   call feedkeys(cmd, 'n')
 endfunction


### PR DESCRIPTION
```
${1:FOO}\n
```
The placeholder value "FOO" can't be selected correctly but "OO\n" is selected. This error is caused by the coc#snippet#select.