### PR TITLE
fix(fs): close underlying file manually to avoid EMFILE

### DIFF
--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -175,8 +175,9 @@ export function readFileLines(fullpath: string, start: number, end: number): Pro
     return Promise.reject(new Error(`file does not exist: ${fullpath}`))
   }
   let res: string[] = []
+  const input = fs.createReadStream(fullpath, { encoding: 'utf8' })
   const rl = readline.createInterface({
-    input: fs.createReadStream(fullpath, { encoding: 'utf8' }),
+    input: input,
     crlfDelay: Infinity,
     terminal: false
   } as any)
@@ -193,6 +194,7 @@ export function readFileLines(fullpath: string, start: number, end: number): Pro
     })
     rl.on('close', () => {
       resolve(res)
+      input.close()
     })
     rl.on('error', reject)
   })
@@ -202,8 +204,9 @@ export function readFileLine(fullpath: string, count: number): Promise<string> {
   if (!fs.existsSync(fullpath)) {
     return Promise.reject(new Error(`file does not exist: ${fullpath}`))
   }
+  const input = fs.createReadStream(fullpath, { encoding: 'utf8' })
   const rl = readline.createInterface({
-    input: fs.createReadStream(fullpath, { encoding: 'utf8' }),
+    input: input,
     crlfDelay: Infinity,
     terminal: false
   } as any)
@@ -216,6 +219,7 @@ export function readFileLine(fullpath: string, count: number): Promise<string> {
           line = line.slice(1)
         }
         rl.close()
+        input.close()
         resolve(line)
         return
       }


### PR DESCRIPTION
# Problem
nodejs [Readline.close](https://nodejs.org/api/readline.html#rlclose)  doesn't close underlying input and output stream, will make file descriptor leak, leading to EMFILE error

# Example

main.go
```go
package main

import "fmt"

func main() {
	fmt.Println("vim-go")
}
```

hello.go
```go
package main

func Add(x, y int) {
	return x + z
}
```
I add some custom log
![image](https://user-images.githubusercontent.com/26727562/170717107-d90398e6-ef9a-4bb3-b4d9-f28e9817f669.png)
after `CocList diagnostics`

CocInfo
```
## versions

vim version: NVIM v0.7.0
node version: v16.13.2
coc.nvim version: 0.0.81-883870c5 2022-05-27 05:07:03 +0800
coc.nvim directory: /home/rammiah/.local/share/nvim/site/pack/packer/start/coc.nvim
term: tmux
platform: linux

## Log of coc.nvim
2022-05-27T22:11:09.613 INFO (pid:1876850) [server] - file /home/rammiah/.config/coc/suggest.txt is open 
2022-05-27T22:11:09.634 INFO (pid:1876850) [services] - registered service "languageserver.golang"
2022-05-27T22:11:09.637 INFO (pid:1876850) [services] - golang state change: stopped => starting
2022-05-27T22:11:09.640 INFO (pid:1876850) [plugin] - coc.nvim initialized with node: v16.13.2 after 70ms
2022-05-27T22:11:09.646 INFO (pid:1876850) [language-client-index] - Language server "languageserver.golang" started with 1876961
2022-05-27T22:11:09.658 INFO (pid:1876850) [server] - file /home/rammiah/.config/coc/suggest.txt is close
2022-05-27T22:11:09.694 INFO (pid:1876850) [services] - golang state change: starting => running
2022-05-27T22:11:09.698 INFO (pid:1876850) [services] - service languageserver.golang started
2022-05-27T22:11:11.078 INFO (pid:1876850) [attach] - receive notification: openList [ 'diagnostics' ]
2022-05-27T22:11:11.081 INFO (pid:1876850) [server] - file /usr/share/datapool/code/go/example/hello.go is open 
2022-05-27T22:11:12.779 INFO (pid:1876850) [attach] - receive notification: openList [ 'diagnostics' ]
2022-05-27T22:11:12.784 INFO (pid:1876850) [server] - file /usr/share/datapool/code/go/example/hello.go is open 
2022-05-27T22:11:16.171 INFO (pid:1876850) [attach] - receive notification: showInfo []
2022-05-27T22:11:48.296 INFO (pid:1876850) [attach] - Request action: listNames []
2022-05-27T22:11:48.847 INFO (pid:1876850) [attach] - receive notification: openList [ 'diagnostics' ]
2022-05-27T22:11:48.887 INFO (pid:1876850) [server] - file /usr/share/datapool/code/go/example/hello.go is open 
2022-05-27T22:12:21.479 INFO (pid:1876850) [attach] - receive notification: showInfo []
```

file descritors
![image](https://user-images.githubusercontent.com/26727562/170717744-3674c3f4-afad-4cb7-9bee-77326e0d6640.png)

# Fixup

manually close the underlying stream.
CocInfo
```
## versions

vim version: NVIM v0.7.0
node version: v16.13.2
coc.nvim version: 0.0.81-36cea817 2022-05-27 21:36:07 +0800
coc.nvim directory: /home/rammiah/.local/share/nvim/site/pack/packer/start/coc.nvim
term: tmux
platform: linux

## Log of coc.nvim

2022-05-27T22:22:58.953 INFO (pid:1924746) [server] - file /home/rammiah/.config/coc/suggest.txt is open
2022-05-27T22:22:58.973 INFO (pid:1924746) [services] - registered service "languageserver.golang"
2022-05-27T22:22:58.976 INFO (pid:1924746) [services] - golang state change: stopped => starting
2022-05-27T22:22:58.978 INFO (pid:1924746) [plugin] - coc.nvim initialized with node: v16.13.2 after 63ms
2022-05-27T22:22:58.984 INFO (pid:1924746) [language-client-index] - Language server "languageserver.golang" started with 1924763
2022-05-27T22:22:58.996 INFO (pid:1924746) [server] - file /home/rammiah/.config/coc/suggest.txt is close
2022-05-27T22:22:59.032 INFO (pid:1924746) [services] - golang state change: starting => running
2022-05-27T22:22:59.037 INFO (pid:1924746) [services] - service languageserver.golang started
2022-05-27T22:23:00.900 INFO (pid:1924746) [attach] - receive notification: openList [ 'diagnostics' ]
2022-05-27T22:23:00.906 INFO (pid:1924746) [server] - file /usr/share/datapool/code/go/example/hello.go is open
2022-05-27T22:23:00.908 INFO (pid:1924746) [server] - file /usr/share/datapool/code/go/example/hello.go is close
2022-05-27T22:23:02.628 INFO (pid:1924746) [attach] - receive notification: openList [ 'diagnostics' ]
2022-05-27T22:23:02.635 INFO (pid:1924746) [server] - file /usr/share/datapool/code/go/example/hello.go is open
2022-05-27T22:23:02.638 INFO (pid:1924746) [server] - file /usr/share/datapool/code/go/example/hello.go is close
2022-05-27T22:23:08.887 INFO (pid:1924746) [attach] - receive notification: showInfo []
```

file descriptor
![image](https://user-images.githubusercontent.com/26727562/170719230-071fbde6-bec2-4c14-9c88-c3e986f91d0e.png)
