### PR TITLE
fix(pum): fix coc#pum#next first tab select wrong line

### DIFF
--- a/autoload/coc/pum.vim
+++ b/autoload/coc/pum.vim
@@ -351,8 +351,9 @@ function! coc#pum#create(lines, opt, config) abort
     let firstline = s:get_firstline(lnum, len(a:lines), config['height'])
     call coc#compat#execute(s:pum_winid, 'call winrestview({"lnum":'.lnum.',"topline":'.firstline.'})')
   endif
-  let s:pum_index = get(config, 'index', -1)
-  call coc#dialog#place_sign(s:pum_bufnr, s:pum_index + 1)
+  let index = get(config, 'index', -1)
+  let s:pum_index = index - 1
+  call coc#dialog#place_sign(s:pum_bufnr, index + 1)
   call setwinvar(s:pum_winid, 'kind', 'pum')
   " content before col and content after cursor
   let linetext = getline('.')


### PR DESCRIPTION
Version 0.0.82.
After the completion pops up, enter the tab key will select the second line by mistake.

Related configs
```
" Use <tab> and <S-tab> to navigate completion list: >

function! s:check_back_space() abort
  let col = col('.') - 1
  return !col || getline('.')[col - 1]  =~ '\s'
endfunction

" Insert <tab> when previous text is space, refresh completion if not.
inoremap <silent><expr> <TAB>
  \ coc#pum#visible() ? coc#pum#next(1):
  \ <SID>check_back_space() ? "\<Tab>" :
  \ coc#refresh()
inoremap <expr><S-TAB> coc#pum#visible() ? coc#pum#prev(1) : "\<C-h>"

" Use <c-space> to trigger completion: >

if has('nvim')
  inoremap <silent><expr> <c-space> coc#refresh()
else
  inoremap <silent><expr> <c-@> coc#refresh()
endif
" Use <CR> to confirm completion, use: >

inoremap <expr> <cr> coc#pum#visible() ? coc#_select_confirm() : "\<CR>"
" To make <CR> to confirm selection of selected complete item or notify coc.nvim to format on enter, use: >
inoremap <silent><expr> <CR> coc#pum#visible() ? coc#_select_confirm()
				\: "\<C-g>u\<CR>\<c-r>=coc#on_enter()\<CR>"
```


