### PR TITLE
feat(workspaceFolder): support wildcard for bottomUpFiletypes

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -1071,7 +1071,7 @@
     "workspace.bottomUpFiletypes": {
       "type": "array",
       "default": [],
-      "description": "Filetypes that should have workspace folder should resolved from base directory of file.",
+      "description": "Filetypes that should have workspace folder should resolved from base directory of file, or [\"*\"] for any filetype.",
       "items": {
         "type": "string"
       }

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -1432,7 +1432,7 @@ Workspace related~
 "workspace.bottomUpFiletypes"				*coc-config-workspace-bottomUpFiletypes*
 
 	Filetypes that should have workspace folder should resolved from
-	base directory of file.
+	base directory of file, or `["*"]` for any filetype.
 
 	Default: []
 

--- a/src/__tests__/core/workspaceFolder.test.ts
+++ b/src/__tests__/core/workspaceFolder.test.ts
@@ -1,4 +1,5 @@
 import { Neovim } from '@chemzqm/neovim'
+import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import { Disposable, WorkspaceFoldersChangeEvent } from 'vscode-languageserver-protocol'
@@ -221,6 +222,35 @@ describe('WorkspaceFolderController', () => {
       let res = workspaceFolder.resolveRoot(doc, path.join(os.homedir(), 'foo'), true, expand)
       expect(res).toBe(null)
     })
+
+    describe('bottomUpFileTypes', () => {
+      it('should respect specific filetype', async () => {
+        updateConfiguration('coc.preferences.rootPatterns', ['.vim'], ['.git', '.hg', '.projections.json'])
+        updateConfiguration('workspace.bottomUpFiletypes', ['vim'], [])
+        let root = path.join(os.tmpdir(), 'a')
+        let dir = path.join(root, '.vim')
+        if (!fs.existsSync(dir)) fs.mkdirSync(dir, {recursive: true})
+        let file = path.join(dir, 'foo')
+        await nvim.command(`edit ${file}`)
+        await nvim.command('setf vim')
+        let doc = await workspace.document
+        let res = workspaceFolder.resolveRoot(doc, file, true, expand)
+        expect(res).toBe(root)
+      })
+
+      it('should respect wildcard', async () => {
+        updateConfiguration('coc.preferences.rootPatterns', ['.vim'], ['.git', '.hg', '.projections.json'])
+        updateConfiguration('workspace.bottomUpFiletypes', ['*'], [])
+        let root = path.join(os.tmpdir(), 'a')
+        let dir = path.join(root, '.vim')
+        if (!fs.existsSync(dir)) fs.mkdirSync(dir, {recursive: true})
+        let file = path.join(dir, 'foo')
+        await nvim.command(`edit ${file}`)
+        let doc = await workspace.document
+        let res = workspaceFolder.resolveRoot(doc, file, true, expand)
+        expect(res).toBe(root)
+      })
+    })
   })
 
   describe('renameWorkspaceFolder()', () => {
@@ -236,9 +266,7 @@ describe('WorkspaceFolderController', () => {
       expect(e.removed.length).toBe(1)
       expect(e.added.length).toBe(1)
     })
-  })
 
-  describe('removeWorkspaceFolder()', () => {
     it('should remote workspaceFolder', async () => {
       let e: WorkspaceFoldersChangeEvent
       disposables.push(workspaceFolder.onDidChangeWorkspaceFolders(ev => {

--- a/src/__tests__/core/workspaceFolder.test.ts
+++ b/src/__tests__/core/workspaceFolder.test.ts
@@ -229,7 +229,10 @@ describe('WorkspaceFolderController', () => {
         updateConfiguration('workspace.bottomUpFiletypes', ['vim'], [])
         let root = path.join(os.tmpdir(), 'a')
         let dir = path.join(root, '.vim')
-        if (!fs.existsSync(dir)) fs.mkdirSync(dir, {recursive: true})
+        if (!fs.existsSync(dir)) {
+          fs.mkdirSync(dir, {recursive: true})
+          await helper.wait(30)
+        }
         let file = path.join(dir, 'foo')
         await nvim.command(`edit ${file}`)
         await nvim.command('setf vim')
@@ -243,7 +246,10 @@ describe('WorkspaceFolderController', () => {
         updateConfiguration('workspace.bottomUpFiletypes', ['*'], [])
         let root = path.join(os.tmpdir(), 'a')
         let dir = path.join(root, '.vim')
-        if (!fs.existsSync(dir)) fs.mkdirSync(dir, {recursive: true})
+        if (!fs.existsSync(dir)) {
+          fs.mkdirSync(dir, {recursive: true})
+          await helper.wait(30)
+        }
         let file = path.join(dir, 'foo')
         await nvim.command(`edit ${file}`)
         let doc = await workspace.document

--- a/src/__tests__/core/workspaceFolder.test.ts
+++ b/src/__tests__/core/workspaceFolder.test.ts
@@ -272,7 +272,9 @@ describe('WorkspaceFolderController', () => {
       expect(e.removed.length).toBe(1)
       expect(e.added.length).toBe(1)
     })
+  })
 
+  describe('removeWorkspaceFolder()', () => {
     it('should remote workspaceFolder', async () => {
       let e: WorkspaceFoldersChangeEvent
       disposables.push(workspaceFolder.onDidChangeWorkspaceFolders(ev => {

--- a/src/core/workspaceFolder.ts
+++ b/src/core/workspaceFolder.ts
@@ -87,7 +87,7 @@ export default class WorkspaceFolderController {
     let dir = path.dirname(u.fsPath)
     let config = this.configurations.getConfiguration('workspace', document.uri)
     let ignoredFiletypes = config.get<string[]>('ignoredFiletypes', [])
-    let bottomUpFileTypes = config.get<string[]>('bottomUpFiletypes', [])
+    let bottomUpFiletypes = config.get<string[]>('bottomUpFiletypes', [])
     let checkCwd = config.get<boolean>('workspaceFolderCheckCwd', true)
     let ignored = config.get<string[]>('ignoredFolders', [])
     let fallbackCwd = config.get<boolean>('workspaceFolderFallbackCwd', true)
@@ -99,7 +99,7 @@ export default class WorkspaceFolderController {
     for (let patternType of types) {
       let patterns = this.getRootPatterns(document, patternType)
       if (patterns && patterns.length) {
-        let isBottomUp = bottomUpFileTypes.includes(document.filetype)
+        let isBottomUp = bottomUpFiletypes.includes('*') || bottomUpFiletypes.includes(document.filetype)
         let root = resolveRoot(dir, patterns, cwd, isBottomUp, checkCwd, ignored)
         if (root) {
           res = root


### PR DESCRIPTION
```json
{
    "workspace.workspaceFolderCheckCwd": false,
    "workspace.bottomUpFiletypes": ["*"],
}
```
is extremely useful for the git submodule to find a correct workspace.
