### PR TITLE
fix(compose_hlgroup): check hlGroup if is cleared

### DIFF
--- a/autoload/coc/highlight.vim
+++ b/autoload/coc/highlight.vim
@@ -421,7 +421,7 @@ function! coc#highlight#compose_hlgroup(fgGroup, bgGroup) abort
   if a:fgGroup ==# a:bgGroup
     return a:fgGroup
   endif
-  if hlexists(hlGroup) && match(execute('hi '.hlGroup, 'silent!'), 'cleared') ==# -1
+  if hlexists(hlGroup) && match(execute('hi '.hlGroup, 'silent!'), 'cleared') == -1
     return hlGroup
   endif
   let fgId = synIDtrans(hlID(a:fgGroup))

--- a/autoload/coc/highlight.vim
+++ b/autoload/coc/highlight.vim
@@ -421,7 +421,7 @@ function! coc#highlight#compose_hlgroup(fgGroup, bgGroup) abort
   if a:fgGroup ==# a:bgGroup
     return a:fgGroup
   endif
-  if hlexists(hlGroup)
+  if hlexists(hlGroup) && match(execute('hi '.hlGroup, 'silent!'), 'cleared') ==# -1
     return hlGroup
   endif
   let fgId = synIDtrans(hlID(a:fgGroup))


### PR DESCRIPTION
Sometimes changing the theme will cause the highlighting to be cleared. I don't know if there is a better way to check, if so then close this pr