### PR TITLE
fix(ui): Consider multigrid UI for float window placement

### DIFF
--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -995,7 +995,8 @@ function! coc#float#nvim_scroll_adjust(winid) abort
       for winid in winids
         if nvim_win_is_valid(winid)
           if coc#window#get_var(winid, 'kind', '') != 'close'
-            let [row, column] = nvim_win_get_position(winid)
+            let config = nvim_win_get_config(winid)
+            let [row, column] = [config.row, config.col]
             call nvim_win_set_config(winid, {
                   \ 'row': row,
                   \ 'col': column - 1,


### PR DESCRIPTION
The current implementation of the tooltip position associated with pum is not displayed in the correct position in the Neovim GUI that supports multigrid ui. 
This fix resolves this issue.

The following is related information on this issue.

https://github.com/neovim/neovim/issues/11935
Yggdroot/LeaderF#501
https://github.com/neoclide/coc.nvim/pull/3150