### PR TITLE
fix(pum): fix regex pattern on keymapping check

### DIFF
--- a/autoload/coc/ui.vim
+++ b/autoload/coc/ui.vim
@@ -8,7 +8,7 @@ let s:sign_groups = []
 function! coc#ui#check_pum_keymappings() abort
   let keys = []
   for key in ['<cr>', '<tab>']
-    if maparg(key, 'i') =~# 'pumvisible()'
+    if maparg(key, 'i') =~# '\<pumvisible()'
       call add(keys, key)
     endif
   endfor


### PR DESCRIPTION
The previous pattern accidentally matched with "safe_pumvisible()"
or similar so I prepend "\<" to clarify the word.

```vim
  function! s:safe_pumvisible() abort
    try
      return coc#pum#visible()
    catch /^Vim\%((\a\+)\)\=:E117:/
      return pumvisible()
    endtry
  endfunction
  inoremap <expr> <CR> <SID>safe_pumvisible() ? ....
```