### PR TITLE
Add: Smart-case functionality and ignore-case to CocList fuzzy search

### DIFF
--- a/src/__tests__/list/manager.test.ts
+++ b/src/__tests__/list/manager.test.ts
@@ -137,7 +137,7 @@ describe('list', () => {
         input: 'test',
         interactive: false,
         matcher: 'strict',
-        ignorecase: true,
+        caseOption: "ignore-case",
         position: 'top',
         mode: 'normal',
         noQuit: false,

--- a/src/__tests__/list/worker.test.ts
+++ b/src/__tests__/list/worker.test.ts
@@ -223,4 +223,30 @@ describe('list worker', () => {
     await helper.wait(300)
     expect(manager.isActivated).toBe(false)
   })
+
+
+  it('should be able to filter by fuzzy smartcase', async () => {
+    items = [{
+      label: 'fooBar',
+    }, {
+      label: 'FooBar',
+    }]
+    disposables.push(manager.registerList(new DataList(nvim)))
+    await manager.start(['--smart-case','data'])
+    await manager.session.ui.ready
+    await nvim.input('F')
+    await helper.wait(50)
+    let buf = await nvim.buffer
+    let lines = await buf.lines
+    expect(lines).toEqual(['FooBar'])
+
+    await nvim.input('<c-u>')
+    await nvim.input('f')
+    await helper.wait(50)
+    buf = await nvim.buffer
+    lines = await buf.lines
+    expect(lines).toEqual([ 'fooBar', 'FooBar'])
+    await manager.cancel()
+  })
+
 })

--- a/src/list/manager.ts
+++ b/src/list/manager.ts
@@ -24,6 +24,7 @@ import ServicesList from './source/services'
 import SourcesList from './source/sources'
 import SymbolsList from './source/symbols'
 import stripAnsi from 'strip-ansi'
+import { CaseOption } from '../types';
 const logger = require('../util/logger')('list-manager')
 
 const mouseKeys = ['<LeftMouse>', '<LeftDrag>', '<LeftRelease>', '<2-LeftMouse>']
@@ -226,6 +227,7 @@ export class ListManager implements Disposable {
     let name: string
     let input = ''
     let matcher: Matcher = 'fuzzy'
+    let caseOption : CaseOption = "sensitive"
     let position = 'bottom'
     let listArgs: string[] = []
     let listOptions: string[] = []
@@ -246,6 +248,7 @@ export class ListManager implements Disposable {
     let config = workspace.getConfiguration(`list.source.${name}`)
     if (!listOptions.length && !listArgs.length) listOptions = config.get<string[]>('defaultOptions', [])
     if (!listArgs.length) listArgs = config.get<string[]>('defaultArgs', [])
+
     for (let opt of listOptions) {
       if (opt.startsWith('--input')) {
         input = opt.slice(8)
@@ -263,7 +266,9 @@ export class ListManager implements Disposable {
         position = 'top'
       } else if (opt == '--tab') {
         position = 'tab'
-      } else if (opt == '--ignore-case' || opt == '--normal' || opt == '--no-sort') {
+      } else if (opt == "--ignore-case" || opt == "--smart-case" ) {
+        caseOption = opt.slice(2) as CaseOption
+      } else if ( opt == '--normal' || opt == '--no-sort') {
         options.push(opt.slice(2))
       } else if (opt == '--first') {
         first = true
@@ -298,7 +303,8 @@ export class ListManager implements Disposable {
         interactive,
         matcher,
         position,
-        ignorecase: options.includes('ignore-case') ? true : false,
+        // ignorecase: options.includes('ignore-case') ? true : false,
+        caseOption,
         mode: !options.includes('normal') ? 'insert' : 'normal',
         sort: !options.includes('no-sort') ? true : false
       },

--- a/src/list/worker.ts
+++ b/src/list/worker.ts
@@ -235,8 +235,6 @@ export default class Worker {
 
   private async filterItemsByInclude(inputs: string[], items: ListItem[], token: CancellationToken, onFilter: OnFilter): Promise<void> {
     let { caseOption } = this.listOptions
-    logger.info("filterItemsByInclude", caseOption)
-    // TODO 04/07/20 psacawa: handle smart case
     let ignorecase  = caseOption === "ignore-case" || (caseOption === "smart-case" && ! this.hasUppercaseInputs(inputs))
     if (ignorecase) inputs = inputs.map(s => s.toLowerCase())
     await filter(items, item => {
@@ -259,7 +257,6 @@ export default class Worker {
 
   private async filterItemsByRegex(inputs: string[], items: ListItem[], token: CancellationToken, onFilter: OnFilter): Promise<void> {
     let {caseOption}  = this.listOptions
-    logger.info("filterItemsByRegex", this.listOptions.caseOption)
     let ignorecase  = caseOption === "ignore-case" || (caseOption === "smart-case" && ! this.hasUppercaseInputs(inputs))
     let flags = ignorecase ? 'iu' : 'u'
     let regexes = inputs.reduce((p, c) => {
@@ -288,7 +285,6 @@ export default class Worker {
 
   private async filterItemsByFuzzyMatch(inputs: string[], items: ListItem[], token: CancellationToken, onFilter: OnFilter): Promise<void> {
     let { sort, caseOption } = this.listOptions
-    logger.info("filterItemsByFuzzyMatch", this.listOptions.caseOption)
     let ignorecase  = caseOption === "ignore-case" || (caseOption === "smart-case" && ! this.hasUppercaseInputs(inputs))
     let idx = 0
     await filter(items, item => {
@@ -319,7 +315,6 @@ export default class Worker {
   }
 
   private async filterItems(arr: ListItem[], opts: FilterOption, token: CancellationToken): Promise<void> {
-    // logger.info("filterItems", this.listOptions)
     let { input } = this
     if (input.length === 0) {
       let items = arr.map(item => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1057,11 +1057,14 @@ export type ListMode = 'normal' | 'insert'
 
 export type Matcher = 'strict' | 'fuzzy' | 'regex'
 
+// smart case means case-insensitive if there are no capitals, otherwise sensitive
+export type CaseOption = 'normal-case' |  'ignore-case' | "smart-case"
+
 export interface ListOptions {
   position: string
   reverse: boolean
   input: string
-  ignorecase: boolean
+  caseOption: CaseOption
   interactive: boolean
   sort: boolean
   mode: ListMode

--- a/src/util/fzy.ts
+++ b/src/util/fzy.ts
@@ -190,9 +190,11 @@ export function positions(needle: string, haystack: string): number[] {
   return positions
 }
 
-export function hasMatch(needle: string, haystack: string): boolean {
-  needle = needle.toLowerCase()
-  haystack = haystack.toLowerCase()
+export function hasMatch(needle: string, haystack: string, ignoreCase: boolean): boolean {
+  if (ignoreCase) {
+    needle = needle.toLowerCase()
+    haystack = haystack.toLowerCase()
+  }
   let l = needle.length
   for (let i = 0, j = 0; i < l; i += 1) {
     j = haystack.indexOf(needle[i], j) + 1


### PR DESCRIPTION
"Smart-case" search means that if the search term is all lowercase, then
the search will be case-insensitive. If there is any upper-case
character, then the search is case-sensitive. Therefore,

"Foo" doesn't match "fooBar", but
"foob" does match "FooBar", and
"FooB" does match "FooBar".

At the moment, no tests.

Available via e.g.

```
CocList --smart-case outline
```

`ListOptions` interface is modified to achieve this.

**Demo**
[![asciicast](https://asciinema.org/a/bv3y7LGrMY4hPu2bu3b8Br6qa.svg)](https://asciinema.org/a/bv3y7LGrMY4hPu2bu3b8Br6qa)