### PR TITLE
Set minimum for col_start highlights to 0

### DIFF
--- a/autoload/coc/notify.vim
+++ b/autoload/coc/notify.vim
@@ -166,7 +166,7 @@ function! coc#notify#create(lines, config) abort
     let height = height + 1
   endif
   if !empty(actions)
-    let before = width - strwidth(actionText)
+    let before = max([width - strwidth(actionText), 0])
     let lines = lines + [repeat(' ', before).actionText]
     let height = height + 1
     call s:add_action_highlights(before, height - 1, highlights, actions)


### PR DESCRIPTION
This can throw an error when less than 0, due to [this check](https://github.com/neovim/neovim/blob/feba56af7d032c948a78c21735502bebe45f8361/src/nvim/api/extmark.c#L876-L878) in Neovim.

Error message looks like:
```
2022-07-29T14:28:26.870 ERROR (pid:128515) [node-client] - request error on "nvim_call_function" [
  'coc#notify#create',
  [
    [ 'Select how LSP should resolve this macro:' ],
    {
      broder: true,
      focusable: true,
      marginRight: 10,
      timeout: 10000,
      maxWidth: 60,
      maxHeight: 10,
      highlight: 'CocFloating',
      winblend: 30,
      disabled: false,
      source: 'coc.nvim',
      kind: 'info',
      borderhighlight: 'CocNotificationInfo',
      actions: [Array]
    }
  ]
] Vim(call):E5555: API call: Column value outside range Error: 
    at NeovimClient2.request (/home/noah/personal/coc.nvim/node_modules/@chemzqm/neovim/lib/api/Base.js:29:21)
    at NeovimClient2.call (/home/noah/personal/coc.nvim/node_modules/@chemzqm/neovim/lib/api/Neovim.js:186:21)
    at Notification.show (/home/noah/personal/coc.nvim/src/model/notification.ts:84:26)
    at /home/noah/personal/coc.nvim/src/window.ts:832:20
    at new Promise (<anonymous>)
    at Window.createNotification (/home/noah/personal/coc.nvim/src/window.ts:820:12)
    at Window._showMessage (/home/noah/personal/coc.nvim/src/window.ts:610:26)
    at Window.showInformationMessage (/home/noah/personal/coc.nvim/src/window.ts:567:23)
    at /home/noah/personal/coc.nvim/src/language-client/client.ts:3644:18
    at handleRequest (/home/noah/personal/coc.nvim/node_modules/vscode-jsonrpc/lib/common/connection.js:44
```

Found while researching #3951.