### PR TITLE
fix(signature): fix activeParameter

### DIFF
--- a/src/handler/signature.ts
+++ b/src/handler/signature.ts
@@ -135,11 +135,12 @@ export default class Signature {
 
   private async showSignatureHelp(doc: Document, position: Position, signatureHelp: SignatureHelp, offset: number): Promise<void> {
     let { signatures, activeParameter } = signatureHelp
+    activeParameter = typeof activeParameter === 'number' ? activeParameter : undefined
     let paramDoc: string | MarkupContent = null
     let startOffset = offset
     let docs = signatures.reduce((p, c, idx) => {
       let activeIndexes: [number, number] = null
-      let activeIndex = c.activeParameter ?? typeof activeParameter === 'number' ? activeParameter : undefined
+      let activeIndex = c.activeParameter ?? activeParameter
       if (activeIndex === undefined && c.parameters?.length > 0) {
         activeIndex = 0
       }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -381,6 +381,14 @@ declare module 'coc.nvim' {
      * The parameters of this signature.
      */
     parameters?: ParameterInformation[]
+    /**
+     * The index of the active parameter.
+     *
+     * If provided, this is used in place of `SignatureHelp.activeParameter`.
+     *
+     * @since 3.16.0
+     */
+    activeParameter?: number;
   }
 
   /**


### PR DESCRIPTION
`??` has higher precedence than `? :`