### PR TITLE
fix(files): workaround buffer name limitation on Windows (Neovim)

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -182,14 +182,10 @@ function! coc#util#jump(cmd, filepath, ...) abort
     else
       exec 'drop '.fnameescape(file)
     endif
-  elseif a:cmd == 'edit'
-    if bufloaded(file)
-      exe 'b '.bufnr(file)
-    else
-      exe a:cmd.' '.fnameescape(file)
-    endif
+  elseif a:cmd == 'edit' && bufloaded(file)
+    exe 'b '.bufnr(file)
   else
-    exe a:cmd.' '.fnameescape(file)
+    call s:safer_open(a:cmd, file)
   endif
   if !empty(get(a:, 1, []))
     let line = getline(a:1[0] + 1)
@@ -205,6 +201,40 @@ function! coc#util#jump(cmd, filepath, ...) abort
   endif
   if s:is_vim
     redraw
+  endif
+endfunction
+
+function! s:safer_open(cmd, file) abort
+  " How to support :pedit and :drop?
+  let is_supported_cmd = index(["edit", "split", "vsplit", "tabe"], a:cmd) >= 0
+
+  if is_supported_cmd && has('win32') && has('nvim')
+    if bufloaded(a:file)
+      let buf = bufnr(a:file)
+      " Do not reload existing buffer
+      let reload_buffer = v:false
+    else
+      " Workaround a bug for Win32 paths (works in Neovim only).
+      "
+      " reference:
+      " - https://github.com/vim/vim/issues/541
+      " - https://github.com/neoclide/coc-java/issues/82
+      let buf = nvim_create_buf(v:true, v:false)
+      " Ignore swap file error occuring when, for example, file is a URI.
+      silent! call nvim_buf_set_name(buf, a:file)
+      let reload_buffer = v:true
+    endif
+    if a:cmd != 'edit'
+      " Open split, tab, etc. by a:cmd.
+      exe a:cmd
+    endif
+    " Set filename and reload file (or URI) contents by :edit.
+    exe 'keepjumps buffer ' . buf
+    if reload_buffer
+      exe 'keepjumps edit'
+    endif
+  else
+    exe a:cmd.' '.fnameescape(a:file)
   endif
 endfunction
 

--- a/src/core/files.ts
+++ b/src/core/files.ts
@@ -110,7 +110,7 @@ export default class Files {
         let bufname = fixDriver(path.normalize(fsPath))
         await this.nvim.call('coc#util#jump', [jumpCommand, bufname, pos])
       } else {
-        if (os.platform() == 'win32') {
+        if (nvim.isVim && os.platform() == 'win32') {
           uri = uri.replace(/\/?/, '?')
         }
         await this.nvim.call('coc#util#jump', [jumpCommand, uri, pos])


### PR DESCRIPTION
On Windows, due to Vim's bug, you can't correctly `fnameescape()`
special characters in buffer name.
(reference: https://github.com/vim/vim/issues/541)

Therefore, you can't open a buffer whose name contains some special
character with `:edit`, preventing correctly jump to definition in some
LSPs. For example, jdtls returns custom URI (jdt://...) if the
definition is inside metadata. This URI contains `?`, so it can't be
opened in Windows (https://github.com/neoclide/coc-java/issues/82).

I found that you can workaround this bug using Neovim API to set a
buffer name directly, though it's Neovim-only solution.

Fixes #2748.