### PR TITLE
fix(files): Workaround Windows path limitation on Vim too

### DIFF
--- a/src/core/files.ts
+++ b/src/core/files.ts
@@ -110,9 +110,6 @@ export default class Files {
         let bufname = fixDriver(path.normalize(fsPath))
         await this.nvim.call('coc#util#jump', [jumpCommand, bufname, pos])
       } else {
-        if (nvim.isVim && os.platform() == 'win32') {
-          uri = uri.replace(/\/?/, '?')
-        }
         await this.nvim.call('coc#util#jump', [jumpCommand, uri, pos])
       }
     }


### PR DESCRIPTION
This improves the workaround introduced in #3904 and #3907. The previous
implementation is using Neovim-only API, but new implementation uses
`bufadd()` to create the buffer with specified name, so it works on Vim
too.

With quick testing, it seems that new implementation works without issue
like #3906 even if non-URI like path was given, so you may not have to
check it looks like URI, but keep it for now to reduce the risk of
potential breakage.

Sorry for sending a patch again and again.