### PR TITLE
Refactor language client

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,9 +115,9 @@
     "unidecode": "^0.1.8",
     "unzip-stream": "^0.3.1",
     "uuid": "^7.0.3",
-    "vscode-languageserver-protocol": "^3.17.1",
-    "vscode-languageserver-textdocument": "^1.0.4",
-    "vscode-languageserver-types": "^3.17.1",
+    "vscode-languageserver-protocol": "^3.17.2",
+    "vscode-languageserver-textdocument": "^1.0.5",
+    "vscode-languageserver-types": "^3.17.2",
     "vscode-uri": "^3.0.3",
     "which": "^2.0.2"
   }

--- a/src/__tests__/client/changedFiles.test.ts
+++ b/src/__tests__/client/changedFiles.test.ts
@@ -58,5 +58,4 @@ describe('Client integration', () => {
       done(e)
     })
   })
-
 })

--- a/src/__tests__/client/converter.test.ts
+++ b/src/__tests__/client/converter.test.ts
@@ -24,7 +24,7 @@ describe('converter', () => {
 
   it('should asChangeTextDocumentParams', () => {
     let doc = createDocument()
-    expect(cv.asChangeTextDocumentParams(doc).textDocument.uri).toBe(doc.uri)
+    expect(cv.asFullChangeTextDocumentParams(doc).textDocument.uri).toBe(doc.uri)
   })
 
   it('should asWillSaveTextDocumentParams', () => {
@@ -89,10 +89,10 @@ describe('converter', () => {
   it('Completion Result - edit range', async () => {
     const completionResult: CompletionList = {
       isIncomplete: true,
-      itemDefaults:  { editRange: Range.create(1,2,3,4) },
+      itemDefaults: { editRange: Range.create(1, 2, 3, 4) },
       items: [{ label: 'item', data: 'data' }]
     }
-    const result = cv.asCompletionList(completionResult)
+    const result = await cv.asCompletionList(completionResult)
     assert.strictEqual(result.isIncomplete, completionResult.isIncomplete)
     assert.strictEqual(result.items.length, 1)
     assert.strictEqual(result.items[0].label, 'item')
@@ -101,10 +101,10 @@ describe('converter', () => {
   it('Completion Result - edit range with textEditText', async () => {
     const completionResult: CompletionList = {
       isIncomplete: true,
-      itemDefaults:  { editRange: Range.create(1,2,3,4) },
+      itemDefaults: { editRange: Range.create(1, 2, 3, 4) },
       items: [{ label: 'item', textEditText: 'text', data: 'data' }]
     }
-    const result = cv.asCompletionList(completionResult)
+    const result = await cv.asCompletionList(completionResult)
     assert.strictEqual(result.isIncomplete, completionResult.isIncomplete)
     assert.strictEqual(result.items.length, 1)
     assert.strictEqual(result.items[0].label, 'item')
@@ -114,10 +114,10 @@ describe('converter', () => {
   it('Completion Result - insert / replace range', async () => {
     const completionResult: CompletionList = {
       isIncomplete: true,
-      itemDefaults: { editRange: { insert: Range.create(1,1,1,1), replace: Range.create(1,2,3,4) } },
+      itemDefaults: { editRange: { insert: Range.create(1, 1, 1, 1), replace: Range.create(1, 2, 3, 4) } },
       items: [{ label: 'item', data: 'data' }]
     }
-    const result = cv.asCompletionList(completionResult)
+    const result = await cv.asCompletionList(completionResult)
     assert.strictEqual(result.isIncomplete, completionResult.isIncomplete)
     assert.strictEqual(result.items.length, 1)
     assert.strictEqual(result.items[0].label, 'item')
@@ -127,10 +127,10 @@ describe('converter', () => {
   it('Completion Result - insert / replace range with textEditText', async () => {
     const completionResult: CompletionList = {
       isIncomplete: true,
-      itemDefaults: { editRange: { insert: Range.create(1,1,1,1), replace: Range.create(1,2,3,4) } },
+      itemDefaults: { editRange: { insert: Range.create(1, 1, 1, 1), replace: Range.create(1, 2, 3, 4) } },
       items: [{ label: 'item', textEditText: 'text', data: 'data' }]
     }
-    const result = cv.asCompletionList(completionResult)
+    const result = await cv.asCompletionList(completionResult)
     assert.strictEqual(result.isIncomplete, completionResult.isIncomplete)
     assert.strictEqual(result.items.length, 1)
     assert.strictEqual(result.items[0].label, 'item')
@@ -140,10 +140,10 @@ describe('converter', () => {
   it('Completion Result - commit characters', async () => {
     const completionResult: CompletionList = {
       isIncomplete: true,
-      itemDefaults: { commitCharacters: ['.', ',']},
+      itemDefaults: { commitCharacters: ['.', ','] },
       items: [{ label: 'item', data: 'data' }]
     }
-    const result = cv.asCompletionList(completionResult)
+    const result = await cv.asCompletionList(completionResult)
     assert.strictEqual(result.isIncomplete, completionResult.isIncomplete)
     assert.strictEqual(result.items.length, 1)
     assert.strictEqual(result.items[0].label, 'item')
@@ -159,7 +159,7 @@ describe('converter', () => {
       itemDefaults: { insertTextMode: InsertTextMode.asIs },
       items: [{ label: 'item', data: 'data' }]
     }
-    const result = cv.asCompletionList(completionResult)
+    const result = await cv.asCompletionList(completionResult)
     assert.strictEqual(result.isIncomplete, completionResult.isIncomplete)
     assert.strictEqual(result.items.length, 1)
     assert.strictEqual(result.items[0].label, 'item')
@@ -172,10 +172,10 @@ describe('converter', () => {
       itemDefaults: { insertTextFormat: InsertTextFormat.Snippet },
       items: [{ label: 'item', insertText: '${value}', data: 'data' }]
     }
-    const result = cv.asCompletionList(completionResult)
+    const result = await cv.asCompletionList(completionResult)
     assert.strictEqual(result.isIncomplete, completionResult.isIncomplete)
     assert.strictEqual(result.items.length, 1)
     assert.strictEqual(result.items[0].label, 'item')
-    assert.strictEqual(result.items[0].insertTextFormat , InsertTextFormat.Snippet)
+    assert.strictEqual(result.items[0].insertTextFormat, InsertTextFormat.Snippet)
   })
 })

--- a/src/language-client/callHierarchy.ts
+++ b/src/language-client/callHierarchy.ts
@@ -1,17 +1,11 @@
 'use strict'
-/* --------------------------------------------------------------------------------------------
- * Copyright (c) Microsoft Corporation. All rights reserved.
- * Licensed under the MIT License. See License.txt in the project root for license information.
- * ------------------------------------------------------------------------------------------ */
-'use strict'
-
 import {
   CallHierarchyClientCapabilities, CallHierarchyIncomingCall, CallHierarchyIncomingCallsRequest, CallHierarchyItem, CallHierarchyOptions, CallHierarchyOutgoingCall, CallHierarchyOutgoingCallsRequest, CallHierarchyPrepareRequest, CallHierarchyRegistrationOptions, CancellationToken, ClientCapabilities, Disposable, DocumentSelector, Position, ServerCapabilities
 } from 'vscode-languageserver-protocol'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import languages from '../languages'
 import { CallHierarchyProvider, ProviderResult } from '../provider'
-import { BaseLanguageClient, ensure, TextDocumentFeature } from './client'
+import { TextDocumentLanguageFeature, FeatureClient, ensure } from './features'
 import { asTextDocumentPositionParams } from './utils/converter'
 
 export interface PrepareCallHierarchySignature {
@@ -37,8 +31,8 @@ export interface CallHierarchyMiddleware {
   provideCallHierarchyOutgoingCalls?: (this: void, item: CallHierarchyItem, token: CancellationToken, next: CallHierarchyOutgoingCallsSignature) => ProviderResult<CallHierarchyOutgoingCall[]>
 }
 
-export class CallHierarchyFeature extends TextDocumentFeature<boolean | CallHierarchyOptions, CallHierarchyRegistrationOptions, CallHierarchyProvider> {
-  constructor(client: BaseLanguageClient) {
+export class CallHierarchyFeature extends TextDocumentLanguageFeature<boolean | CallHierarchyOptions, CallHierarchyRegistrationOptions, CallHierarchyProvider, CallHierarchyMiddleware> {
+  constructor(client: FeatureClient<CallHierarchyMiddleware>) {
     super(client, CallHierarchyPrepareRequest.type)
   }
 
@@ -70,7 +64,7 @@ export class CallHierarchyFeature extends TextDocumentFeature<boolean | CallHier
           )
         }
 
-        const middleware = client.clientOptions.middleware
+        const middleware = client.middleware
         return middleware.prepareCallHierarchy
           ? middleware.prepareCallHierarchy(document, position, token, prepareCallHierarchy)
           : prepareCallHierarchy(document, position, token)
@@ -87,7 +81,7 @@ export class CallHierarchyFeature extends TextDocumentFeature<boolean | CallHier
           )
         }
 
-        const middleware = client.clientOptions.middleware
+        const middleware = client.middleware
         return middleware.provideCallHierarchyIncomingCalls
           ? middleware.provideCallHierarchyIncomingCalls(item, token, provideCallHierarchyIncomingCalls)
           : provideCallHierarchyIncomingCalls(item, token)
@@ -104,7 +98,7 @@ export class CallHierarchyFeature extends TextDocumentFeature<boolean | CallHier
           )
         }
 
-        const middleware = client.clientOptions.middleware
+        const middleware = client.middleware
         return middleware.provideCallHierarchyOutgoingCalls
           ? middleware.provideCallHierarchyOutgoingCalls(item, token, provideCallHierarchyOutgoingCalls)
           : provideCallHierarchyOutgoingCalls(item, token)

--- a/src/language-client/client.ts
+++ b/src/language-client/client.ts
@@ -1,139 +1,62 @@
 'use strict'
-/* ---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
-/* eslint-disable */
+import debounce from 'debounce'
+import os from 'os'
 import path from 'path'
-import { ApplyWorkspaceEditParams, CompletionItemTag, ApplyWorkspaceEditRequest, ApplyWorkspaceEditResponse, CancellationToken, ClientCapabilities, CodeAction, CodeActionContext, CodeActionKind, CodeActionOptions, CodeActionParams, CodeActionRegistrationOptions, CodeActionRequest, CodeLens, CodeLensOptions, CodeLensRegistrationOptions, CodeLensRequest, CodeLensResolveRequest, Command, CompletionContext, CompletionItem, CompletionItemKind, CompletionList, CompletionOptions, CompletionRegistrationOptions, CompletionRequest, CompletionResolveRequest, createProtocolConnection, DeclarationRequest, Definition, DefinitionOptions, DefinitionRegistrationOptions, DefinitionRequest, Diagnostic, DiagnosticSeverity, DiagnosticTag, DidChangeConfigurationNotification, DidChangeConfigurationParams, DidChangeConfigurationRegistrationOptions, DidChangeTextDocumentNotification, DidChangeTextDocumentParams, DidChangeWatchedFilesNotification, DidChangeWatchedFilesParams, DidChangeWatchedFilesRegistrationOptions, DidCloseTextDocumentNotification, DidCloseTextDocumentParams, DidOpenTextDocumentNotification, DidOpenTextDocumentParams, DidSaveTextDocumentNotification, DidSaveTextDocumentParams, Disposable, DocumentColorRequest, DocumentFormattingOptions, DocumentFormattingParams, DocumentFormattingRequest, DocumentHighlight, DocumentHighlightOptions, DocumentHighlightRegistrationOptions, DocumentHighlightRequest, DocumentLink, DocumentLinkOptions, DocumentLinkRegistrationOptions, DocumentLinkRequest, DocumentLinkResolveRequest, DocumentOnTypeFormattingOptions, DocumentOnTypeFormattingParams, DocumentOnTypeFormattingRegistrationOptions, DocumentOnTypeFormattingRequest, DocumentRangeFormattingOptions, DocumentRangeFormattingParams, DocumentRangeFormattingRegistrationOptions, DocumentRangeFormattingRequest, DocumentSelector, DocumentSymbol, DocumentSymbolOptions, DocumentSymbolRegistrationOptions, DocumentSymbolRequest, Emitter, Event, ExecuteCommandParams, ExecuteCommandRegistrationOptions, ExecuteCommandRequest, ExitNotification, FailureHandlingKind, FileChangeType, FileEvent, FoldingRangeRequest, FormattingOptions, GenericNotificationHandler, GenericRequestHandler, Hover, HoverOptions, HoverRegistrationOptions, HoverRequest, ImplementationRequest, InitializedNotification, InitializeError, InitializeParams, InitializeRequest, InitializeResult, Location, Logger, LogMessageNotification, LogMessageParams, MarkupKind, Message, MessageReader, MessageType, MessageWriter, NotificationHandler, NotificationHandler0, NotificationType, NotificationType0, Position, PrepareRenameRequest, ProgressToken, ProgressType, PublishDiagnosticsNotification, PublishDiagnosticsParams, Range, ReferenceOptions, ReferenceRegistrationOptions, ReferencesRequest, RegistrationParams, RegistrationRequest, RenameOptions, RenameParams, RenameRegistrationOptions, RenameRequest, RequestHandler, RequestHandler0, RequestType, RequestType0, ResourceOperationKind, ResponseError, SelectionRangeRequest, ServerCapabilities, ShowMessageNotification, ShowMessageParams, ShowMessageRequest, ShutdownRequest, SignatureHelp, SignatureHelpOptions, SignatureHelpRegistrationOptions, SignatureHelpRequest, StaticRegistrationOptions, SymbolInformation, SymbolKind, SymbolTag, TelemetryEventNotification, TextDocumentChangeRegistrationOptions, TextDocumentEdit, TextDocumentPositionParams, TextDocumentRegistrationOptions, TextDocumentSaveRegistrationOptions, TextDocumentSyncKind, TextDocumentSyncOptions, TextEdit, Trace, TraceFormat, TraceOptions, Tracer, TypeDefinitionRequest, UnregistrationParams, UnregistrationRequest, WatchKind, WillSaveTextDocumentNotification, WillSaveTextDocumentParams, WillSaveTextDocumentWaitUntilRequest, WorkDoneProgressOptions, WorkspaceEdit, WorkspaceFolder, WorkspaceSymbolRequest, SignatureHelpContext, WorkDoneProgressBegin, WorkDoneProgressEnd, WorkDoneProgressReport, WorkDoneProgress, DefinitionLink, ProtocolRequestType0, ProtocolRequestType, MessageSignature, ProtocolNotificationType0, ProtocolNotificationType, RegistrationType, LSPErrorCodes, SaveOptions, CancellationStrategy, CallHierarchyPrepareRequest, SemanticTokensRegistrationType, CodeActionResolveRequest, CodeLensRefreshRequest, ShowDocumentParams, ShowDocumentRequest, ShowDocumentResult, InsertTextMode, LinkedEditingRangeRequest, DidCreateFilesNotification, FileOperationRegistrationOptions, DidRenameFilesNotification, DidDeleteFilesNotification, WillCreateFilesRequest, WillRenameFilesRequest, WillDeleteFilesRequest, ShowMessageRequestParams, MessageActionItem, InlayHintRequest, TypeHierarchyPrepareRequest, InlineValueRequest, DocumentDiagnosticRequest, SemanticTokensRequest, SemanticTokensRangeRequest, SemanticTokensDeltaRequest } from 'vscode-languageserver-protocol'
+import { ApplyWorkspaceEditParams, ApplyWorkspaceEditRequest, ApplyWorkspaceEditResult, CallHierarchyPrepareRequest, CancellationStrategy, CancellationToken, ClientCapabilities, CodeActionRequest, CodeLensRequest, CompletionRequest, createProtocolConnection, DeclarationRequest, DefinitionRequest, Diagnostic, DiagnosticSeverity, DiagnosticTag, DidChangeTextDocumentNotification, DidChangeWatchedFilesNotification, DidCloseTextDocumentNotification, DidCreateFilesNotification, DidDeleteFilesNotification, DidOpenTextDocumentNotification, DidRenameFilesNotification, DidSaveTextDocumentNotification, Disposable, DocumentColorRequest, DocumentDiagnosticRequest, DocumentFormattingRequest, DocumentHighlightRequest, DocumentLinkRequest, DocumentOnTypeFormattingRequest, DocumentRangeFormattingRequest, DocumentSelector, DocumentSymbolRequest, Emitter, ErrorCodes, Event, ExitNotification, FailureHandlingKind, FileEvent, FileOperationRegistrationOptions, FoldingRangeRequest, GenericNotificationHandler, GenericRequestHandler, HoverRequest, ImplementationRequest, InitializedNotification, InitializeParams, InitializeRequest, InitializeResult, InlayHintRequest, InlineValueRequest, LinkedEditingRangeRequest, Logger, LogMessageNotification, LSPErrorCodes, MarkupKind, Message, MessageActionItem, MessageReader, MessageSignature, MessageType, MessageWriter, NotificationHandler, NotificationHandler0, NotificationType, NotificationType0, PositionEncodingKind, ProgressToken, ProgressType, ProtocolNotificationType, ProtocolNotificationType0, ProtocolRequestType, ProtocolRequestType0, PublishDiagnosticsNotification, PublishDiagnosticsParams, ReferencesRequest, RegistrationParams, RegistrationRequest, RenameRequest, RequestHandler, RequestHandler0, RequestType, RequestType0, ResourceOperationKind, ResponseError, SelectionRangeRequest, SemanticTokensDeltaRequest, SemanticTokensRangeRequest, SemanticTokensRegistrationType, SemanticTokensRequest, ServerCapabilities, ShowDocumentParams, ShowDocumentRequest, ShowDocumentResult, ShowMessageNotification, ShowMessageRequest, ShowMessageRequestParams, ShutdownRequest, SignatureHelpRequest, TelemetryEventNotification, TextDocumentEdit, TextDocumentRegistrationOptions, TextDocumentSyncKind, TextDocumentSyncOptions, TextEdit, Trace, TraceFormat, TraceOptions, Tracer, TypeDefinitionRequest, TypeHierarchyPrepareRequest, UnregistrationParams, UnregistrationRequest, WillCreateFilesRequest, WillDeleteFilesRequest, WillRenameFilesRequest, WillSaveTextDocumentNotification, WillSaveTextDocumentWaitUntilRequest, WorkDoneProgress, WorkDoneProgressBegin, WorkDoneProgressEnd, WorkDoneProgressReport, WorkspaceEdit, WorkspaceSymbolRequest } from 'vscode-languageserver-protocol'
 import { TextDocument } from "vscode-languageserver-textdocument"
 import { URI } from 'vscode-uri'
-import commands from '../commands'
+import DiagnosticCollection from '../diagnostic/collection'
 import languages from '../languages'
-import { ConfigurationChangeEvent, FileSystemWatcher as FileWatcher } from '../types'
-import { CallHierarchyProvider, CodeActionProvider, CodeLensProvider, CompletionItemProvider, DeclarationProvider, DefinitionProvider, DiagnosticProvider, DocumentColorProvider, DocumentFormattingEditProvider, DocumentHighlightProvider, DocumentLinkProvider, DocumentRangeFormattingEditProvider, DocumentSymbolProvider, FoldingRangeProvider, HoverProvider, ImplementationProvider, LinkedEditingRangeProvider, OnTypeFormattingEditProvider, ProviderResult, ReferenceProvider, RenameProvider, SelectionRangeProvider, SignatureHelpProvider, TypeDefinitionProvider, TypeHierarchyProvider, WorkspaceSymbolProvider } from '../provider'
-import { FileCreateEvent, FileDeleteEvent, FileRenameEvent, FileWillCreateEvent, FileWillDeleteEvent, FileWillRenameEvent, OutputChannel, TextDocumentWillSaveEvent, Thenable, MessageItem } from '../types'
+import { CallHierarchyProvider, CodeActionProvider, CompletionItemProvider, DeclarationProvider, DefinitionProvider, DocumentColorProvider, DocumentFormattingEditProvider, DocumentHighlightProvider, DocumentLinkProvider, DocumentRangeFormattingEditProvider, DocumentSymbolProvider, FoldingRangeProvider, HoverProvider, ImplementationProvider, LinkedEditingRangeProvider, OnTypeFormattingEditProvider, ProviderResult, ReferenceProvider, RenameProvider, SelectionRangeProvider, SignatureHelpProvider, TypeDefinitionProvider, TypeHierarchyProvider, WorkspaceSymbolProvider } from '../provider'
+import { FileCreateEvent, FileDeleteEvent, FileRenameEvent, FileSystemWatcher as FileWatcher, FileWillCreateEvent, FileWillDeleteEvent, FileWillRenameEvent, MessageItem, OutputChannel, Thenable } from '../types'
 import { resolveRoot, sameFile } from '../util/fs'
 import * as Is from '../util/is'
-import { omit } from '../util/lodash'
-import { mergeConfigProperties } from '../configuration/util'
-import DiagnosticCollection from '../diagnostic/collection'
+import { comparePosition } from '../util/position'
 import window from '../window'
 import workspace from '../workspace'
-import sources from '../sources'
-import { CallHierarchyMiddleware } from './callHierarchy'
-import { ColorProviderMiddleware } from './colorProvider'
-import { ConfigurationWorkspaceMiddleware } from './configuration'
-import { DeclarationMiddleware } from './declaration'
-import { FoldingRangeProviderMiddleware } from './foldingRange'
-import { ImplementationMiddleware } from './implementation'
+import { CallHierarchyFeature, CallHierarchyMiddleware } from './callHierarchy'
+import { CodeActionFeature, CodeActionMiddleware } from './codeAction'
+import { CodeLensFeature, CodeLensMiddleware, CodeLensProviderShape } from './codeLens'
+import { ColorProviderFeature, ColorProviderMiddleware } from './colorProvider'
+import { $CompletionOptions, CompletionItemFeature, CompletionMiddleware } from './completion'
+import { $ConfigurationOptions, ConfigurationMiddleware, PullConfigurationFeature, SyncConfigurationFeature } from './configuration'
+import { DeclarationFeature, DeclarationMiddleware } from './declaration'
+import { DefinitionFeature, DefinitionMiddleware } from './definition'
+import { $DiagnosticPullOptions, DiagnosticFeature, DiagnosticProviderMiddleware, DiagnosticProviderShape } from './diagnostic'
+import { DocumentHighlightFeature, DocumentHighlightMiddleware } from './documentHighlight'
+import { DocumentLinkFeature, DocumentLinkMiddleware } from './documentLink'
+import { DocumentSymbolFeature, DocumentSymbolMiddleware } from './documentSymbol'
+import { ExecuteCommandFeature, ExecuteCommandMiddleware } from './executeCommand'
+import { Connection, DynamicFeature, ensure, FeatureClient, RegistrationData, StaticFeature, TextDocumentProviderFeature, TextDocumentSendFeature } from './features'
+import { DidCreateFilesFeature, DidDeleteFilesFeature, DidRenameFilesFeature, FileOperationsMiddleware, WillCreateFilesFeature, WillDeleteFilesFeature, WillRenameFilesFeature } from './fileOperations'
+import { FileSystemWatcherFeature } from './fileSystemWatcher'
+import { FoldingRangeFeature, FoldingRangeProviderMiddleware } from './foldingRange'
+import { $FormattingOptions, DocumentFormattingFeature, DocumentOnTypeFormattingFeature, DocumentRangeFormattingFeature, FormattingMiddleware } from './formatting'
+import { HoverFeature, HoverMiddleware } from './hover'
+import { ImplementationFeature, ImplementationMiddleware } from './implementation'
+import { InlayHintsFeature, InlayHintsMiddleware, InlayHintsProviderShape } from './inlayHint'
+import { InlineValueFeature, InlineValueMiddleware, InlineValueProviderShape } from './inlineValue'
+import { LinkedEditingFeature, LinkedEditingRangeMiddleware } from './linkedEditingRange'
+import { ProgressFeature } from './progress'
 import { ProgressPart } from './progressPart'
-import { SelectionRangeProviderMiddleware } from './selectionRange'
-import { SemanticTokensMiddleware, SemanticTokensProviders } from './semanticTokens'
-import { TypeDefinitionMiddleware } from './typeDefinition'
-import { FileOperationsMiddleware } from './fileOperations'
-import { Delayer } from './utils/async'
-import os from 'os'
+import { ReferencesFeature, ReferencesMiddleware } from './reference'
+import { RenameFeature, RenameMiddleware } from './rename'
+import { SelectionRangeFeature, SelectionRangeProviderMiddleware } from './selectionRange'
+import { SemanticTokensFeature, SemanticTokensMiddleware, SemanticTokensProviderShape } from './semanticTokens'
+import { SignatureHelpFeature, SignatureHelpMiddleware } from './signatureHelp'
+import { DidChangeTextDocumentFeature, DidChangeTextDocumentFeatureShape, DidCloseTextDocumentFeature, DidCloseTextDocumentFeatureShape, DidOpenTextDocumentFeature, DidOpenTextDocumentFeatureShape, DidSaveTextDocumentFeature, DidSaveTextDocumentFeatureShape, ResolvedTextDocumentSyncCapabilities, TextDocumentSynchronizationMiddleware, WillSaveFeature, WillSaveWaitUntilFeature } from './textSynchronization'
+import { TypeDefinitionFeature, TypeDefinitionMiddleware } from './typeDefinition'
+import { TypeHierarchyFeature, TypeHierarchyMiddleware } from './typeHierarchy'
 import * as cv from './utils/converter'
+import { CloseAction, DefaultErrorHandler, ErrorAction, ErrorHandler, InitializationFailedHandler } from './utils/errorHandler'
+import { ConsoleLogger, NullLogger } from './utils/logger'
 import * as UUID from './utils/uuid'
-import { WorkspaceFolderWorkspaceMiddleware } from './workspaceFolders'
-import { InlayHintsMiddleware, InlayHintsProviderShape } from './inlayHint'
-import { InlineValueMiddleware, InlineValueProviderShape } from './inlineValue'
-import { TypeHierarchyMiddleware } from './typeHierarchy'
-import { LinkedEditingRangeMiddleware } from './linkedEditingRange'
-import { WorkspaceSymbolMiddleware } from './workspaceSymbol'
-import { comparePosition } from '../util/position'
-import { disposeAll } from '../util'
-import { DiagnosticProviderMiddleware, DiagnosticProviderShape, DiagnosticPullOptions } from './diagnostic'
+import { $WorkspaceOptions, WorkspaceFolderMiddleware, WorkspaceFoldersFeature } from './workspaceFolders'
+import { WorkspaceProviderFeature, WorkspaceSymbolFeature, WorkspaceSymbolMiddleware } from './workspaceSymbol'
 
 const logger = require('../util/logger')('language-client-client')
 
-interface IConnection {
-  listen(): void
-  unlisten(): void
-
-  sendRequest<R, PR, E, RO>(type: ProtocolRequestType0<R, PR, E, RO>, token?: CancellationToken): Promise<R>
-  sendRequest<P, R, PR, E, RO>(type: ProtocolRequestType<P, R, PR, E, RO>, params: P, token?: CancellationToken): Promise<R>
-  sendRequest<R, E>(type: RequestType0<R, E>, token?: CancellationToken): Promise<R>
-  sendRequest<P, R, E>(type: RequestType<P, R, E>, params: P, token?: CancellationToken): Promise<R>
-  sendRequest<R>(method: string, token?: CancellationToken): Promise<R>
-  sendRequest<R>(method: string, param: any, token?: CancellationToken): Promise<R>
-  sendRequest<R>(type: string | MessageSignature, ...params: any[]): Promise<R>
-
-  onRequest<R, PR, E, RO>(type: ProtocolRequestType0<R, PR, E, RO>, handler: RequestHandler0<R, E>): Disposable
-  onRequest<P, R, PR, E, RO>(type: ProtocolRequestType<P, R, PR, E, RO>, handler: RequestHandler<P, R, E>): Disposable
-  onRequest<R, E>(type: RequestType0<R, E>, handler: RequestHandler0<R, E>): Disposable
-  onRequest<P, R, E>(type: RequestType<P, R, E>, handler: RequestHandler<P, R, E>): Disposable
-  onRequest<R, E>(method: string, handler: GenericRequestHandler<R, E>): Disposable
-  onRequest<R, E>(method: string | MessageSignature, handler: GenericRequestHandler<R, E>): Disposable
-
-  sendNotification<RO>(type: ProtocolNotificationType0<RO>): void
-  sendNotification<P, RO>(type: ProtocolNotificationType<P, RO>, params?: P): void
-  sendNotification(type: NotificationType0): void
-  sendNotification<P>(type: NotificationType<P>, params?: P): void
-  sendNotification(method: string): void
-  sendNotification(method: string, params: any): void
-  sendNotification(method: string | MessageSignature, params?: any): void
-
-  onNotification<RO>(type: ProtocolNotificationType0<RO>, handler: NotificationHandler0): Disposable
-  onNotification<P, RO>(type: ProtocolNotificationType<P, RO>, handler: NotificationHandler<P>): Disposable
-  onNotification(type: NotificationType0, handler: NotificationHandler0): Disposable
-  onNotification<P>(type: NotificationType<P>, handler: NotificationHandler<P>): Disposable
-  onNotification(method: string, handler: GenericNotificationHandler): Disposable
-  onNotification(method: string | MessageSignature, handler: GenericNotificationHandler): Disposable
-
-  onProgress<P>(type: ProgressType<P>, token: string | number, handler: NotificationHandler<P>): Disposable
-  sendProgress<P>(type: ProgressType<P>, token: string | number, value: P): void
-
-  trace(value: Trace, tracer: Tracer, sendNotification?: boolean): void
-  trace(value: Trace, tracer: Tracer, traceOptions?: TraceOptions): void
-
-  initialize(params: InitializeParams): Promise<InitializeResult>
-  shutdown(): Promise<void>
-  exit(): void
-
-  onLogMessage(handle: NotificationHandler<LogMessageParams>): void
-  onShowMessage(handler: NotificationHandler<ShowMessageParams>): void
-  onTelemetry(handler: NotificationHandler<any>): void
-
-  didChangeConfiguration(params: DidChangeConfigurationParams): void
-  didChangeWatchedFiles(params: DidChangeWatchedFilesParams): void
-
-  didOpenTextDocument(params: DidOpenTextDocumentParams): void
-  didChangeTextDocument(params: DidChangeTextDocumentParams): void
-  didCloseTextDocument(params: DidCloseTextDocumentParams): void
-  didSaveTextDocument(params: DidSaveTextDocumentParams): void
-  onDiagnostics(handler: NotificationHandler<PublishDiagnosticsParams>): void
-
-  end(): void
-  dispose(): void
-}
-
-class ConsoleLogger implements Logger {
-  public error(message: string): void {
-    logger.error(message)
-  }
-  public warn(message: string): void {
-    logger.warn(message)
-  }
-  public info(message: string): void {
-    logger.info(message)
-  }
-  public log(message: string): void {
-    logger.log(message)
-  }
-}
-
-export class NullLogger implements Logger {
-  error(_message: string): void {
-  }
-  warn(_message: string): void {
-  }
-  info(_message: string): void {
-  }
-  log(_message: string): void {
-  }
-}
+export { ErrorAction, CloseAction, NullLogger }
 
 interface ConnectionErrorHandler {
   (error: Error, message: Message | undefined, count: number | undefined): void
@@ -148,202 +71,68 @@ interface ConnectionOptions {
   maxRestartCount?: number
 }
 
-function createConnection(
-  inputStream: NodeJS.ReadableStream,
-  outputStream: NodeJS.WritableStream,
-  errorHandler: ConnectionErrorHandler,
-  closeHandler: ConnectionCloseHandler,
-  options?: ConnectionOptions
-): IConnection
-function createConnection(
-  reader: MessageReader,
-  writer: MessageWriter,
-  errorHandler: ConnectionErrorHandler,
-  closeHandler: ConnectionCloseHandler,
-  options?: ConnectionOptions
-): IConnection
-function createConnection(
-  input: any,
-  output: any,
-  errorHandler: ConnectionErrorHandler,
-  closeHandler: ConnectionCloseHandler,
-  options?: ConnectionOptions
-): IConnection {
+function createConnection(input: MessageReader, output: MessageWriter, errorHandler: ConnectionErrorHandler, closeHandler: ConnectionCloseHandler, options?: ConnectionOptions): Connection {
   let logger = new ConsoleLogger()
   let connection = createProtocolConnection(input, output, logger, options)
-  let disposables: Disposable[] = []
-  connection.onError(data => {
-    errorHandler(data[0], data[1], data[2])
-  }, null, disposables)
-  connection.onClose(closeHandler, null, disposables)
-  let result: IConnection = {
-    listen: (): void => connection.listen(),
-    unlisten: (): void => {
-      disposeAll(disposables)
+  let _lastUsed = -1
+  // let disposables: Disposable[] = []
+  connection.onError(data => { errorHandler(data[0], data[1], data[2]) })
+  connection.onClose(closeHandler)
+  let result: Connection = {
+    get lastUsed(): number {
+      return _lastUsed
     },
-
-    sendRequest: <R>(type: string | MessageSignature, ...params: any[]): Promise<R> => connection.sendRequest(Is.string(type) ? type : type.method, ...params),
+    resetLastUsed: (): void => {
+      _lastUsed = -1
+    },
+    hasPendingResponse: (): boolean => connection.hasPendingResponse(),
+    listen: (): void => connection.listen(),
+    sendRequest: <R>(type: string | MessageSignature, ...params: any[]): Promise<R> => {
+      _lastUsed = Date.now()
+      return connection.sendRequest(Is.string(type) ? type : type.method, ...params)
+    },
     onRequest: <R, E>(type: string | MessageSignature, handler: GenericRequestHandler<R, E>): Disposable => connection.onRequest(Is.string(type) ? type : type.method, handler),
-
-    sendNotification: (type: string | MessageSignature, params?: any): void => void connection.sendNotification(Is.string(type) ? type : type.method, params),
+    sendNotification: (type: string | MessageSignature, params?: any): Promise<void> => {
+      _lastUsed = Date.now()
+      return connection.sendNotification(Is.string(type) ? type : type.method, params)
+    },
     onNotification: (type: string | MessageSignature, handler: GenericNotificationHandler): Disposable => connection.onNotification(Is.string(type) ? type : type.method, handler),
 
     onProgress: connection.onProgress,
     sendProgress: connection.sendProgress,
-
     trace: (
       value: Trace,
       tracer: Tracer,
       sendNotificationOrTraceOptions?: boolean | TraceOptions
-    ): void => {
+    ): Promise<void> => {
       const defaultTraceOptions: TraceOptions = {
         sendNotification: false,
         traceFormat: TraceFormat.Text
       }
-
       if (sendNotificationOrTraceOptions === undefined) {
-        connection.trace(value, tracer, defaultTraceOptions)
+        return connection.trace(value, tracer, defaultTraceOptions)
       } else if (Is.boolean(sendNotificationOrTraceOptions)) {
-        connection.trace(value, tracer, sendNotificationOrTraceOptions)
+        return connection.trace(value, tracer, sendNotificationOrTraceOptions)
       } else {
-        connection.trace(value, tracer, sendNotificationOrTraceOptions)
+        return connection.trace(value, tracer, sendNotificationOrTraceOptions)
       }
     },
-
-    initialize: (params: InitializeParams) =>
-      connection.sendRequest(InitializeRequest.type, params),
-    shutdown: () => connection.sendRequest(ShutdownRequest.type, undefined),
-    exit: () => connection.sendNotification(ExitNotification.type),
-
-    onLogMessage: (handler: NotificationHandler<LogMessageParams>) =>
-      connection.onNotification(LogMessageNotification.type, handler),
-    onShowMessage: (handler: NotificationHandler<ShowMessageParams>) =>
-      connection.onNotification(ShowMessageNotification.type, handler),
-    onTelemetry: (handler: NotificationHandler<any>) =>
-      connection.onNotification(TelemetryEventNotification.type, handler),
-
-    didChangeConfiguration: (params: DidChangeConfigurationParams) =>
-      connection.sendNotification(
-        DidChangeConfigurationNotification.type,
-        params
-      ),
-    didChangeWatchedFiles: (params: DidChangeWatchedFilesParams) =>
-      connection.sendNotification(
-        DidChangeWatchedFilesNotification.type,
-        params
-      ),
-
-    didOpenTextDocument: (params: DidOpenTextDocumentParams) =>
-      connection.sendNotification(DidOpenTextDocumentNotification.type, params),
-    didChangeTextDocument: (params: DidChangeTextDocumentParams) =>
-      connection.sendNotification(
-        DidChangeTextDocumentNotification.type,
-        params
-      ),
-    didCloseTextDocument: (params: DidCloseTextDocumentParams) =>
-      connection.sendNotification(
-        DidCloseTextDocumentNotification.type,
-        params
-      ),
-    didSaveTextDocument: (params: DidSaveTextDocumentParams) =>
-      connection.sendNotification(DidSaveTextDocumentNotification.type, params),
-
-    onDiagnostics: (handler: NotificationHandler<PublishDiagnosticsParams>) =>
-      connection.onNotification(PublishDiagnosticsNotification.type, handler),
-
+    initialize: (params: InitializeParams) => {
+      _lastUsed = Date.now()
+      return connection.sendRequest(InitializeRequest.type, params)
+    },
+    shutdown: () => {
+      _lastUsed = Date.now()
+      return connection.sendRequest(ShutdownRequest.type, undefined)
+    },
+    exit: () => {
+      _lastUsed = Date.now()
+      return connection.sendNotification(ExitNotification.type)
+    },
     end: () => connection.end(),
     dispose: () => connection.dispose()
   }
-
   return result
-}
-
-/**
- * An action to be performed when the connection is producing errors.
- */
-export enum ErrorAction {
-  /**
-   * Continue running the server.
-   */
-  Continue = 1,
-  /**
-   * Shutdown the server.
-   */
-  Shutdown = 2
-}
-
-/**
- * An action to be performed when the connection to a server got closed.
- */
-export enum CloseAction {
-  /**
-   * Don't restart the server. The connection stays closed.
-   */
-  DoNotRestart = 1,
-  /**
-   * Restart the server.
-   */
-  Restart = 2
-}
-
-/**
- * A pluggable error handler that is invoked when the connection is either
- * producing errors or got closed.
- */
-export interface ErrorHandler {
-  /**
-   * An error has occurred while writing or reading from the connection.
-   *
-   * @param error - the error received
-   * @param message - the message to be delivered to the server if know.
-   * @param count - a count indicating how often an error is received. Will
-   *  be reset if a message got successfully send or received.
-   */
-  error(error: Error, message: Message | undefined, count: number | undefined): ErrorAction
-
-  /**
-   * The connection to the server got closed.
-   */
-  closed(): CloseAction
-}
-
-class DefaultErrorHandler implements ErrorHandler {
-  private readonly restarts: number[]
-
-  constructor(private name: string, private maxRestartCount: number) {
-    this.restarts = []
-  }
-
-  public error(_error: Error, _message: Message, count: number): ErrorAction {
-    if (count && count <= 3) {
-      return ErrorAction.Continue
-    }
-    return ErrorAction.Shutdown
-  }
-  public closed(): CloseAction {
-    this.restarts.push(Date.now())
-    if (this.restarts.length < this.maxRestartCount) {
-      return CloseAction.Restart
-    } else {
-      let diff = this.restarts[this.restarts.length - 1] - this.restarts[0]
-      if (diff <= 3 * 60 * 1000) {
-        window.showMessage(`The "${this.name}" server crashed ${this.maxRestartCount} times in the last 3 minutes. The server will not be restarted.`, 'error')
-        return CloseAction.DoNotRestart
-      } else {
-        this.restarts.shift()
-        return CloseAction.Restart
-      }
-    }
-  }
-}
-
-export interface InitializationFailedHandler {
-  (error: ResponseError<InitializeError> | Error | any): boolean
-}
-
-export interface SynchronizeOptions {
-  configurationSection?: string | string[]
-  fileEvents?: FileWatcher | FileWatcher[]
 }
 
 export enum RevealOutputChannelOn {
@@ -361,153 +150,6 @@ export interface HandleDiagnosticsSignature {
   (this: void, uri: string, diagnostics: Diagnostic[]): void
 }
 
-export interface ProvideCompletionItemsSignature {
-  (
-    this: void,
-    document: TextDocument,
-    position: Position,
-    context: CompletionContext,
-    token: CancellationToken,
-  ): ProviderResult<CompletionItem[] | CompletionList>
-}
-
-export interface ResolveCompletionItemSignature {
-  (this: void, item: CompletionItem, token: CancellationToken): ProviderResult<CompletionItem>
-}
-
-export interface ProvideHoverSignature {
-  (
-    this: void,
-    document: TextDocument,
-    position: Position,
-    token: CancellationToken
-  ): ProviderResult<Hover>
-}
-
-export interface ProvideSignatureHelpSignature {
-  (
-    this: void,
-    document: TextDocument,
-    position: Position,
-    context: SignatureHelpContext,
-    token: CancellationToken
-  ): ProviderResult<SignatureHelp>
-}
-
-export interface ProvideDefinitionSignature {
-  (
-    this: void,
-    document: TextDocument,
-    position: Position,
-    token: CancellationToken
-  ): ProviderResult<Definition | DefinitionLink[]>
-}
-
-export interface ProvideReferencesSignature {
-  (
-    this: void,
-    document: TextDocument,
-    position: Position,
-    options: { includeDeclaration: boolean },
-    token: CancellationToken
-  ): ProviderResult<Location[]>
-}
-
-export interface ProvideDocumentHighlightsSignature {
-  (
-    this: void,
-    document: TextDocument,
-    position: Position,
-    token: CancellationToken
-  ): ProviderResult<DocumentHighlight[]>
-}
-
-export interface ProvideDocumentSymbolsSignature {
-  (this: void, document: TextDocument, token: CancellationToken): ProviderResult<SymbolInformation[] | DocumentSymbol[]>
-}
-
-export interface ProvideCodeActionsSignature {
-  (
-    this: void,
-    document: TextDocument,
-    range: Range,
-    context: CodeActionContext,
-    token: CancellationToken
-  ): ProviderResult<(Command | CodeAction)[]>
-}
-
-export interface ResolveCodeActionSignature {
-  (this: void, item: CodeAction, token: CancellationToken): ProviderResult<CodeAction>
-}
-
-export interface ProvideCodeLensesSignature {
-  (this: void, document: TextDocument, token: CancellationToken): ProviderResult<CodeLens[]>
-}
-
-export interface ResolveCodeLensSignature {
-  (this: void, codeLens: CodeLens, token: CancellationToken): ProviderResult<CodeLens>
-}
-
-export interface ProvideDocumentFormattingEditsSignature {
-  (
-    this: void,
-    document: TextDocument,
-    options: FormattingOptions,
-    token: CancellationToken
-  ): ProviderResult<TextEdit[]>
-}
-
-export interface ProvideDocumentRangeFormattingEditsSignature {
-  (
-    this: void,
-    document: TextDocument,
-    range: Range,
-    options: FormattingOptions,
-    token: CancellationToken
-  ): ProviderResult<TextEdit[]>
-}
-
-export interface ProvideOnTypeFormattingEditsSignature {
-  (
-    this: void,
-    document: TextDocument,
-    position: Position,
-    ch: string,
-    options: FormattingOptions,
-    token: CancellationToken
-  ): ProviderResult<TextEdit[]>
-}
-
-export interface PrepareRenameSignature {
-  (this: void, document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Range | { range: Range, placeholder: string }>
-}
-
-export interface ProvideRenameEditsSignature {
-  (
-    this: void,
-    document: TextDocument,
-    position: Position,
-    newName: string,
-    token: CancellationToken
-  ): ProviderResult<WorkspaceEdit>
-}
-
-export interface ProvideDocumentLinksSignature {
-  (this: void, document: TextDocument, token: CancellationToken): ProviderResult<DocumentLink[]>
-}
-
-export interface ResolveDocumentLinkSignature {
-  (this: void, link: DocumentLink, token: CancellationToken): ProviderResult<DocumentLink>
-}
-
-export interface ExecuteCommandSignature {
-  (this: void, command: string, args: any[]): ProviderResult<any>
-}
-
-export interface NextSignature<P, R> {
-  (this: void, data: P, next: (data: P) => R): R
-}
-
 export interface DidChangeConfigurationSignature {
   (this: void, sections: string[] | undefined): void
 }
@@ -522,214 +164,48 @@ export interface _WorkspaceMiddleware {
     sections: string[] | undefined,
     next: DidChangeConfigurationSignature
   ) => void
-  didChangeWatchedFile?: (this: void, event: FileEvent, next: DidChangeWatchedFileSignature) => void
+  didChangeWatchedFile?: (this: void, event: FileEvent, next: DidChangeWatchedFileSignature) => Promise<void>
 }
 
-export type WorkspaceMiddleware = _WorkspaceMiddleware & ConfigurationWorkspaceMiddleware & WorkspaceFolderWorkspaceMiddleware & FileOperationsMiddleware
+export type WorkspaceMiddleware = _WorkspaceMiddleware & ConfigurationMiddleware & WorkspaceFolderMiddleware & FileOperationsMiddleware
 
 export interface _WindowMiddleware {
   showDocument?: (this: void, params: ShowDocumentParams, next: ShowDocumentRequest.HandlerSignature) => Promise<ShowDocumentResult>
 }
-
-export type WindowMiddleware = _WindowMiddleware
 
 /**
  * The Middleware lets extensions intercept the request and notifications send and received
  * from the server
  */
 export interface _Middleware {
-  didOpen?: NextSignature<TextDocument, void>
-  didChange?: NextSignature<DidChangeTextDocumentParams, void>
-  willSave?: NextSignature<TextDocumentWillSaveEvent, void>
-  willSaveWaitUntil?: NextSignature<
-    TextDocumentWillSaveEvent,
-    Thenable<TextEdit[]>
-  >
-  didSave?: NextSignature<TextDocument, void>
-  didClose?: NextSignature<TextDocument, void>
-
-  handleDiagnostics?: (
-    this: void,
-    uri: string,
-    diagnostics: Diagnostic[],
-    next: HandleDiagnosticsSignature
-  ) => void
-  provideCompletionItem?: (
-    this: void,
-    document: TextDocument,
-    position: Position,
-    context: CompletionContext,
-    token: CancellationToken,
-    next: ProvideCompletionItemsSignature
-  ) => ProviderResult<CompletionItem[] | CompletionList>
-  resolveCompletionItem?: (
-    this: void,
-    item: CompletionItem,
-    token: CancellationToken,
-    next: ResolveCompletionItemSignature
-  ) => ProviderResult<CompletionItem>
-  provideHover?: (
-    this: void,
-    document: TextDocument,
-    position: Position,
-    token: CancellationToken,
-    next: ProvideHoverSignature
-  ) => ProviderResult<Hover>
-  provideSignatureHelp?: (
-    this: void,
-    document: TextDocument,
-    position: Position,
-    context: SignatureHelpContext,
-    token: CancellationToken,
-    next: ProvideSignatureHelpSignature
-  ) => ProviderResult<SignatureHelp>
-  provideDefinition?: (
-    this: void,
-    document: TextDocument,
-    position: Position,
-    token: CancellationToken,
-    next: ProvideDefinitionSignature
-  ) => ProviderResult<Definition | DefinitionLink[]>
-  provideReferences?: (
-    this: void,
-    document: TextDocument,
-    position: Position,
-    options: { includeDeclaration: boolean },
-    token: CancellationToken,
-    next: ProvideReferencesSignature
-  ) => ProviderResult<Location[]>
-  provideDocumentHighlights?: (
-    this: void,
-    document: TextDocument,
-    position: Position,
-    token: CancellationToken,
-    next: ProvideDocumentHighlightsSignature
-  ) => ProviderResult<DocumentHighlight[]>
-  provideDocumentSymbols?: (
-    this: void,
-    document: TextDocument,
-    token: CancellationToken,
-    next: ProvideDocumentSymbolsSignature
-  ) => ProviderResult<SymbolInformation[] | DocumentSymbol[]>
-  provideCodeActions?: (
-    this: void,
-    document: TextDocument,
-    range: Range,
-    context: CodeActionContext,
-    token: CancellationToken,
-    next: ProvideCodeActionsSignature
-  ) => ProviderResult<(Command | CodeAction)[]>
-  handleWorkDoneProgress?: (
-    this: void,
-    token: ProgressToken,
-    params: WorkDoneProgressBegin | WorkDoneProgressReport | WorkDoneProgressEnd, next: HandleWorkDoneProgressSignature
-  ) => void
-  resolveCodeAction?: (
-    this: void,
-    item: CodeAction,
-    token: CancellationToken,
-    next: ResolveCodeActionSignature
-  ) => ProviderResult<CodeAction>
-  provideCodeLenses?: (
-    this: void,
-    document: TextDocument,
-    token: CancellationToken,
-    next: ProvideCodeLensesSignature
-  ) => ProviderResult<CodeLens[]>
-  resolveCodeLens?: (
-    this: void,
-    codeLens: CodeLens,
-    token: CancellationToken,
-    next: ResolveCodeLensSignature
-  ) => ProviderResult<CodeLens>
-  provideDocumentFormattingEdits?: (
-    this: void,
-    document: TextDocument,
-    options: FormattingOptions,
-    token: CancellationToken,
-    next: ProvideDocumentFormattingEditsSignature
-  ) => ProviderResult<TextEdit[]>
-  provideDocumentRangeFormattingEdits?: (
-    this: void,
-    document: TextDocument,
-    range: Range,
-    options: FormattingOptions,
-    token: CancellationToken,
-    next: ProvideDocumentRangeFormattingEditsSignature
-  ) => ProviderResult<TextEdit[]>
-  provideOnTypeFormattingEdits?: (
-    this: void,
-    document: TextDocument,
-    position: Position,
-    ch: string,
-    options: FormattingOptions,
-    token: CancellationToken,
-    next: ProvideOnTypeFormattingEditsSignature
-  ) => ProviderResult<TextEdit[]>
-  prepareRename?: (
-    this: void, document: TextDocument,
-    position: Position,
-    token: CancellationToken,
-    next: PrepareRenameSignature
-  ) => ProviderResult<Range | { range: Range, placeholder: string }>
-  provideRenameEdits?: (
-    this: void,
-    document: TextDocument,
-    position: Position,
-    newName: string,
-    token: CancellationToken,
-    next: ProvideRenameEditsSignature
-  ) => ProviderResult<WorkspaceEdit>
-  provideDocumentLinks?: (
-    this: void,
-    document: TextDocument,
-    token: CancellationToken,
-    next: ProvideDocumentLinksSignature
-  ) => ProviderResult<DocumentLink[]>
-  resolveDocumentLink?: (
-    this: void,
-    link: DocumentLink,
-    token: CancellationToken,
-    next: ResolveDocumentLinkSignature
-  ) => ProviderResult<DocumentLink>
-  executeCommand?: (
-    this: void,
-    command: string,
-    args: any[],
-    next: ExecuteCommandSignature
-  ) => ProviderResult<any>
+  handleDiagnostics?: (this: void, uri: string, diagnostics: Diagnostic[], next: HandleDiagnosticsSignature) => void
+  handleWorkDoneProgress?: (this: void, token: ProgressToken, params: WorkDoneProgressBegin | WorkDoneProgressReport | WorkDoneProgressEnd, next: HandleWorkDoneProgressSignature) => void
   workspace?: WorkspaceMiddleware
-  window?: WindowMiddleware
+  window?: _WindowMiddleware
 }
 
-export type Middleware = _Middleware &
-  TypeDefinitionMiddleware &
-  ImplementationMiddleware &
-  ColorProviderMiddleware &
-  DeclarationMiddleware &
-  FoldingRangeProviderMiddleware &
-  CallHierarchyMiddleware &
-  SemanticTokensMiddleware &
-  InlayHintsMiddleware &
-  InlineValueMiddleware &
-  TypeHierarchyMiddleware &
-  WorkspaceSymbolMiddleware &
-  DiagnosticProviderMiddleware &
-  LinkedEditingRangeMiddleware &
+export type Middleware = _Middleware & TextDocumentSynchronizationMiddleware & SignatureHelpMiddleware & ReferencesMiddleware &
+  DefinitionMiddleware & DocumentHighlightMiddleware & DocumentSymbolMiddleware & DocumentLinkMiddleware &
+  CodeActionMiddleware & FormattingMiddleware & RenameMiddleware & CodeLensMiddleware &
+  HoverMiddleware & CompletionMiddleware & ExecuteCommandMiddleware & TypeDefinitionMiddleware &
+  ImplementationMiddleware & ColorProviderMiddleware & DeclarationMiddleware &
+  FoldingRangeProviderMiddleware & CallHierarchyMiddleware & SemanticTokensMiddleware &
+  InlayHintsMiddleware & InlineValueMiddleware & TypeHierarchyMiddleware &
+  WorkspaceSymbolMiddleware & DiagnosticProviderMiddleware & LinkedEditingRangeMiddleware &
   SelectionRangeProviderMiddleware
 
-export interface LanguageClientOptions {
-  ignoredRootPaths?: string[]
+export type LanguageClientOptions = {
+  rootPatterns?: string[]
+  requireRootPattern?: boolean
   documentSelector?: DocumentSelector | string[]
-  synchronize?: SynchronizeOptions
+  separateDiagnostics?: boolean
+  disableMarkdown?: boolean
   disableWorkspaceFolders?: boolean
   disableDiagnostics?: boolean
   disableCompletion?: boolean
   diagnosticCollectionName?: string
   disableDynamicRegister?: boolean
-  disableSnippetCompletion?: boolean
   disabledFeatures?: string[]
-  formatterPriority?: number
   outputChannelName?: string
   outputChannel?: OutputChannel
   revealOutputChannelOn?: RevealOutputChannelOn
@@ -743,23 +219,21 @@ export interface LanguageClientOptions {
   progressOnInitialization?: boolean
   errorHandler?: ErrorHandler
   middleware?: Middleware
-  workspaceFolder?: WorkspaceFolder
   connectionOptions?: ConnectionOptions
-  diagnosticPullOptions?: DiagnosticPullOptions
   markdown?: {
     isTrusted?: boolean
     supportHtml?: boolean
   }
-}
+} & $ConfigurationOptions & $CompletionOptions & $FormattingOptions & $DiagnosticPullOptions & $WorkspaceOptions
 
-interface ResolvedClientOptions {
-  ignoredRootPaths?: string[]
+type ResolvedClientOptions = {
   disabledFeatures: string[]
-  disableSnippetCompletion: boolean
+  disableMarkdown: boolean
   disableDynamicRegister: boolean
-  formatterPriority: number
+  separateDiagnostics: boolean
+  rootPatterns?: string[]
+  requireRootPattern?: boolean
   documentSelector?: DocumentSelector
-  synchronize: SynchronizeOptions
   diagnosticCollectionName?: string
   outputChannelName: string
   revealOutputChannelOn: RevealOutputChannelOn
@@ -769,14 +243,12 @@ interface ResolvedClientOptions {
   progressOnInitialization: boolean
   errorHandler: ErrorHandler
   middleware: Middleware
-  workspaceFolder?: WorkspaceFolder
   connectionOptions?: ConnectionOptions
-  diagnosticPullOptions?: DiagnosticPullOptions
   markdown: {
     isTrusted: boolean
     supportHtml?: boolean
   }
-}
+} & $ConfigurationOptions & $CompletionOptions & $FormattingOptions & $DiagnosticPullOptions & $WorkspaceOptions
 
 export enum State {
   Stopped = 1,
@@ -798,2270 +270,13 @@ export enum ClientState {
   Stopped
 }
 
-export const SupportedSymbolKinds: SymbolKind[] = [
-  SymbolKind.File,
-  SymbolKind.Module,
-  SymbolKind.Namespace,
-  SymbolKind.Package,
-  SymbolKind.Class,
-  SymbolKind.Method,
-  SymbolKind.Property,
-  SymbolKind.Field,
-  SymbolKind.Constructor,
-  SymbolKind.Enum,
-  SymbolKind.Interface,
-  SymbolKind.Function,
-  SymbolKind.Variable,
-  SymbolKind.Constant,
-  SymbolKind.String,
-  SymbolKind.Number,
-  SymbolKind.Boolean,
-  SymbolKind.Array,
-  SymbolKind.Object,
-  SymbolKind.Key,
-  SymbolKind.Null,
-  SymbolKind.EnumMember,
-  SymbolKind.Struct,
-  SymbolKind.Event,
-  SymbolKind.Operator,
-  SymbolKind.TypeParameter
-]
-
-const SupportedCompletionItemKinds: CompletionItemKind[] = [
-  CompletionItemKind.Text,
-  CompletionItemKind.Method,
-  CompletionItemKind.Function,
-  CompletionItemKind.Constructor,
-  CompletionItemKind.Field,
-  CompletionItemKind.Variable,
-  CompletionItemKind.Class,
-  CompletionItemKind.Interface,
-  CompletionItemKind.Module,
-  CompletionItemKind.Property,
-  CompletionItemKind.Unit,
-  CompletionItemKind.Value,
-  CompletionItemKind.Enum,
-  CompletionItemKind.Keyword,
-  CompletionItemKind.Snippet,
-  CompletionItemKind.Color,
-  CompletionItemKind.File,
-  CompletionItemKind.Reference,
-  CompletionItemKind.Folder,
-  CompletionItemKind.EnumMember,
-  CompletionItemKind.Constant,
-  CompletionItemKind.Struct,
-  CompletionItemKind.Event,
-  CompletionItemKind.Operator,
-  CompletionItemKind.TypeParameter
-]
-
-export const SupportedSymbolTags: SymbolTag[] = [
-  SymbolTag.Deprecated
-]
-
-export function ensure<T, K extends keyof T>(target: T, key: K): T[K] {
-  if (target[key] === undefined) {
-    target[key] = {} as any
-  }
-  return target[key]
-}
-
-interface ResolvedTextDocumentSyncCapabilities {
-  resolvedTextDocumentSync?: TextDocumentSyncOptions
-}
-
-export interface RegistrationData<T> {
-  id: string
-  registerOptions: T
-}
-
-/**
- * A static feature. A static feature can't be dynamically activate via the
- * server. It is wired during the initialize sequence.
- */
-export interface StaticFeature {
-  /**
-   * Called to fill the initialize params.
-   *
-   * @params the initialize params.
-   */
-  fillInitializeParams?: (params: InitializeParams) => void
-
-  /**
-   * Called to fill in the client capabilities this feature implements.
-   *
-   * @param capabilities The client capabilities to fill.
-   */
-  fillClientCapabilities(capabilities: ClientCapabilities): void
-
-  /**
-   * Initialize the feature. This method is called on a feature instance
-   * when the client has successfully received the initialize request from
-   * the server and before the client sends the initialized notification
-   * to the server.
-   *
-   * @param capabilities the server capabilities
-   * @param documentSelector the document selector pass to the client's constructor.
-   *  May be `undefined` if the client was created without a selector.
-   */
-  initialize(
-    capabilities: ServerCapabilities,
-    documentSelector: DocumentSelector | undefined
-  ): void
-
-  /**
-   * Called when the client is stopped to dispose this feature. Usually a feature
-   * unregisters listeners registered hooked up with the VS Code extension host.
-   */
-  dispose(): void
-}
-
-export interface DynamicFeature<RO> {
-
-  /**
-   * Called to fill the initialize params.
-   *
-   * @params the initialize params.
-   */
-  fillInitializeParams?: (params: InitializeParams) => void
-
-  /**
-   * Called to fill in the client capabilities this feature implements.
-   *
-   * @param capabilities The client capabilities to fill.
-   */
-  fillClientCapabilities(capabilities: ClientCapabilities): void
-
-  /**
-   * Initialize the feature. This method is called on a feature instance
-   * when the client has successfully received the initialize request from
-   * the server and before the client sends the initialized notification
-   * to the server.
-   *
-   * @param capabilities the server capabilities.
-   * @param documentSelector the document selector pass to the client's constructor.
-   *  May be `undefined` if the client was created without a selector.
-   */
-  initialize(
-    capabilities: ServerCapabilities,
-    documentSelector: DocumentSelector | undefined
-  ): void
-
-  /**
-   * The signature (e.g. method) for which this features support dynamic activation / registration.
-   */
-  registrationType: RegistrationType<RO>
-
-  /**
-   * Is called when the server send a register request for the given message.
-   *
-   * @param data additional registration data as defined in the protocol.
-   */
-  register(data: RegistrationData<RO>): void
-
-  /**
-   * Is called when the server wants to unregister a feature.
-   *
-   * @param id the id used when registering the feature.
-   */
-  unregister(id: string): void
-
-  /**
-   * Called when the client is stopped to dispose this feature. Usually a feature
-   * unregisters listeners registered hooked up with the VS Code extension host.
-   */
-  dispose(): void
-}
-
-export interface NotificationFeature<T extends Function> {
-  /**
-   * Triggers the corresponding RPC method.
-   */
-  getProvider(document: TextDocument): { send: T } | undefined
-}
-
-namespace DynamicFeature {
-  export function is<T>(value: any): value is DynamicFeature<T> {
-    let candidate: DynamicFeature<T> = value
-    return (
-      candidate &&
-      Is.func(candidate.register) &&
-      Is.func(candidate.unregister) &&
-      Is.func(candidate.dispose) &&
-      candidate.registrationType !== undefined
-    )
-  }
-}
-
-interface CreateParamsSignature<E, P> {
-  (data: E): P
-}
-
-abstract class DocumentNotifications<P, E>
-  implements DynamicFeature<TextDocumentRegistrationOptions>, NotificationFeature<(data: E) => void> {
-  private _listener: Disposable | undefined
-  protected _selectors: Map<string, DocumentSelector> = new Map()
-
-  public static textDocumentFilter(
-    selectors: IterableIterator<DocumentSelector>,
-    textDocument: TextDocument
-  ): boolean {
-    for (const selector of selectors) {
-      if (workspace.match(selector, textDocument) > 0) {
-        return true
-      }
-    }
-    return false
-  }
-
-  constructor(
-    protected _client: BaseLanguageClient,
-    private _event: Event<E>,
-    protected _type: ProtocolNotificationType<P, TextDocumentRegistrationOptions>,
-    protected _middleware: NextSignature<E, void> | undefined,
-    protected _createParams: CreateParamsSignature<E, P>,
-    protected _selectorFilter?: (
-      selectors: IterableIterator<DocumentSelector>,
-      data: E
-    ) => boolean
-  ) {}
-
-  public abstract registrationType: RegistrationType<TextDocumentRegistrationOptions>
-
-  public abstract fillClientCapabilities(capabilities: ClientCapabilities): void
-
-  public abstract initialize(
-    capabilities: ServerCapabilities,
-    documentSelector: DocumentSelector | undefined
-  ): void
-
-  public register(
-    data: RegistrationData<TextDocumentRegistrationOptions>
-  ): void {
-    if (!data.registerOptions.documentSelector) {
-      return
-    }
-    if (!this._listener) {
-      this._listener = this._event(this.callback, this)
-    }
-    this._selectors.set(data.id, data.registerOptions.documentSelector)
-  }
-
-  private callback(data: E): void {
-    if (
-      !this._selectorFilter ||
-      this._selectorFilter(this._selectors.values(), data)
-    ) {
-      if (this._middleware) {
-        this._middleware(data, data =>
-          this._client.sendNotification(this._type, this._createParams(data))
-        )
-      } else {
-        this._client.sendNotification(this._type, this._createParams(data))
-      }
-      this.notificationSent(data)
-    }
-  }
-
-  protected notificationSent(_data: E): void {}
-
-  public unregister(id: string): void {
-    this._selectors.delete(id)
-    if (this._selectors.size === 0 && this._listener) {
-      this._listener.dispose()
-      this._listener = undefined
-    }
-  }
-
-  public dispose(): void {
-    this._selectors.clear()
-    if (this._listener) {
-      this._listener.dispose()
-      this._listener = undefined
-    }
-  }
-
-  public getProvider(document: TextDocument): { send: (data: E) => void } | undefined {
-    for (const selector of this._selectors.values()) {
-      if (workspace.match(selector, document)) {
-        return {
-          send: (data: E) => {
-            this.callback(data)
-          }
-        }
-      }
-    }
-    return undefined
-  }
-}
-
-class DidOpenTextDocumentFeature extends DocumentNotifications<DidOpenTextDocumentParams, TextDocument> {
-  constructor(client: BaseLanguageClient, private _syncedDocuments: Map<string, TextDocument>) {
-    super(
-      client,
-      workspace.onDidOpenTextDocument,
-      DidOpenTextDocumentNotification.type,
-      client.clientOptions.middleware!.didOpen,
-      (textDocument) => {
-        return { textDocument: cv.convertToTextDocumentItem(textDocument) }
-      },
-      DocumentNotifications.textDocumentFilter
-    )
-  }
-
-  public get registrationType(): RegistrationType<TextDocumentRegistrationOptions> {
-    return DidOpenTextDocumentNotification.type
-  }
-
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    ensure(ensure(capabilities, 'textDocument')!, 'synchronization')!.dynamicRegistration = true
-  }
-
-  public initialize(
-    capabilities: ServerCapabilities,
-    documentSelector: DocumentSelector
-  ): void {
-    let textDocumentSyncOptions = (capabilities as ResolvedTextDocumentSyncCapabilities).resolvedTextDocumentSync
-    if (
-      documentSelector &&
-      textDocumentSyncOptions &&
-      textDocumentSyncOptions.openClose
-    ) {
-      this.register({
-        id: UUID.generateUuid(),
-        registerOptions: { documentSelector: documentSelector }
-      })
-    }
-  }
-
-  public register(
-    data: RegistrationData<TextDocumentRegistrationOptions>
-  ): void {
-    super.register(data)
-    if (!data.registerOptions.documentSelector) {
-      return
-    }
-    let documentSelector = data.registerOptions.documentSelector
-    workspace.textDocuments.forEach(textDocument => {
-      let uri: string = textDocument.uri.toString()
-      if (this._syncedDocuments.has(uri)) {
-        return
-      }
-      if (workspace.match(documentSelector, textDocument) > 0) {
-        let middleware = this._client.clientOptions.middleware!
-        let didOpen = (textDocument: TextDocument) => {
-          this._client.sendNotification(
-            this._type,
-            this._createParams(textDocument)
-          )
-        }
-        if (middleware.didOpen) {
-          middleware.didOpen(textDocument, didOpen)
-        } else {
-          didOpen(textDocument)
-        }
-        this._syncedDocuments.set(uri, textDocument)
-      }
-    })
-  }
-
-  protected notificationSent(textDocument: TextDocument): void {
-    super.notificationSent(textDocument)
-    this._syncedDocuments.set(textDocument.uri.toString(), textDocument)
-  }
-}
-
-class DidCloseTextDocumentFeature extends DocumentNotifications<
-  DidCloseTextDocumentParams,
-  TextDocument
-> {
-  constructor(
-    client: BaseLanguageClient,
-    private _syncedDocuments: Map<string, TextDocument>
-  ) {
-    super(
-      client,
-      workspace.onDidCloseTextDocument,
-      DidCloseTextDocumentNotification.type,
-      client.clientOptions.middleware!.didClose,
-      (textDocument) => cv.asCloseTextDocumentParams(textDocument),
-      DocumentNotifications.textDocumentFilter
-    )
-  }
-
-  public get registrationType(): RegistrationType<TextDocumentRegistrationOptions> {
-    return DidCloseTextDocumentNotification.type
-  }
-
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    ensure(
-      ensure(capabilities, 'textDocument')!,
-      'synchronization'
-    )!.dynamicRegistration = true
-  }
-
-  public initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {
-    let textDocumentSyncOptions = (capabilities as ResolvedTextDocumentSyncCapabilities).resolvedTextDocumentSync
-    if (
-      documentSelector &&
-      textDocumentSyncOptions &&
-      textDocumentSyncOptions.openClose
-    ) {
-      this.register({
-        id: UUID.generateUuid(),
-        registerOptions: { documentSelector: documentSelector }
-      })
-    }
-  }
-
-  protected notificationSent(textDocument: TextDocument): void {
-    super.notificationSent(textDocument)
-    this._syncedDocuments.delete(textDocument.uri.toString())
-  }
-
-  public unregister(id: string): void {
-    let selector = this._selectors.get(id)!
-    // The super call removed the selector from the map
-    // of selectors.
-    super.unregister(id)
-    let selectors = this._selectors.values()
-    this._syncedDocuments.forEach(textDocument => {
-      if (
-        workspace.match(selector, textDocument) > 0 &&
-        !this._selectorFilter!(selectors, textDocument)
-      ) {
-        let middleware = this._client.clientOptions.middleware!
-        let didClose = (textDocument: TextDocument) => {
-          this._client.sendNotification(this._type, this._createParams(textDocument))
-        }
-        this._syncedDocuments.delete(textDocument.uri.toString())
-        if (middleware.didClose) {
-          middleware.didClose(textDocument, didClose)
-        } else {
-          didClose(textDocument)
-        }
-      }
-    })
-  }
-}
-
-interface DidChangeTextDocumentData {
-  documentSelector: DocumentSelector
-  syncKind: 0 | 1 | 2
-}
-
-class DidChangeTextDocumentFeature
-  implements DynamicFeature<TextDocumentChangeRegistrationOptions>, NotificationFeature<(event: DidChangeTextDocumentParams) => void> {
-  private _listener: Disposable | undefined
-  private _changeData: Map<string, DidChangeTextDocumentData> = new Map<string, DidChangeTextDocumentData>()
-
-  constructor(private _client: BaseLanguageClient) {}
-
-  public get registrationType(): RegistrationType<TextDocumentChangeRegistrationOptions> {
-    return DidChangeTextDocumentNotification.type
-  }
-
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    ensure(ensure(capabilities, 'textDocument')!, 'synchronization')!.dynamicRegistration = true
-  }
-
-  public initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {
-    let textDocumentSyncOptions = (capabilities as ResolvedTextDocumentSyncCapabilities).resolvedTextDocumentSync
-    if (
-      documentSelector &&
-      textDocumentSyncOptions &&
-      textDocumentSyncOptions.change !== undefined &&
-      textDocumentSyncOptions.change !== TextDocumentSyncKind.None
-    ) {
-      this.register({
-        id: UUID.generateUuid(),
-        registerOptions: Object.assign(
-          {},
-          { documentSelector: documentSelector },
-          { syncKind: textDocumentSyncOptions.change }
-        )
-      })
-    }
-  }
-
-  public register(
-    data: RegistrationData<TextDocumentChangeRegistrationOptions>
-  ): void {
-    if (!data.registerOptions.documentSelector) {
-      return
-    }
-    if (!this._listener) {
-      this._listener = workspace.onDidChangeTextDocument(event => {
-        this.callback({ textDocument: event.textDocument, contentChanges: event.contentChanges.slice() })
-      }, this)
-    }
-    this._changeData.set(data.id, {
-      documentSelector: data.registerOptions.documentSelector,
-      syncKind: data.registerOptions.syncKind
-    })
-  }
-
-  private callback(event: DidChangeTextDocumentParams): void {
-    // Text document changes are send for dirty changes as well. We don't
-    // have dirty / undirty events in the LSP so we ignore content changes
-    // with length zero.
-    if (event.contentChanges.length === 0) {
-      return
-    }
-    let doc = workspace.getDocument(event.textDocument.uri)
-    if (!doc) return
-    let { textDocument } = doc
-    for (const changeData of this._changeData.values()) {
-      if (workspace.match(changeData.documentSelector, textDocument) > 0) {
-        let middleware = this._client.clientOptions.middleware!
-        if (changeData.syncKind === TextDocumentSyncKind.Incremental) {
-          let didChange = event => {
-            this._client.sendNotification(
-              DidChangeTextDocumentNotification.type,
-              omit(event, ['bufnr', 'original', 'originalLines'])
-            )
-          }
-          if (middleware.didChange) {
-            middleware.didChange(event, didChange)
-          } else {
-            didChange(event)
-          }
-        } else if (changeData.syncKind === TextDocumentSyncKind.Full) {
-          let didChange: (event: DidChangeTextDocumentParams) => void = () => {
-            this._client.sendNotification(
-              DidChangeTextDocumentNotification.type,
-              cv.asChangeTextDocumentParams(textDocument)
-            )
-          }
-          if (middleware.didChange) {
-            middleware.didChange(event, didChange)
-          } else {
-            didChange(event)
-          }
-        }
-      }
-    }
-  }
-
-  public unregister(id: string): void {
-    this._changeData.delete(id)
-    if (this._changeData.size === 0 && this._listener) {
-      this._listener.dispose()
-      this._listener = undefined
-    }
-  }
-
-  public dispose(): void {
-    this._changeData.clear()
-    if (this._listener) {
-      this._listener.dispose()
-      this._listener = undefined
-    }
-  }
-
-  public getProvider(document: TextDocument): { send: (event: DidChangeTextDocumentParams) => void } | undefined {
-    for (const changeData of this._changeData.values()) {
-      if (workspace.match(changeData.documentSelector, document)) {
-        return {
-          send: (event: DidChangeTextDocumentParams): void => {
-            this.callback(event)
-          }
-        }
-      }
-    }
-    return undefined
-  }
-}
-
-class WillSaveFeature extends DocumentNotifications<WillSaveTextDocumentParams, TextDocumentWillSaveEvent> {
-  constructor(client: BaseLanguageClient) {
-    super(
-      client,
-      workspace.onWillSaveTextDocument,
-      WillSaveTextDocumentNotification.type,
-      client.clientOptions.middleware!.willSave,
-      willSaveEvent => cv.asWillSaveTextDocumentParams(willSaveEvent),
-      (selectors, willSaveEvent) => DocumentNotifications.textDocumentFilter(selectors, willSaveEvent.document)
-    )
-  }
-
-  public get registrationType(): RegistrationType<TextDocumentRegistrationOptions> {
-    return WillSaveTextDocumentNotification.type
-  }
-
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    let value = ensure(ensure(capabilities, 'textDocument')!, 'synchronization')!
-    value.willSave = true
-  }
-
-  public initialize(
-    capabilities: ServerCapabilities,
-    documentSelector: DocumentSelector
-  ): void {
-    let textDocumentSyncOptions = (capabilities as ResolvedTextDocumentSyncCapabilities).resolvedTextDocumentSync
-    if (
-      documentSelector &&
-      textDocumentSyncOptions &&
-      textDocumentSyncOptions.willSave
-    ) {
-      this.register({
-        id: UUID.generateUuid(),
-        registerOptions: { documentSelector: documentSelector }
-      })
-    }
-  }
-}
-
-class WillSaveWaitUntilFeature implements DynamicFeature<TextDocumentRegistrationOptions> {
-  private _listener: Disposable | undefined
-  private _selectors: Map<string, DocumentSelector> = new Map<string, DocumentSelector>()
-
-  constructor(private _client: BaseLanguageClient) {}
-
-  public get registrationType(): RegistrationType<TextDocumentRegistrationOptions> {
-    return WillSaveTextDocumentWaitUntilRequest.type
-  }
-
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    let value = ensure(ensure(capabilities, 'textDocument')!, 'synchronization')!
-    value.willSaveWaitUntil = true
-  }
-
-  public initialize(
-    capabilities: ServerCapabilities,
-    documentSelector: DocumentSelector
-  ): void {
-    let textDocumentSyncOptions = (capabilities as ResolvedTextDocumentSyncCapabilities).resolvedTextDocumentSync
-    if (
-      documentSelector &&
-      textDocumentSyncOptions &&
-      textDocumentSyncOptions.willSaveWaitUntil
-    ) {
-      this.register({
-        id: UUID.generateUuid(),
-        registerOptions: { documentSelector: documentSelector }
-      })
-    }
-  }
-
-  public register(
-    data: RegistrationData<TextDocumentRegistrationOptions>
-  ): void {
-    if (!data.registerOptions.documentSelector) {
-      return
-    }
-    if (!this._listener) {
-      this._listener = workspace.onWillSaveTextDocument(this.callback, this)
-    }
-    this._selectors.set(data.id, data.registerOptions.documentSelector)
-  }
-
-  private callback(event: TextDocumentWillSaveEvent): void {
-    if (DocumentNotifications.textDocumentFilter(
-      this._selectors.values(),
-      event.document)) {
-      let middleware = this._client.clientOptions.middleware!
-      let willSaveWaitUntil = (event: TextDocumentWillSaveEvent): Thenable<TextEdit[]> => {
-        return this._client
-          .sendRequest(
-            WillSaveTextDocumentWaitUntilRequest.type,
-            cv.asWillSaveTextDocumentParams(event)
-          )
-          .then(edits => {
-            return edits ? edits : []
-          }, e => {
-            window.showMessage(`Error on willSaveWaitUntil: ${e}`, 'error')
-            logger.error(e)
-            return []
-          })
-      }
-      event.waitUntil(
-        middleware.willSaveWaitUntil
-          ? middleware.willSaveWaitUntil(event, willSaveWaitUntil)
-          : willSaveWaitUntil(event)
-      )
-    }
-  }
-
-  public unregister(id: string): void {
-    this._selectors.delete(id)
-    if (this._selectors.size === 0 && this._listener) {
-      this._listener.dispose()
-      this._listener = undefined
-    }
-  }
-
-  public dispose(): void {
-    this._selectors.clear()
-    if (this._listener) {
-      this._listener.dispose()
-      this._listener = undefined
-    }
-  }
-}
-
-class DidSaveTextDocumentFeature extends DocumentNotifications<
-  DidSaveTextDocumentParams,
-  TextDocument
-> {
-  private _includeText: boolean
-
-  constructor(client: BaseLanguageClient) {
-    super(
-      client,
-      workspace.onDidSaveTextDocument,
-      DidSaveTextDocumentNotification.type,
-      client.clientOptions.middleware!.didSave,
-      textDocument =>
-        cv.asSaveTextDocumentParams(
-          textDocument,
-          this._includeText
-        ),
-      DocumentNotifications.textDocumentFilter
-    )
-    this._includeText = false
-  }
-
-  public get registrationType(): RegistrationType<TextDocumentSaveRegistrationOptions> {
-    return DidSaveTextDocumentNotification.type
-  }
-
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    ensure(
-      ensure(capabilities, 'textDocument')!,
-      'synchronization'
-    )!.didSave = true
-  }
-
-  public initialize(
-    capabilities: ServerCapabilities,
-    documentSelector: DocumentSelector
-  ): void {
-    const textDocumentSyncOptions = (capabilities as ResolvedTextDocumentSyncCapabilities).resolvedTextDocumentSync
-    if (
-      documentSelector &&
-      textDocumentSyncOptions &&
-      textDocumentSyncOptions.save
-    ) {
-      const saveOptions: SaveOptions = typeof textDocumentSyncOptions.save === 'boolean'
-        ? { includeText: false }
-        : { includeText: !!textDocumentSyncOptions.save.includeText }
-      this.register({
-        id: UUID.generateUuid(),
-        registerOptions: Object.assign(
-          {},
-          { documentSelector: documentSelector },
-          saveOptions
-        )
-      })
-    }
-  }
-
-  public register(
-    data: RegistrationData<TextDocumentSaveRegistrationOptions>
-  ): void {
-    this._includeText = !!data.registerOptions.includeText
-    super.register(data)
-  }
-}
-
-class FileSystemWatcherFeature
-  implements DynamicFeature<DidChangeWatchedFilesRegistrationOptions> {
-  private _watchers: Map<string, Disposable[]> = new Map<string, Disposable[]>()
-
-  constructor(
-    _client: BaseLanguageClient,
-    private _notifyFileEvent: (event: FileEvent) => void
-  ) {}
-
-  public get registrationType(): RegistrationType<DidChangeWatchedFilesRegistrationOptions> {
-    return DidChangeWatchedFilesNotification.type
-  }
-
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    ensure(
-      ensure(capabilities, 'workspace')!,
-      'didChangeWatchedFiles'
-    )!.dynamicRegistration = true
-  }
-
-  public initialize(
-    _capabilities: ServerCapabilities,
-    _documentSelector: DocumentSelector
-  ): void {}
-
-  public register(
-    data: RegistrationData<DidChangeWatchedFilesRegistrationOptions>
-  ): void {
-    if (!Array.isArray(data.registerOptions.watchers)) {
-      return
-    }
-    let disposables: Disposable[] = []
-    for (let watcher of data.registerOptions.watchers) {
-      if (!Is.string(watcher.globPattern)) {
-        continue
-      }
-      let watchCreate: boolean = true,
-        watchChange: boolean = true,
-        watchDelete: boolean = true
-      if (watcher.kind != null) {
-        watchCreate = (watcher.kind & WatchKind.Create) !== 0
-        watchChange = (watcher.kind & WatchKind.Change) != 0
-        watchDelete = (watcher.kind & WatchKind.Delete) != 0
-      }
-      let fileSystemWatcher = workspace.createFileSystemWatcher(
-        watcher.globPattern,
-        !watchCreate,
-        !watchChange,
-        !watchDelete
-      )
-      this.hookListeners(
-        fileSystemWatcher,
-        watchCreate,
-        watchChange,
-        watchDelete,
-        disposables
-      )
-      disposables.push(fileSystemWatcher)
-    }
-    this._watchers.set(data.id, disposables)
-  }
-
-  public registerRaw(id: string, fileSystemWatchers: FileWatcher[]) {
-    let disposables: Disposable[] = []
-    for (let fileSystemWatcher of fileSystemWatchers) {
-      disposables.push(fileSystemWatcher)
-      this.hookListeners(fileSystemWatcher, true, true, true, disposables)
-    }
-    this._watchers.set(id, disposables)
-  }
-
-  private hookListeners(
-    fileSystemWatcher: FileWatcher,
-    watchCreate: boolean,
-    watchChange: boolean,
-    watchDelete: boolean,
-    listeners: Disposable[]
-  ): void {
-    if (watchCreate) {
-      fileSystemWatcher.onDidCreate(
-        resource =>
-          this._notifyFileEvent({
-            uri: cv.asUri(resource),
-            type: FileChangeType.Created
-          }),
-        null,
-        listeners
-      )
-    }
-    if (watchChange) {
-      fileSystemWatcher.onDidChange(
-        resource =>
-          this._notifyFileEvent({
-            uri: cv.asUri(resource),
-            type: FileChangeType.Changed
-          }),
-        null,
-        listeners
-      )
-    }
-    if (watchDelete) {
-      fileSystemWatcher.onDidDelete(
-        resource =>
-          this._notifyFileEvent({
-            uri: cv.asUri(resource),
-            type: FileChangeType.Deleted
-          }),
-        null,
-        listeners
-      )
-    }
-  }
-
-  public unregister(id: string): void {
-    let disposables = this._watchers.get(id)
-    if (disposables) {
-      for (let disposable of disposables) {
-        disposable.dispose()
-      }
-    }
-  }
-
-  public dispose(): void {
-    this._watchers.forEach(disposables => {
-      for (let disposable of disposables) {
-        disposable.dispose()
-      }
-    })
-    this._watchers.clear()
-  }
-}
-
-interface TextDocumentFeatureRegistration<RO, PR> {
-  disposable: Disposable
-  data: RegistrationData<RO>
-  provider: PR
-}
-
-export interface TextDocumentProviderFeature<T> {
-  /**
-   * Triggers the corresponding RPC method.
-   */
-  getProvider(textDocument: TextDocument): T | undefined
-}
-
-export abstract class TextDocumentFeature<
-  PO, RO extends TextDocumentRegistrationOptions & PO, PR
-  > implements DynamicFeature<RO> {
-  private _registrations: Map<string, TextDocumentFeatureRegistration<RO, PR>> = new Map()
-
-  constructor(
-    protected _client: BaseLanguageClient,
-    private _registrationType: RegistrationType<RO>
-  ) {}
-
-  public get registrationType(): RegistrationType<RO> {
-    return this._registrationType
-  }
-
-  public abstract fillClientCapabilities(capabilities: ClientCapabilities): void
-
-  public abstract initialize(
-    capabilities: ServerCapabilities,
-    documentSelector: DocumentSelector
-  ): void
-
-  public register(data: RegistrationData<RO>): void {
-    if (!data.registerOptions.documentSelector) {
-      return
-    }
-    let registration = this.registerLanguageProvider(data.registerOptions)
-    this._registrations.set(data.id, { disposable: registration[0], data, provider: registration[1] })
-  }
-
-  protected abstract registerLanguageProvider(options: RO): [Disposable, PR]
-
-  public unregister(id: string): void {
-    let registration = this._registrations.get(id)
-    if (registration) {
-      registration.disposable.dispose()
-    }
-  }
-
-  public dispose(): void {
-    this._registrations.forEach(value => {
-      value.disposable.dispose()
-    })
-    this._registrations.clear()
-  }
-
-  protected getRegistration(documentSelector: DocumentSelector | undefined, capability: undefined | PO | (RO & StaticRegistrationOptions)): [string | undefined, (RO & { documentSelector: DocumentSelector }) | undefined] {
-    if (!capability) {
-      return [undefined, undefined]
-    } else if (TextDocumentRegistrationOptions.is(capability)) {
-      const id = StaticRegistrationOptions.hasId(capability) ? capability.id : UUID.generateUuid()
-      const selector = capability.documentSelector || documentSelector
-      if (selector) {
-        return [id, Object.assign({}, capability, { documentSelector: selector })]
-      }
-    } else if (Is.boolean(capability) && capability === true || WorkDoneProgressOptions.is(capability)) {
-      if (!documentSelector) {
-        return [undefined, undefined]
-      }
-      let options: RO & { documentSelector: DocumentSelector } = (Is.boolean(capability) && capability === true ? { documentSelector } : Object.assign({}, capability, { documentSelector })) as any
-      return [UUID.generateUuid(), options]
-    }
-    return [undefined, undefined]
-  }
-
-  protected getRegistrationOptions(documentSelector: DocumentSelector | undefined, capability: undefined | PO): (RO & { documentSelector: DocumentSelector }) | undefined {
-    if (!documentSelector || !capability) {
-      return undefined
-    }
-    return (Is.boolean(capability) && capability === true ? { documentSelector } : Object.assign({}, capability, { documentSelector })) as RO & { documentSelector: DocumentSelector }
-  }
-
-  public getProvider(textDocument: TextDocument): PR | undefined {
-    for (const registration of this._registrations.values()) {
-      let selector = registration.data.registerOptions.documentSelector
-      if (selector !== null && workspace.match(selector, textDocument) > 0) {
-        return registration.provider
-      }
-    }
-    return undefined
-  }
-
-  protected getAllProviders(): Iterable<PR> {
-    const result: PR[] = []
-    for (const item of this._registrations.values()) {
-      result.push(item.provider)
-    }
-    return result
-  }
-}
-
-export interface WorkspaceProviderFeature<PR> {
-  getProviders(): PR[] | undefined
-}
-
-export interface ProvideResolveFeature<T1 extends Function, T2 extends Function> {
-  provide: T1
-  resolve: T2
-}
-
-class CompletionItemFeature extends TextDocumentFeature<CompletionOptions, CompletionRegistrationOptions, CompletionItemProvider> {
-  private index: number
-  constructor(client: BaseLanguageClient) {
-    super(client, CompletionRequest.type)
-  }
-
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    let snippetSupport = this._client.clientOptions.disableSnippetCompletion !== true
-    let completion = ensure(ensure(capabilities, 'textDocument')!, 'completion')!
-    completion.dynamicRegistration = true
-    completion.contextSupport = true
-    completion.completionItem = {
-      snippetSupport,
-      commitCharactersSupport: true,
-      documentationFormat: this._client.supportedMarkupKind,
-      deprecatedSupport: true,
-      preselectSupport: true,
-      insertReplaceSupport: true,
-      tagSupport: { valueSet: [CompletionItemTag.Deprecated] },
-      resolveSupport: { properties: ['documentation', 'detail', 'additionalTextEdits'] },
-      labelDetailsSupport: true,
-      insertTextModeSupport: { valueSet: [InsertTextMode.asIs, InsertTextMode.adjustIndentation] }
-    }
-    completion.completionItemKind = { valueSet: SupportedCompletionItemKinds }
-    completion.insertTextMode = InsertTextMode.adjustIndentation
-    completion.completionList = {
-      itemDefaults: [
-        'commitCharacters', 'editRange', 'insertTextFormat', 'insertTextMode'
-      ]
-    }
-  }
-
-  public initialize(
-    capabilities: ServerCapabilities,
-    documentSelector: DocumentSelector
-  ): void {
-    this.index = 0
-    const options = this.getRegistrationOptions(documentSelector, capabilities.completionProvider)
-    if (!options) {
-      return
-    }
-    this.register({
-      id: UUID.generateUuid(),
-      registerOptions: options
-    })
-  }
-
-  protected registerLanguageProvider(options: CompletionRegistrationOptions): [Disposable, CompletionItemProvider] {
-    let triggerCharacters = options.triggerCharacters || []
-    let allCommitCharacters = options.allCommitCharacters || []
-    let priority = (options as any).priority as number
-    const provider: CompletionItemProvider = {
-      provideCompletionItems: (document: TextDocument, position: Position, token: CancellationToken, context: CompletionContext): ProviderResult<CompletionList | CompletionItem[]> => {
-        const client = this._client
-        const middleware = this._client.clientOptions.middleware!
-        const provideCompletionItems: ProvideCompletionItemsSignature = (document, position, context, token) => {
-          return client.sendRequest(
-            CompletionRequest.type,
-            cv.asCompletionParams(document, position, context),
-            token
-          ).then(
-              res => {
-                if (token.isCancellationRequested) return []
-                if (Array.isArray(res)) return res
-
-                return cv.asCompletionList(res, allCommitCharacters, token)
-              },
-              error => {
-                return client.handleFailedRequest(CompletionRequest.type, token, error, [])
-              }
-            )
-        }
-
-        return middleware.provideCompletionItem
-          ? middleware.provideCompletionItem(document, position, context, token, provideCompletionItems)
-          : provideCompletionItems(document, position, context, token)
-      },
-      resolveCompletionItem: options.resolveProvider
-        ? (item: CompletionItem, token: CancellationToken): ProviderResult<CompletionItem> => {
-          const client = this._client
-          const middleware = this._client.clientOptions.middleware!
-          const resolveCompletionItem: ResolveCompletionItemSignature = (item, token) => {
-            return client.sendRequest(
-              CompletionResolveRequest.type,
-              item,
-              token
-            ).then(
-              res => token.isCancellationRequested ? item : res,
-              error => {
-                return client.handleFailedRequest(CompletionResolveRequest.type, token, error, item)
-            })
-          }
-
-          return middleware.resolveCompletionItem
-            ? middleware.resolveCompletionItem(item, token, resolveCompletionItem)
-            : resolveCompletionItem(item, token)
-        }
-        : undefined
-    }
-    // index is needed since one language server could create many sources.
-    let name = this._client.id + (this.index ? '-' + this.index : '')
-    sources.removeSource(name)
-    const disposable = languages.registerCompletionItemProvider(
-      name,
-      'LS',
-      options.documentSelector || this._client.clientOptions.documentSelector,
-      provider,
-      triggerCharacters,
-      priority,
-      allCommitCharacters)
-    this.index = this.index + 1
-    return [disposable, provider]
-  }
-}
-
-class HoverFeature extends TextDocumentFeature<
-  boolean | HoverOptions, HoverRegistrationOptions, HoverProvider
-> {
-  constructor(client: BaseLanguageClient) {
-    super(client, HoverRequest.type)
-  }
-
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    const hoverCapability = ensure(
-      ensure(capabilities, 'textDocument')!,
-      'hover'
-    )!
-    hoverCapability.dynamicRegistration = true
-    hoverCapability.contentFormat = this._client.supportedMarkupKind
-  }
-
-  public initialize(
-    capabilities: ServerCapabilities,
-    documentSelector: DocumentSelector
-  ): void {
-    const options = this.getRegistrationOptions(documentSelector, capabilities.hoverProvider)
-    if (!options) {
-      return
-    }
-    this.register({
-      id: UUID.generateUuid(),
-      registerOptions: options
-    })
-  }
-
-  protected registerLanguageProvider(
-    options: HoverRegistrationOptions
-  ): [Disposable, HoverProvider] {
-    const provider: HoverProvider = {
-      provideHover: (document, position, token) => {
-        const client = this._client
-        const provideHover: ProvideHoverSignature = (document, position, token) => {
-          return client.sendRequest(
-            HoverRequest.type,
-            cv.asTextDocumentPositionParams(document, position),
-            token
-          ).then(
-            res => token.isCancellationRequested ? null : res,
-            error => {
-              return client.handleFailedRequest(HoverRequest.type, token, error, null)
-          })
-        }
-
-        const middleware = client.clientOptions.middleware!
-        return middleware.provideHover
-          ? middleware.provideHover(document, position, token, provideHover)
-          : provideHover(document, position, token)
-      }
-    }
-
-    return [languages.registerHoverProvider(options.documentSelector!, provider), provider]
-  }
-}
-
-class SignatureHelpFeature extends TextDocumentFeature<
-  SignatureHelpOptions, SignatureHelpRegistrationOptions, SignatureHelpProvider
-> {
-  constructor(client: BaseLanguageClient) {
-    super(client, SignatureHelpRequest.type)
-  }
-
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    let config = ensure(ensure(capabilities, 'textDocument')!, 'signatureHelp')!
-    config.dynamicRegistration = true
-    config.contextSupport = true
-    config.signatureInformation = {
-      documentationFormat: this._client.supportedMarkupKind,
-      activeParameterSupport: true,
-      parameterInformation: {
-        labelOffsetSupport: true
-      }
-    } as any
-  }
-
-  public initialize(
-    capabilities: ServerCapabilities,
-    documentSelector: DocumentSelector
-  ): void {
-    const options = this.getRegistrationOptions(documentSelector, capabilities.signatureHelpProvider)
-    if (!options) {
-      return
-    }
-    this.register({
-      id: UUID.generateUuid(),
-      registerOptions: options
-    })
-  }
-
-  protected registerLanguageProvider(
-    options: SignatureHelpRegistrationOptions
-  ): [Disposable, SignatureHelpProvider] {
-    const provider: SignatureHelpProvider = {
-      provideSignatureHelp: (document, position, token, context) => {
-        const client = this._client
-        const providerSignatureHelp: ProvideSignatureHelpSignature = (document, position, context, token) => {
-          return client.sendRequest(
-            SignatureHelpRequest.type,
-            cv.asSignatureHelpParams(document, position, context),
-            token
-          ).then(
-            res => token.isCancellationRequested ? null : res,
-            error => {
-              return client.handleFailedRequest(SignatureHelpRequest.type, token, error, null)
-          })
-        }
-
-        const middleware = client.clientOptions.middleware!
-        return middleware.provideSignatureHelp
-          ? middleware.provideSignatureHelp(document, position, context, token, providerSignatureHelp)
-          : providerSignatureHelp(document, position, context, token)
-      }
-    }
-
-    const triggerCharacters = options.triggerCharacters || []
-    const disposable = languages.registerSignatureHelpProvider(options.documentSelector!, provider, triggerCharacters)
-    return [disposable, provider]
-  }
-}
-
-class DefinitionFeature extends TextDocumentFeature<
-  boolean | DefinitionOptions, DefinitionRegistrationOptions, DefinitionProvider
-> {
-  constructor(client: BaseLanguageClient) {
-    super(client, DefinitionRequest.type)
-  }
-
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    let definitionSupport = ensure(ensure(capabilities, 'textDocument')!, 'definition')!
-    definitionSupport.dynamicRegistration = true
-    // definitionSupport.linkSupport = true
-  }
-
-  public initialize(
-    capabilities: ServerCapabilities,
-    documentSelector: DocumentSelector
-  ): void {
-    const options = this.getRegistrationOptions(documentSelector, capabilities.definitionProvider)
-    if (!options) {
-      return
-    }
-    this.register({
-      id: UUID.generateUuid(),
-      registerOptions: options
-    })
-  }
-
-  protected registerLanguageProvider(
-    options: DefinitionRegistrationOptions
-  ): [Disposable, DefinitionProvider] {
-    const provider: DefinitionProvider = {
-      provideDefinition: (document, position, token) => {
-        const client = this._client
-        const provideDefinition: ProvideDefinitionSignature = (document, position, token) => {
-          return client.sendRequest(
-            DefinitionRequest.type,
-            cv.asTextDocumentPositionParams(document, position),
-            token
-          ).then(
-            res => token.isCancellationRequested ? null : res,
-            error => {
-              return client.handleFailedRequest(DefinitionRequest.type, token, error, null)
-          })
-        }
-        const middleware = client.clientOptions.middleware!
-        return middleware.provideDefinition
-          ? middleware.provideDefinition(document, position, token, provideDefinition)
-          : provideDefinition(document, position, token)
-      }
-    }
-
-    return [languages.registerDefinitionProvider(options.documentSelector!, provider), provider]
-  }
-}
-
-class ReferencesFeature extends TextDocumentFeature<
-  boolean | ReferenceOptions, ReferenceRegistrationOptions, ReferenceProvider
-> {
-  constructor(client: BaseLanguageClient) {
-    super(client, ReferencesRequest.type)
-  }
-
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    ensure(
-      ensure(capabilities, 'textDocument')!,
-      'references'
-    )!.dynamicRegistration = true
-  }
-
-  public initialize(
-    capabilities: ServerCapabilities,
-    documentSelector: DocumentSelector
-  ): void {
-    const options = this.getRegistrationOptions(documentSelector, capabilities.referencesProvider)
-    if (!options) {
-      return
-    }
-    this.register({
-      id: UUID.generateUuid(),
-      registerOptions: options
-    })
-  }
-
-  protected registerLanguageProvider(
-    options: TextDocumentRegistrationOptions
-  ): [Disposable, ReferenceProvider] {
-    const provider: ReferenceProvider = {
-      provideReferences: (document, position, options, token) => {
-        const client = this._client
-        const _providerReferences: ProvideReferencesSignature = (document, position, options, token) => {
-          return client.sendRequest(
-            ReferencesRequest.type,
-            cv.asReferenceParams(document, position, options),
-            token
-          ).then(
-            res => token.isCancellationRequested ? null : res,
-            error => {
-              return client.handleFailedRequest(ReferencesRequest.type, token, error, null)
-          })
-        }
-        const middleware = client.clientOptions.middleware!
-        return middleware.provideReferences
-          ? middleware.provideReferences(document, position, options, token, _providerReferences)
-          : _providerReferences(document, position, options, token)
-      }
-    }
-    return [languages.registerReferencesProvider(options.documentSelector!, provider), provider]
-  }
-}
-
-class DocumentHighlightFeature extends TextDocumentFeature<
-  boolean | DocumentHighlightOptions, DocumentHighlightRegistrationOptions, DocumentHighlightProvider
-> {
-  constructor(client: BaseLanguageClient) {
-    super(client, DocumentHighlightRequest.type)
-  }
-
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    ensure(
-      ensure(capabilities, 'textDocument')!,
-      'documentHighlight'
-    )!.dynamicRegistration = true
-  }
-
-  public initialize(
-    capabilities: ServerCapabilities,
-    documentSelector: DocumentSelector
-  ): void {
-    const options = this.getRegistrationOptions(documentSelector, capabilities.documentHighlightProvider)
-    if (!options) {
-      return
-    }
-    this.register({
-      id: UUID.generateUuid(),
-      registerOptions: options
-    })
-  }
-
-  protected registerLanguageProvider(
-    options: TextDocumentRegistrationOptions
-  ): [Disposable, DocumentHighlightProvider] {
-    const provider: DocumentHighlightProvider = {
-      provideDocumentHighlights: (document, position, token) => {
-        const client = this._client
-        const _provideDocumentHighlights: ProvideDocumentHighlightsSignature = (document, position, token) => {
-          return client.sendRequest(
-            DocumentHighlightRequest.type,
-            cv.asTextDocumentPositionParams(document, position),
-            token
-          ).then(
-            res => token.isCancellationRequested ? null : res,
-            error => {
-              return client.handleFailedRequest(DocumentHighlightRequest.type, token, error, null)
-          })
-        }
-        const middleware = client.clientOptions.middleware!
-        return middleware.provideDocumentHighlights
-          ? middleware.provideDocumentHighlights(document, position, token, _provideDocumentHighlights)
-          : _provideDocumentHighlights(document, position, token)
-      }
-    }
-    return [languages.registerDocumentHighlightProvider(options.documentSelector!, provider), provider]
-  }
-}
-
-class DocumentSymbolFeature extends TextDocumentFeature<
-  boolean | DocumentSymbolOptions, DocumentSymbolRegistrationOptions, DocumentSymbolProvider
-> {
-  constructor(client: BaseLanguageClient) {
-    super(client, DocumentSymbolRequest.type)
-  }
-
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    let symbolCapabilities = ensure(ensure(capabilities, 'textDocument')!, 'documentSymbol')! as any
-    symbolCapabilities.dynamicRegistration = true
-    symbolCapabilities.symbolKind = {
-      valueSet: SupportedSymbolKinds
-    }
-    symbolCapabilities.hierarchicalDocumentSymbolSupport = true
-    symbolCapabilities.tagSupport = {
-      valueSet: SupportedSymbolTags
-    }
-    symbolCapabilities.labelSupport = true
-  }
-
-  public initialize(
-    capabilities: ServerCapabilities,
-    documentSelector: DocumentSelector
-  ): void {
-    const options = this.getRegistrationOptions(documentSelector, capabilities.documentSymbolProvider)
-    if (!options) {
-      return
-    }
-    this.register({
-      id: UUID.generateUuid(),
-      registerOptions: options
-    })
-  }
-
-  protected registerLanguageProvider(
-    options: DocumentSymbolRegistrationOptions
-  ): [Disposable, DocumentSymbolProvider] {
-    const provider: DocumentSymbolProvider = {
-      provideDocumentSymbols: (document, token) => {
-        const client = this._client
-        const _provideDocumentSymbols: ProvideDocumentSymbolsSignature = (document, token) => {
-          return client.sendRequest(
-            DocumentSymbolRequest.type,
-            cv.asDocumentSymbolParams(document),
-            token
-          ).then(
-            (data) => {
-              if (token.isCancellationRequested || data === undefined || data === null) {
-                return undefined
-              }
-              if (data.length === 0) {
-                return []
-              } else {
-                let element = data[0]
-                if (DocumentSymbol.is(element)) {
-                  return data as DocumentSymbol[]
-                } else {
-                  return data as SymbolInformation[]
-                }
-              }
-            },
-            (error) => {
-              return client.handleFailedRequest(DocumentSymbolRequest.type, token, error, null)
-            }
-          )
-        }
-        const middleware = client.clientOptions.middleware!
-        return middleware.provideDocumentSymbols
-          ? middleware.provideDocumentSymbols(document, token, _provideDocumentSymbols)
-          : _provideDocumentSymbols(document, token)
-      }
-    }
-    const metadata = options.label ? { label: options.label } : undefined
-    return [languages.registerDocumentSymbolProvider(options.documentSelector!, provider, metadata), provider]
-  }
-}
-
-class CodeActionFeature extends TextDocumentFeature<boolean | CodeActionOptions, CodeActionRegistrationOptions, CodeActionProvider> {
-  private disposables: Disposable[] = []
-  constructor(client: BaseLanguageClient) {
-    super(client, CodeActionRequest.type)
-  }
-
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    const cap = ensure(ensure(capabilities, 'textDocument')!, 'codeAction')!
-    cap.dynamicRegistration = true
-    cap.isPreferredSupport = true
-    cap.disabledSupport = true
-    cap.dataSupport = true
-    cap.honorsChangeAnnotations = false
-    cap.resolveSupport = {
-      properties: ['edit']
-    }
-    cap.codeActionLiteralSupport = {
-      codeActionKind: {
-        valueSet: [
-          CodeActionKind.Empty,
-          CodeActionKind.QuickFix,
-          CodeActionKind.Refactor,
-          CodeActionKind.RefactorExtract,
-          CodeActionKind.RefactorInline,
-          CodeActionKind.RefactorRewrite,
-          CodeActionKind.Source,
-          CodeActionKind.SourceOrganizeImports
-        ]
-      }
-    }
-  }
-
-  public initialize(
-    capabilities: ServerCapabilities,
-    documentSelector: DocumentSelector
-  ): void {
-    const options = this.getRegistrationOptions(documentSelector, capabilities.codeActionProvider)
-    if (!options) {
-      return
-    }
-
-    this.register({
-      id: UUID.generateUuid(),
-      registerOptions: options
-    })
-  }
-
-  protected registerLanguageProvider(
-    options: CodeActionRegistrationOptions
-  ): [Disposable, CodeActionProvider] {
-    const registCommand = (id: string) => {
-      if (commands.has(id)) return
-      const client = this._client
-      const executeCommand: ExecuteCommandSignature = (command: string, args: any[]): any => {
-        const params: ExecuteCommandParams = {
-          command,
-          arguments: args
-        }
-        return client.sendRequest(ExecuteCommandRequest.type, params).then(undefined, (error) => {
-          client.handleFailedRequest(ExecuteCommandRequest.type, undefined, error, undefined)
-          throw error
-        })
-      }
-      const middleware = client.clientOptions.middleware!
-      this.disposables.push(commands.registerCommand(id, (...args: any[]) => {
-        return middleware.executeCommand
-          ? middleware.executeCommand(id, args, executeCommand)
-          : executeCommand(id, args)
-      }, null, true))
-    }
-    const provider: CodeActionProvider = {
-      provideCodeActions: (document, range, context, token) => {
-        const client = this._client
-        const _provideCodeActions: ProvideCodeActionsSignature = (document, range, context, token) => {
-          const params: CodeActionParams = {
-            textDocument: {
-              uri: document.uri
-            },
-            range,
-            context,
-          }
-          return client.sendRequest(CodeActionRequest.type, params, token).then(
-            (values) => {
-              if (token.isCancellationRequested || values === undefined || values === null) {
-                return undefined
-              }
-              // some server may not registered commands to client.
-              values.forEach(val => {
-                let cmd = Command.is(val) ? val.command : val.command?.command
-                if (cmd && !commands.has(cmd)) registCommand(cmd)
-              })
-              return values
-            },
-            (error) => {
-              return client.handleFailedRequest(CodeActionRequest.type, token, error, null)
-            }
-          )
-        }
-        const middleware = client.clientOptions.middleware!
-        return middleware.provideCodeActions
-          ? middleware.provideCodeActions(document, range, context, token, _provideCodeActions)
-          : _provideCodeActions(document, range, context, token)
-      },
-      resolveCodeAction: options.resolveProvider
-        ? (item: CodeAction, token: CancellationToken) => {
-          const client = this._client
-          const middleware = this._client.clientOptions.middleware!
-          const resolveCodeAction: ResolveCodeActionSignature = (item, token) => {
-            return client.sendRequest(CodeActionResolveRequest.type, item, token).then(
-              (values) => token.isCancellationRequested ? item : values,
-              (error) => {
-                return client.handleFailedRequest(CodeActionResolveRequest.type, token, error, item)
-              }
-            )
-          }
-          return middleware.resolveCodeAction
-            ? middleware.resolveCodeAction(item, token, resolveCodeAction)
-            : resolveCodeAction(item, token)
-        }
-        : undefined
-    }
-    return [languages.registerCodeActionProvider(options.documentSelector, provider, this._client.id, options.codeActionKinds), provider]
-  }
-
-  public dispose(): void {
-    this.disposables.forEach(o => {
-      o.dispose()
-    })
-    this.disposables = []
-    super.dispose()
-  }
-}
-
-interface CodeLensProviderData {
-  provider?: CodeLensProvider
-  onDidChangeCodeLensEmitter?: Emitter<void>
-}
-
-class CodeLensFeature extends TextDocumentFeature<CodeLensOptions, CodeLensRegistrationOptions, CodeLensProviderData> {
-  constructor(client: BaseLanguageClient) {
-    super(client, CodeLensRequest.type)
-  }
-
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    ensure(
-      ensure(capabilities, 'textDocument')!,
-      'codeLens'
-    )!.dynamicRegistration = true
-    ensure(ensure(capabilities, 'workspace')!,
-      'codeLens'
-    )!.refreshSupport = true
-  }
-
-  public initialize(
-    capabilities: ServerCapabilities,
-    documentSelector: DocumentSelector
-  ): void {
-    const client = this._client
-    client.onRequest(CodeLensRefreshRequest.type, async () => {
-      for (const provider of this.getAllProviders()) {
-        provider.onDidChangeCodeLensEmitter.fire()
-      }
-    })
-    const options = this.getRegistrationOptions(documentSelector, capabilities.codeLensProvider)
-    if (!options) {
-      return
-    }
-    this.register({
-      id: UUID.generateUuid(),
-      registerOptions: options
-    })
-  }
-
-  protected registerLanguageProvider(
-    options: CodeLensRegistrationOptions
-  ): [Disposable, CodeLensProviderData] {
-    const emitter: Emitter<void> = new Emitter<void>()
-    const provider: CodeLensProvider = {
-      onDidChangeCodeLenses: emitter.event,
-      provideCodeLenses: (document, token) => {
-        const client = this._client
-        const provideCodeLenses: ProvideCodeLensesSignature = (document, token) => {
-          return client.sendRequest(
-            CodeLensRequest.type,
-            cv.asCodeLensParams(document),
-            token
-          ).then(
-            res => token.isCancellationRequested ? null : res,
-            error => {
-              return client.handleFailedRequest(CodeLensRequest.type, token, error, null)
-          })
-        }
-        const middleware = client.clientOptions.middleware!
-        return middleware.provideCodeLenses
-          ? middleware.provideCodeLenses(document, token, provideCodeLenses)
-          : provideCodeLenses(document, token)
-      },
-      resolveCodeLens: (options.resolveProvider)
-        ? (codeLens: CodeLens, token: CancellationToken): ProviderResult<CodeLens> => {
-          const client = this._client
-          const resolveCodeLens: ResolveCodeLensSignature = (codeLens, token) => {
-            return client.sendRequest(
-              CodeLensResolveRequest.type,
-              codeLens,
-              token
-            ).then(
-              res => token.isCancellationRequested ? codeLens : res,
-              error => {
-                return client.handleFailedRequest(CodeLensResolveRequest.type, token, error, codeLens)
-            })
-          }
-          const middleware = client.clientOptions.middleware!
-          return middleware.resolveCodeLens
-            ? middleware.resolveCodeLens(codeLens, token, resolveCodeLens)
-            : resolveCodeLens(codeLens, token)
-        }
-        : undefined
-    }
-
-    return [languages.registerCodeLensProvider(options.documentSelector, provider), { provider, onDidChangeCodeLensEmitter: emitter }]
-  }
-}
-
-class DocumentFormattingFeature extends TextDocumentFeature<
-  boolean | DocumentFormattingOptions, DocumentHighlightRegistrationOptions, DocumentFormattingEditProvider
-> {
-
-  constructor(client: BaseLanguageClient) {
-    super(client, DocumentFormattingRequest.type)
-  }
-
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    ensure(
-      ensure(capabilities, 'textDocument')!,
-      'formatting'
-    )!.dynamicRegistration = true
-  }
-
-  public initialize(
-    capabilities: ServerCapabilities,
-    documentSelector: DocumentSelector
-  ): void {
-    const options = this.getRegistrationOptions(documentSelector, capabilities.documentFormattingProvider)
-    if (!options) {
-      return
-    }
-    this.register({
-      id: UUID.generateUuid(),
-      registerOptions: options
-    })
-  }
-
-  protected registerLanguageProvider(
-    options: TextDocumentRegistrationOptions
-  ): [Disposable, DocumentFormattingEditProvider] {
-    const provider: DocumentFormattingEditProvider = {
-      provideDocumentFormattingEdits: (document, options, token) => {
-        const client = this._client
-        const provideDocumentFormattingEdits: ProvideDocumentFormattingEditsSignature = (document, options, token) => {
-          const params: DocumentFormattingParams = {
-            textDocument: { uri: document.uri },
-            options
-          }
-          return client.sendRequest(DocumentFormattingRequest.type, params, token).then(
-            res => token.isCancellationRequested ? null : res,
-            error => {
-              return client.handleFailedRequest(DocumentFormattingRequest.type, token, error, null)
-          })
-        }
-        const middleware = client.clientOptions.middleware!
-        return middleware.provideDocumentFormattingEdits
-          ? middleware.provideDocumentFormattingEdits(document, options, token, provideDocumentFormattingEdits)
-          : provideDocumentFormattingEdits(document, options, token)
-      }
-    }
-
-    return [
-      languages.registerDocumentFormatProvider(options.documentSelector!, provider, this._client.clientOptions.formatterPriority),
-      provider
-    ]
-  }
-}
-
-class DocumentRangeFormattingFeature extends TextDocumentFeature<
-  boolean | DocumentRangeFormattingOptions, DocumentRangeFormattingRegistrationOptions, DocumentRangeFormattingEditProvider
-> {
-  constructor(client: BaseLanguageClient) {
-    super(client, DocumentRangeFormattingRequest.type)
-  }
-
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    ensure(
-      ensure(capabilities, 'textDocument')!,
-      'rangeFormatting'
-    )!.dynamicRegistration = true
-  }
-
-  public initialize(
-    capabilities: ServerCapabilities,
-    documentSelector: DocumentSelector
-  ): void {
-    const options = this.getRegistrationOptions(documentSelector, capabilities.documentRangeFormattingProvider)
-    if (!options) {
-      return
-    }
-    this.register({
-      id: UUID.generateUuid(),
-      registerOptions: options
-    })
-  }
-
-  protected registerLanguageProvider(
-    options: TextDocumentRegistrationOptions
-  ): [Disposable, DocumentRangeFormattingEditProvider] {
-    const provider: DocumentRangeFormattingEditProvider = {
-      provideDocumentRangeFormattingEdits: (document, range, options, token) => {
-        const client = this._client
-        const provideDocumentRangeFormattingEdits: ProvideDocumentRangeFormattingEditsSignature = (document, range, options, token) => {
-          const params: DocumentRangeFormattingParams = {
-            textDocument: { uri: document.uri },
-            range,
-            options,
-          }
-          return client.sendRequest(DocumentRangeFormattingRequest.type, params, token).then(
-            res => token.isCancellationRequested ? null : res,
-            error => {
-              return client.handleFailedRequest(DocumentRangeFormattingRequest.type, token, error, null)
-          })
-        }
-        const middleware = client.clientOptions.middleware!
-        return middleware.provideDocumentRangeFormattingEdits
-          ? middleware.provideDocumentRangeFormattingEdits(document, range, options, token, provideDocumentRangeFormattingEdits)
-          : provideDocumentRangeFormattingEdits(document, range, options, token)
-      }
-    }
-
-    return [languages.registerDocumentRangeFormatProvider(options.documentSelector, provider), provider]
-  }
-}
-
-class DocumentOnTypeFormattingFeature extends TextDocumentFeature<
-  DocumentOnTypeFormattingOptions, DocumentOnTypeFormattingRegistrationOptions, OnTypeFormattingEditProvider
-> {
-
-  constructor(client: BaseLanguageClient) {
-    super(client, DocumentOnTypeFormattingRequest.type)
-  }
-
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    ensure(ensure(capabilities, 'textDocument')!, 'onTypeFormatting')!.dynamicRegistration = true
-  }
-
-  public initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {
-    const options = this.getRegistrationOptions(documentSelector, capabilities.documentOnTypeFormattingProvider)
-    if (!options) {
-      return
-    }
-    this.register({
-      id: UUID.generateUuid(),
-      registerOptions: options
-    })
-  }
-
-  protected registerLanguageProvider(options: DocumentOnTypeFormattingRegistrationOptions): [Disposable, OnTypeFormattingEditProvider] {
-    const provider: OnTypeFormattingEditProvider = {
-      provideOnTypeFormattingEdits: (document, position, ch, options, token) => {
-        const client = this._client
-        const provideOnTypeFormattingEdits: ProvideOnTypeFormattingEditsSignature = (document, position, ch, options, token) => {
-          const params: DocumentOnTypeFormattingParams = {
-            textDocument: cv.asVersionedTextDocumentIdentifier(document),
-            position,
-            ch,
-            options
-          }
-          return client.sendRequest(DocumentOnTypeFormattingRequest.type, params, token).then(
-            res => token.isCancellationRequested ? null : res,
-            error => {
-              return client.handleFailedRequest(DocumentOnTypeFormattingRequest.type, token, error, null)
-          })
-        }
-        const middleware = client.clientOptions.middleware!
-        return middleware.provideOnTypeFormattingEdits
-          ? middleware.provideOnTypeFormattingEdits(document, position, ch, options, token, provideOnTypeFormattingEdits)
-          : provideOnTypeFormattingEdits(document, position, ch, options, token)
-      }
-    }
-
-    const moreTriggerCharacter = options.moreTriggerCharacter || []
-    const characters = [options.firstTriggerCharacter, ...moreTriggerCharacter]
-    return [languages.registerOnTypeFormattingEditProvider(options.documentSelector!, provider, characters), provider]
-  }
-}
-
-interface DefaultBehavior {
-  defaultBehavior: boolean
-}
-
-class RenameFeature extends TextDocumentFeature<boolean | RenameOptions, RenameRegistrationOptions, RenameProvider> {
-  constructor(client: BaseLanguageClient) {
-    super(client, RenameRequest.type)
-  }
-
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    let rename = ensure(ensure(capabilities, 'textDocument')!, 'rename')!
-    rename.dynamicRegistration = true
-    rename.prepareSupport = true
-    // TODO: capabilities
-    // rename.honorsChangeAnnotations = true
-    // Some language server report bug, renable when it's useful
-    // rename.prepareSupportDefaultBehavior = PrepareSupportDefaultBehavior.Identifier
-  }
-
-  public initialize(
-    capabilities: ServerCapabilities,
-    documentSelector: DocumentSelector
-  ): void {
-    const options = this.getRegistrationOptions(documentSelector, capabilities.renameProvider)
-    if (!options) {
-      return
-    }
-    if (Is.boolean(capabilities.renameProvider)) {
-      options.prepareProvider = false
-    }
-    this.register({
-      id: UUID.generateUuid(),
-      registerOptions: options
-    })
-  }
-
-  protected registerLanguageProvider(options: RenameRegistrationOptions): [Disposable, RenameProvider] {
-    const provider: RenameProvider = {
-      provideRenameEdits: (document, position, newName, token) => {
-        const client = this._client
-        const provideRenameEdits: ProvideRenameEditsSignature = (document, position, newName, token) => {
-          const params: RenameParams = {
-            textDocument: { uri: document.uri },
-            position,
-            newName: newName
-          }
-          return client.sendRequest(RenameRequest.type, params, token).then(
-            res => token.isCancellationRequested ? null : res,
-            error => {
-              return client.handleFailedRequest(RenameRequest.type, token, error, null)
-          })
-        }
-        const middleware = client.clientOptions.middleware!
-        return middleware.provideRenameEdits
-          ? middleware.provideRenameEdits(document, position, newName, token, provideRenameEdits)
-          : provideRenameEdits(document, position, newName, token)
-      },
-      prepareRename: options.prepareProvider
-        ? (document, position, token) => {
-          const client = this._client
-          const prepareRename: PrepareRenameSignature = (document, position, token) => {
-            const params: TextDocumentPositionParams = {
-              textDocument: cv.asTextDocumentIdentifier(document),
-              position
-            }
-            return client.sendRequest(PrepareRenameRequest.type, params, token).then(
-              (result) => {
-                if (token.isCancellationRequested) {
-                  return null
-                }
-                if (Range.is(result)) {
-                  return result
-                } else if (this.isDefaultBehavior(result)) {
-                  return result.defaultBehavior === true ? null : Promise.reject(new Error(`The element can't be renamed.`))
-                } else if (result && Range.is(result.range)) {
-                  return {
-                    range: result.range,
-                    placeholder: result.placeholder
-                  }
-                }
-                // To cancel the rename vscode API expects a rejected promise.
-                return Promise.reject(new Error(`The element can't be renamed.`))
-              },
-              (error: ResponseError<void>) => {
-                return client.handleFailedRequest(PrepareRenameRequest.type, token, error, undefined)
-              }
-            )
-          }
-          const middleware = client.clientOptions.middleware!
-          return middleware.prepareRename
-            ? middleware.prepareRename(document, position, token, prepareRename)
-            : prepareRename(document, position, token)
-        }
-        : undefined
-    }
-
-    return [languages.registerRenameProvider(options.documentSelector, provider), provider]
-  }
-
-  private isDefaultBehavior(value: any): value is DefaultBehavior {
-    const candidate: DefaultBehavior = value
-    return candidate && Is.boolean(candidate.defaultBehavior)
-  }
-}
-
-class DocumentLinkFeature extends TextDocumentFeature<DocumentLinkOptions, DocumentLinkRegistrationOptions, DocumentLinkProvider> {
-  constructor(client: BaseLanguageClient) {
-    super(client, DocumentLinkRequest.type)
-  }
-
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    const documentLinkCapabilities = ensure(ensure(capabilities, 'textDocument')!, 'documentLink')!
-    documentLinkCapabilities.dynamicRegistration = true
-    documentLinkCapabilities.tooltipSupport = true
-  }
-
-  public initialize(
-    capabilities: ServerCapabilities,
-    documentSelector: DocumentSelector
-  ): void {
-    const options = this.getRegistrationOptions(documentSelector, capabilities.documentLinkProvider)
-    if (!options) {
-      return
-    }
-    this.register({
-      id: UUID.generateUuid(),
-      registerOptions: options
-    })
-  }
-
-  protected registerLanguageProvider(
-    options: DocumentLinkRegistrationOptions
-  ): [Disposable, DocumentLinkProvider] {
-    const provider: DocumentLinkProvider = {
-      provideDocumentLinks: (document: TextDocument, token: CancellationToken): ProviderResult<DocumentLink[]> => {
-        const client = this._client
-        const provideDocumentLinks: ProvideDocumentLinksSignature = (document, token) => {
-          return client.sendRequest(
-            DocumentLinkRequest.type,
-            {
-              textDocument: { uri: document.uri }
-            },
-            token
-          ).then(
-            res => token.isCancellationRequested ? null : res,
-            error => {
-              return client.handleFailedRequest(DocumentLinkRequest.type, token, error, null)
-          })
-        }
-        const middleware = client.clientOptions.middleware!
-        return middleware.provideDocumentLinks
-          ? middleware.provideDocumentLinks(document, token, provideDocumentLinks)
-          : provideDocumentLinks(document, token)
-      },
-      resolveDocumentLink: options.resolveProvider
-        ? (link, token) => {
-          const client = this._client
-          let resolveDocumentLink: ResolveDocumentLinkSignature = (link, token) => {
-            return client.sendRequest(DocumentLinkResolveRequest.type, link, token).then(
-              res => token.isCancellationRequested ? link : res,
-              error => {
-                return client.handleFailedRequest(DocumentLinkResolveRequest.type, token, error, link)
-            })
-          }
-          const middleware = client.clientOptions.middleware!
-          return middleware.resolveDocumentLink
-            ? middleware.resolveDocumentLink(link, token, resolveDocumentLink)
-            : resolveDocumentLink(link, token)
-        }
-        : undefined
-    }
-
-    return [languages.registerDocumentLinkProvider(options.documentSelector, provider), provider]
-  }
-}
-
-class ConfigurationFeature implements DynamicFeature<DidChangeConfigurationRegistrationOptions> {
-  private _listeners: Map<string, Disposable> = new Map<string, Disposable>()
-
-  constructor(private _client: BaseLanguageClient) {}
-
-  public get registrationType(): RegistrationType<DidChangeConfigurationRegistrationOptions> {
-    return DidChangeConfigurationNotification.type
-  }
-
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    ensure(ensure(capabilities, 'workspace')!, 'didChangeConfiguration')!.dynamicRegistration = true
-  }
-
-  public initialize(): void {
-    let section = this._client.clientOptions.synchronize?.configurationSection
-    if (section !== undefined) {
-      this.register({
-        id: UUID.generateUuid(),
-        registerOptions: {
-          section: section
-        }
-      })
-    }
-  }
-
-  public register(
-    data: RegistrationData<DidChangeConfigurationRegistrationOptions>
-  ): void {
-    let { section } = data.registerOptions
-    let disposable = workspace.onDidChangeConfiguration((event) => {
-      this.onDidChangeConfiguration(data.registerOptions.section, event)
-    })
-    this._listeners.set(data.id, disposable)
-    if (section != undefined) {
-      this.onDidChangeConfiguration(section, undefined)
-    }
-  }
-
-  public unregister(id: string): void {
-    let disposable = this._listeners.get(id)
-    if (disposable) {
-      this._listeners.delete(id)
-      disposable.dispose()
-    }
-  }
-
-  public dispose(): void {
-    for (let disposable of this._listeners.values()) {
-      disposable.dispose()
-    }
-    this._listeners.clear()
-  }
-
-  private onDidChangeConfiguration(configurationSection: string | string[] | undefined, event: ConfigurationChangeEvent | undefined): void {
-    let isConfigured = typeof configurationSection === 'string' && configurationSection.startsWith('languageserver.')
-    let sections: string[] | undefined
-    if (Is.string(configurationSection)) {
-      sections = [configurationSection]
-    } else {
-      sections = configurationSection
-    }
-    if (sections != null && event != null) {
-      let affected = sections.some((section) => event.affectsConfiguration(section))
-      if (!affected) return
-    }
-    let didChangeConfiguration = (sections: string[] | undefined): void => {
-      if (sections == null) {
-        this._client.sendNotification(DidChangeConfigurationNotification.type, { settings: null })
-        return
-      }
-      this._client.sendNotification(DidChangeConfigurationNotification.type, {
-        settings: isConfigured ? this.getConfiguredSettings(sections[0]) : this.extractSettingsInformation(sections)
-      })
-    }
-    let middleware = this.getMiddleware()
-    middleware
-      ? middleware(sections, didChangeConfiguration)
-      : didChangeConfiguration(sections)
-  }
-
-  // for configured languageserver
-  private getConfiguredSettings(key: string): any {
-    let len = '.settings'.length
-    let config = workspace.getConfiguration(key.slice(0, - len))
-    return mergeConfigProperties(config.get<any>('settings', {}))
-  }
-
-  private extractSettingsInformation(keys: string[]): any {
-    function ensurePath(config: any, path: string[]): any {
-      let current = config
-      for (let i = 0; i < path.length - 1; i++) {
-        let obj = current[path[i]]
-        if (!obj) {
-          obj = Object.create(null)
-          current[path[i]] = obj
-        }
-        current = obj
-      }
-      return current
-    }
-    let result = Object.create(null)
-    for (let i = 0; i < keys.length; i++) {
-      let key = keys[i]
-      let index: number = key.indexOf('.')
-      let config: any = null
-      if (index >= 0) {
-        config = workspace.getConfiguration(key.substr(0, index)).get(key.substr(index + 1))
-      } else {
-        config = workspace.getConfiguration(key)
-      }
-      if (config) {
-        let path = keys[i].split('.')
-        ensurePath(result, path)[path[path.length - 1]] = config
-      }
-    }
-    return result
-  }
-
-  private getMiddleware() {
-    let middleware = this._client.clientOptions.middleware!
-    if (middleware.workspace && middleware.workspace.didChangeConfiguration) {
-      return middleware.workspace.didChangeConfiguration
-    } else {
-      return undefined
-    }
-  }
-}
-
-class ExecuteCommandFeature
-  implements DynamicFeature<ExecuteCommandRegistrationOptions> {
-  private _commands: Map<string, Disposable[]> = new Map<string, Disposable[]>()
-  constructor(private _client: BaseLanguageClient) {}
-
-  public get registrationType(): RegistrationType<ExecuteCommandRegistrationOptions> {
-    return ExecuteCommandRequest.type
-  }
-
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
-    ensure(
-      ensure(capabilities, 'workspace')!,
-      'executeCommand'
-    )!.dynamicRegistration = true
-  }
-
-  public initialize(capabilities: ServerCapabilities): void {
-    if (!capabilities.executeCommandProvider) {
-      return
-    }
-    this.register({
-      id: UUID.generateUuid(),
-      registerOptions: Object.assign({}, capabilities.executeCommandProvider)
-    })
-  }
-
-  public register(
-    data: RegistrationData<ExecuteCommandRegistrationOptions>
-  ): void {
-    const client = this._client
-    const middleware = client.clientOptions.middleware!
-    const executeCommand: ExecuteCommandSignature = (command: string, args: any[]): any => {
-      const params: ExecuteCommandParams = {
-        command,
-        arguments: args
-      }
-      return client.sendRequest(ExecuteCommandRequest.type, params).then(undefined, (error) => {
-        client.handleFailedRequest(ExecuteCommandRequest.type, undefined, error, undefined)
-        throw error
-      })
-    }
-    if (data.registerOptions.commands) {
-      let disposables: Disposable[] = []
-      for (const command of data.registerOptions.commands) {
-        disposables.push(commands.registerCommand(command, (...args: any[]) => {
-          return middleware.executeCommand
-            ? middleware.executeCommand(command, args, executeCommand)
-            : executeCommand(command, args)
-        }, null, true))
-      }
-      this._commands.set(data.id, disposables)
-    }
-  }
-
-  public unregister(id: string): void {
-    let disposables = this._commands.get(id)
-    if (disposables) {
-      disposables.forEach(disposable => disposable.dispose())
-    }
-  }
-
-  public dispose(): void {
-    this._commands.forEach(value => {
-      value.forEach(disposable => disposable.dispose())
-    })
-    this._commands.clear()
-  }
-}
-
 export interface MessageTransports {
   reader: MessageReader
   writer: MessageWriter
   detached?: boolean
 }
 
+// eslint-disable-next-line no-redeclare
 export namespace MessageTransports {
   export function is(value: any): value is MessageTransports {
     let candidate: MessageTransports = value
@@ -3073,51 +288,38 @@ export namespace MessageTransports {
   }
 }
 
-class OnReady {
-  private _used: boolean
-  constructor(private _resolve: () => void, private _reject: (error: any) => void) {
-    this._used = false
-  }
-
-  public get isUsed(): boolean {
-    return this._used
-  }
-
-  public resolve(): void {
-    this._used = true
-    this._resolve()
-  }
-
-  public reject(error: any): void {
-    this._used = true
-    this._reject(error)
-  }
-}
-
-export abstract class BaseLanguageClient {
+export abstract class BaseLanguageClient implements FeatureClient<Middleware, LanguageClientOptions> {
   private _id: string
   private _name: string
-  private _markdownSupport: boolean
   private _clientOptions: ResolvedClientOptions
   private _rootPath: string | false
+  private _disposed: 'disposing' | 'disposed' | undefined
+  private readonly _ignoredRegistrations: Set<string>
 
   protected _state: ClientState
-  private _onReady: Promise<void>
-  private _onReadyCallbacks: OnReady
+  private _onStart: Promise<void> | undefined
   private _onStop: Promise<void> | undefined
-  private _connectionPromise: Promise<IConnection> | undefined
-  private _resolvedConnection: IConnection | undefined
+  private _connection: Connection | undefined
   private _initializeResult: InitializeResult | undefined
   private _outputChannel: OutputChannel | undefined
   private _capabilities: ServerCapabilities & ResolvedTextDocumentSyncCapabilities
 
-  private _listeners: Disposable[] | undefined
-  private _providers: Disposable[] | undefined
+  private readonly _notificationHandlers: Map<string, GenericNotificationHandler>
+  private readonly _notificationDisposables: Map<string, Disposable>
+  private readonly _pendingNotificationHandlers: Map<string, GenericNotificationHandler>
+  private readonly _requestHandlers: Map<string, GenericRequestHandler<unknown, unknown>>
+  private readonly _requestDisposables: Map<string, Disposable>
+  private readonly _pendingRequestHandlers: Map<string, GenericRequestHandler<unknown, unknown>>
+  private readonly _progressHandlers: Map<string | number, { type: ProgressType<any>; handler: NotificationHandler<any> }>
+  private readonly _pendingProgressHandlers: Map<string | number, { type: ProgressType<any>; handler: NotificationHandler<any> }>
+  private readonly _progressDisposables: Map<string | number, Disposable>
+
+  private _listeners: Disposable[]
   private _diagnostics: DiagnosticCollection | undefined
   private _syncedDocuments: Map<string, TextDocument>
 
-  private _fileEvents: FileEvent[]
-  private _fileEventDelayer: Delayer<void>
+  private _fileEventsMap: Map<string, FileEvent>
+  public debouncedFileNotify: Function & { clear(): void }
   private _stateChangeEmitter: Emitter<StateChangeEvent>
 
   private _traceFormat: TraceFormat
@@ -3136,12 +338,6 @@ export abstract class BaseLanguageClient {
     } else {
       this._outputChannel = undefined
     }
-    let disableSnippetCompletion = false
-    let suggest = workspace.getConfiguration('suggest')
-    if (suggest.get<boolean>('snippetsSupport', true) === false || clientOptions.disableSnippetCompletion) {
-      disableSnippetCompletion = true
-    }
-
     const markdown = { isTrusted: false, supportHtml: false }
     if (clientOptions.markdown != null) {
       markdown.isTrusted = clientOptions.markdown.isTrusted === true
@@ -3149,7 +345,11 @@ export abstract class BaseLanguageClient {
     }
 
     this._clientOptions = {
-      disableSnippetCompletion,
+      rootPatterns: clientOptions.rootPatterns,
+      requireRootPattern: clientOptions.requireRootPattern,
+      separateDiagnostics: clientOptions.separateDiagnostics === true,
+      disableMarkdown: clientOptions.disableMarkdown === true,
+      disableSnippetCompletion: clientOptions.disableSnippetCompletion,
       disableDynamicRegister: clientOptions.disableDynamicRegister,
       disabledFeatures: clientOptions.disabledFeatures || [],
       formatterPriority: clientOptions.formatterPriority,
@@ -3165,7 +365,7 @@ export abstract class BaseLanguageClient {
       initializationFailedHandler: clientOptions.initializationFailedHandler,
       progressOnInitialization: !!clientOptions.progressOnInitialization,
       errorHandler: clientOptions.errorHandler || this.createDefaultErrorHandler(clientOptions.connectionOptions?.maxRestartCount),
-      middleware: clientOptions.middleware || {},
+      middleware: clientOptions.middleware ?? {},
       workspaceFolder: clientOptions.workspaceFolder,
       connectionOptions: clientOptions.connectionOptions,
       markdown
@@ -3181,19 +381,27 @@ export abstract class BaseLanguageClient {
         }
       }
     }
-    this.state = ClientState.Initial
-    this._connectionPromise = undefined
-    this._resolvedConnection = undefined
+    this.$state = ClientState.Initial
+    this._connection = undefined
     this._initializeResult = undefined
-    this._listeners = undefined
-    this._providers = undefined
+    this._listeners = []
     this._diagnostics = undefined
 
-    this._fileEvents = []
-    this._fileEventDelayer = new Delayer<void>(250)
-    this._onReady = new Promise<void>((resolve, reject) => {
-      this._onReadyCallbacks = new OnReady(resolve, reject)
-    })
+    this._notificationHandlers = new Map()
+    this._pendingNotificationHandlers = new Map()
+    this._notificationDisposables = new Map()
+    this._requestHandlers = new Map()
+    this._pendingRequestHandlers = new Map()
+    this._requestDisposables = new Map()
+    this._progressHandlers = new Map()
+    this._pendingProgressHandlers = new Map()
+    this._progressDisposables = new Map()
+
+    this._ignoredRegistrations = new Set()
+    this._fileEventsMap = new Map()
+    this.debouncedFileNotify = debounce(() => {
+      this._notifyFileEvent()
+    }, 200)
     this._onStop = undefined
     this._stateChangeEmitter = new Emitter<StateChangeEvent>()
     this._trace = Trace.Off
@@ -3207,18 +415,25 @@ export abstract class BaseLanguageClient {
       }
     }
     this._syncedDocuments = new Map<string, TextDocument>()
-    let preferences = workspace.getConfiguration('coc.preferences')
-    this._markdownSupport = preferences.get('enableMarkdown', true)
     this.registerBuiltinFeatures()
   }
 
   public get supportedMarkupKind(): MarkupKind[] {
-    if (this._markdownSupport) return [MarkupKind.Markdown, MarkupKind.PlainText]
+    if (!this.clientOptions.disableMarkdown) return [MarkupKind.Markdown, MarkupKind.PlainText]
     return [MarkupKind.PlainText]
   }
 
-  private get state(): ClientState {
+  private get $state(): ClientState {
     return this._state
+  }
+
+  private set $state(value: ClientState) {
+    let oldState = this.getPublicState()
+    this._state = value
+    let newState = this.getPublicState()
+    if (newState !== oldState) {
+      this._stateChangeEmitter.fire({ oldState, newState })
+    }
   }
 
   public get id(): string {
@@ -3229,19 +444,14 @@ export abstract class BaseLanguageClient {
     return this._name
   }
 
-  private set state(value: ClientState) {
-    let oldState = this.getPublicState()
-    this._state = value
-    let newState = this.getPublicState()
-    if (newState !== oldState) {
-      this._stateChangeEmitter.fire({ oldState, newState })
-    }
+  public get middleware(): Middleware {
+    return this._clientOptions.middleware ?? Object.create(null)
   }
 
   public getPublicState(): State {
-    if (this.state === ClientState.Running) {
+    if (this.$state === ClientState.Running) {
       return State.Running
-    } else if (this.state === ClientState.Starting) {
+    } else if (this.$state === ClientState.Starting) {
       return State.Starting
     } else {
       return State.Stopped
@@ -3258,17 +468,13 @@ export abstract class BaseLanguageClient {
   public sendRequest<P, R, E>(type: RequestType<P, R, E>, params: P, token?: CancellationToken): Promise<R>
   public sendRequest<R>(method: string, token?: CancellationToken): Promise<R>
   public sendRequest<R>(method: string, param: any, token?: CancellationToken): Promise<R>
-  public sendRequest<R>(type: string | MessageSignature, ...params: any[]): Promise<R> {
-    if (!this.isConnectionActive()) {
-      throw new Error('Language client is not ready yet')
-    }
+  public async sendRequest<R>(type: string | MessageSignature, ...params: any[]): Promise<R> {
+    this.checkState()
     try {
-      return this._resolvedConnection!.sendRequest<R>(type, ...params)
+      const connection = await this.$start()
+      return await connection.sendRequest<R>(type, ...params)
     } catch (error) {
-      this.error(
-        `Sending request ${Is.string(type) ? type : type.method} failed.`,
-        error
-      )
+      this.error(`Sending request ${Is.string(type) ? type : type.method} failed.`, error)
       throw error
     }
   }
@@ -3279,38 +485,54 @@ export abstract class BaseLanguageClient {
   public onRequest<P, R, E>(type: RequestType<P, R, E>, handler: RequestHandler<P, R, E>): Disposable
   public onRequest<R, E>(method: string, handler: GenericRequestHandler<R, E>): Disposable
   public onRequest<R, E>(type: string | MessageSignature, handler: GenericRequestHandler<R, E>): Disposable {
-    if (!this.isConnectionActive()) {
-      throw new Error('Language client is not ready yet')
+    const method = typeof type === 'string' ? type : type.method
+    this._requestHandlers.set(method, handler)
+    const connection = this.activeConnection()
+    let disposable: Disposable
+    if (connection !== undefined) {
+      this._requestDisposables.set(method, connection.onRequest(type, handler))
+      disposable = {
+        dispose: () => {
+          const disposable = this._requestDisposables.get(method)
+          if (disposable !== undefined) {
+            disposable.dispose()
+            this._requestDisposables.delete(method)
+          }
+        }
+      }
+    } else {
+      this._pendingRequestHandlers.set(method, handler)
+      disposable = {
+        dispose: () => {
+          this._pendingRequestHandlers.delete(method)
+          const disposable = this._requestDisposables.get(method)
+          if (disposable !== undefined) {
+            disposable.dispose()
+            this._requestDisposables.delete(method)
+          }
+        }
+      }
     }
-    try {
-      return this._resolvedConnection!.onRequest(type, handler)
-    } catch (error) {
-      this.error(
-        `Registering request handler ${Is.string(type) ? type : type.method
-        } failed.`,
-        error
-      )
-      throw error
+    return {
+      dispose: () => {
+        this._requestHandlers.delete(method)
+        disposable.dispose()
+      }
     }
   }
 
-  public sendNotification<RO>(type: ProtocolNotificationType0<RO>): void
-  public sendNotification<P, RO>(type: ProtocolNotificationType<P, RO>, params?: P): void
-  public sendNotification(type: NotificationType0): void
-  public sendNotification<P>(type: NotificationType<P>, params?: P): void
-  public sendNotification(method: string): void
-  public sendNotification(method: string, params: any): void
-  public sendNotification<P>(type: string | MessageSignature, params?: P): void {
-    if (!this.isConnectionActive()) {
-      throw new Error('Language client is not ready yet')
-    }
+  public sendNotification<RO>(type: ProtocolNotificationType0<RO>): Promise<void>
+  public sendNotification<P, RO>(type: ProtocolNotificationType<P, RO>, params?: P): Promise<void>
+  public sendNotification(type: NotificationType0): Promise<void>
+  public sendNotification<P>(type: NotificationType<P>, params?: P): Promise<void>
+  public sendNotification(method: string, params?: any): Promise<void>
+  public async sendNotification<P>(type: string | MessageSignature, params?: P): Promise<void> {
+    this.checkState()
     try {
-      this._resolvedConnection!.sendNotification(type, params)
+      const connection = await this.$start()
+      return await connection.sendNotification(type, params)
     } catch (error) {
-      this.error(
-        `Sending notification ${Is.string(type) ? type : type.method} failed.`,
-        error
-      )
+      this.error(`Sending notification ${Is.string(type) ? type : type.method} failed.`, error)
       throw error
     }
   }
@@ -3321,47 +543,89 @@ export abstract class BaseLanguageClient {
   public onNotification<P>(type: NotificationType<P>, handler: NotificationHandler<P>): Disposable
   public onNotification(method: string, handler: GenericNotificationHandler): Disposable
   public onNotification(type: string | MessageSignature, handler: GenericNotificationHandler): Disposable {
-    if (!this.isConnectionActive()) {
-      throw new Error('Language client is not ready yet')
+    const method = typeof type === 'string' ? type : type.method
+    this._notificationHandlers.set(method, handler)
+    const connection = this.activeConnection()
+    let disposable: Disposable
+    if (connection !== undefined) {
+      this._notificationDisposables.set(method, connection.onNotification(type, handler))
+      disposable = {
+        dispose: () => {
+          const disposable = this._notificationDisposables.get(method)
+          if (disposable !== undefined) {
+            disposable.dispose()
+            this._notificationDisposables.delete(method)
+          }
+        }
+      }
+    } else {
+      this._pendingNotificationHandlers.set(method, handler)
+      disposable = {
+        dispose: () => {
+          this._pendingNotificationHandlers.delete(method)
+          const disposable = this._notificationDisposables.get(method)
+          if (disposable !== undefined) {
+            disposable.dispose()
+            this._notificationDisposables.delete(method)
+          }
+        }
+      }
     }
-    try {
-      return this._resolvedConnection!.onNotification(type, handler)
-    } catch (error) {
-      this.error(
-        `Registering notification handler ${Is.string(type) ? type : type.method
-        } failed.`,
-        error
-      )
-      throw error
+    return {
+      dispose: () => {
+        this._notificationHandlers.delete(method)
+        disposable.dispose()
+      }
     }
   }
 
   public onProgress<P>(type: ProgressType<any>, token: string | number, handler: NotificationHandler<P>): Disposable {
-    if (!this.isConnectionActive()) {
-      throw new Error('Language client is not ready yet')
-    }
-    try {
-      if (type == WorkDoneProgress.type) {
-        const handleWorkDoneProgress = this._clientOptions.middleware!.handleWorkDoneProgress
-        if (handleWorkDoneProgress !== undefined) {
-          return this._resolvedConnection!.onProgress(type, token, (params) => {
-            handleWorkDoneProgress(token, params as any, () => handler(params as unknown as P))
-          })
+    this._progressHandlers.set(token, { type, handler })
+    const connection = this.activeConnection()
+    let disposable: Disposable
+    const handleWorkDoneProgress = this._clientOptions.middleware?.handleWorkDoneProgress
+    const realHandler = WorkDoneProgress.is(type) && handleWorkDoneProgress !== undefined
+      ? (params: P) => {
+        handleWorkDoneProgress(token, params as any, () => handler(params as unknown as P))
+      }
+      : handler
+    if (connection !== undefined) {
+      this._progressDisposables.set(token, connection.onProgress(type, token, realHandler))
+      disposable = {
+        dispose: () => {
+          const disposable = this._progressDisposables.get(token)
+          if (disposable !== undefined) {
+            disposable.dispose()
+            this._progressDisposables.delete(token)
+          }
         }
       }
-      return this._resolvedConnection!.onProgress(type, token, handler)
-    } catch (error) {
-      this.error(`Registering progress handler for token ${token} failed.`, error)
-      throw error
+    } else {
+      this._pendingProgressHandlers.set(token, { type, handler })
+      disposable = {
+        dispose: () => {
+          this._pendingProgressHandlers.delete(token)
+          const disposable = this._progressDisposables.get(token)
+          if (disposable !== undefined) {
+            disposable.dispose()
+            this._progressDisposables.delete(token)
+          }
+        }
+      }
+    }
+    return {
+      dispose: (): void => {
+        this._progressHandlers.delete(token)
+        disposable.dispose()
+      }
     }
   }
 
-  public sendProgress<P>(type: ProgressType<P>, token: string | number, value: P): void {
-    if (!this.isConnectionActive()) {
-      throw new Error('Language client is not ready yet')
-    }
+  public async sendProgress<P>(type: ProgressType<P>, token: string | number, value: P): Promise<void> {
+    this.checkState()
     try {
-      this._resolvedConnection!.sendProgress(type, token, value)
+      const connection = await this.$start()
+      await connection.sendProgress(type, token, value)
     } catch (error) {
       this.error(`Sending progress for token ${token} failed.`, error)
       throw error
@@ -3394,17 +658,13 @@ export abstract class BaseLanguageClient {
 
   public set trace(value: Trace) {
     this._trace = value
-    this.onReady().then(
-      () => {
-        this.resolveConnection().then(connection => {
-          connection.trace(this._trace, this._tracer, {
-            sendNotification: false,
-            traceFormat: this._traceFormat
-          })
-        })
-      },
-      () => {}
-    )
+    const connection = this.activeConnection()
+    if (connection !== undefined) {
+      void connection.trace(this._trace, this._tracer, {
+        sendNotification: false,
+        traceFormat: this._traceFormat
+      })
+    }
   }
 
   private logObjectTrace(data: any): void {
@@ -3478,45 +738,61 @@ export abstract class BaseLanguageClient {
 
   public needsStart(): boolean {
     return (
-      this.state === ClientState.Initial ||
-      this.state === ClientState.Stopping ||
-      this.state === ClientState.Stopped
+      this.$state === ClientState.Initial ||
+      this.$state === ClientState.Stopping ||
+      this.$state === ClientState.Stopped
     )
   }
 
   public needsStop(): boolean {
     return (
-      this.state === ClientState.Starting || this.state === ClientState.Running
+      this.$state === ClientState.Starting || this.$state === ClientState.Running
     )
   }
 
+  private activeConnection(): Connection | undefined {
+    return this.$state === ClientState.Running && this._connection !== undefined ? this._connection : undefined
+  }
+
   public onReady(): Promise<void> {
-    return this._onReady
+    if (this._onStart) return this._onStart
+    return new Promise(resolve => {
+      let disposable = this.onDidChangeState(e => {
+        if (e.newState === State.Running) {
+          disposable.dispose()
+          resolve()
+        }
+      })
+    })
   }
 
   public get started(): boolean {
-    return this.state != ClientState.Initial
+    return this.$state != ClientState.Initial
   }
 
-  private isConnectionActive(): boolean {
-    return this.state === ClientState.Running && !!this._resolvedConnection
+  public isRunning(): boolean {
+    return this.$state === ClientState.Running
   }
 
-  public start(): Disposable {
+  public async _start(): Promise<void> {
+    if (this._disposed === 'disposing' || this._disposed === 'disposed') {
+      throw new Error(`Client got disposed and can't be restarted.`)
+    }
+    if (this.$state === ClientState.Stopping) {
+      throw new Error(`Client is currently stopping. Can only restart a full stopped client`)
+    }
+    // We are already running or are in the process of getting up
+    // to speed.
+    if (this._onStart !== undefined) {
+      return this._onStart
+    }
     this._rootPath = this.resolveRootPath()
-    if (this._rootPath === false) {
-      this.warn(`Required root pattern not resolved, server won't start.`)
-      return Disposable.create(() => {})
-    }
-    if (this._onReadyCallbacks.isUsed) {
-      this._onReady = new Promise((resolve, reject) => {
-        this._onReadyCallbacks = new OnReady(resolve, reject)
-      })
-    }
-    this._listeners = []
-    this._providers = []
+
+    const [promise, resolve, reject] = this.createOnStartPromise()
+    this._onStart = promise
+
     // If we restart then the diagnostics collection is reused.
-    if (!this._diagnostics) {
+    if (this._diagnostics === undefined) {
       let opts = this._clientOptions
       let name = opts.diagnosticCollectionName ? opts.diagnosticCollectionName : this._id
       if (!opts.disabledFeatures.includes('diagnostics')) {
@@ -3524,139 +800,179 @@ export abstract class BaseLanguageClient {
       }
     }
 
-    this.state = ClientState.Starting
-    this.resolveConnection()
-      .then(connection => {
-        connection.onLogMessage(message => {
-          let kind: string
-          switch (message.type) {
-            case MessageType.Error:
-              kind = 'error'
-              this.error(message.message)
-              break
-            case MessageType.Warning:
-              kind = 'warning'
-              this.warn(message.message)
-              break
-            case MessageType.Info:
-              kind = 'info'
-              this.info(message.message)
-              break
-            default:
-              kind = 'log'
-              this.outputChannel.appendLine(message.message)
-          }
-          if (global.hasOwnProperty('__TEST__')) {
-            console.log(`[${kind}] ${message.message}`)
-            return
-          }
-        })
-        connection.onShowMessage(message => {
-          switch (message.type) {
-            case MessageType.Error:
-              window.showErrorMessage(message.message)
-              break
-            case MessageType.Warning:
-              window.showWarningMessage(message.message)
-              break
-            case MessageType.Info:
-              window.showInformationMessage(message.message)
-              break
-            default:
-              window.showInformationMessage(message.message)
-          }
-        })
-        connection.onRequest(ShowMessageRequest.type, (params: ShowMessageRequestParams) => {
-          let messageFunc: <T extends MessageItem>(message: string, ...items: T[]) => Thenable<T>
-          switch (params.type) {
-            case MessageType.Error:
-              messageFunc = window.showErrorMessage.bind(window)
-              break
-            case MessageType.Warning:
-              messageFunc = window.showWarningMessage.bind(window)
-              break
-            case MessageType.Info:
-              messageFunc = window.showInformationMessage.bind(window)
-              break
-            default:
-              messageFunc = window.showInformationMessage.bind(window)
-          }
-          let actions: MessageActionItem[] = params.actions || []
-          return messageFunc(params.message, ...actions).then(res => {
-            return res == null ? null : res
-          })
-        })
-        connection.onRequest(ShowDocumentRequest.type, async (params): Promise<ShowDocumentResult> => {
-          const showDocument = async (params: ShowDocumentParams): Promise<ShowDocumentResult> => {
-            try {
-              if (params.external === true || /^https?:\/\//.test(params.uri)) {
-                await workspace.openResource(params.uri)
-                return { success: true }
-              } else {
-                let { selection, takeFocus } = params
-                if (takeFocus === false) {
-                  await workspace.loadFile(params.uri)
-                } else {
-                  await workspace.jumpTo(params.uri, selection?.start)
-                  if (comparePosition(selection.start, selection.end) != 0) {
-                    await window.selectRange(selection)
-                  }
-                }
-                return { success: true }
-              }
-            } catch (error) {
-              return { success: true }
-            }
-          }
-          const middleware = this._clientOptions.middleware.window?.showDocument
-          if (middleware !== undefined) {
-            return middleware(params, showDocument)
-          } else {
-            return showDocument(params)
-          }
-        })
-        connection.onTelemetry(_data => {
-          // ignored
-        })
-        connection.listen()
-        // Error is handled in the initialize call.
-        return this.initialize(connection)
-      }).then(undefined, error => {
-        this.state = ClientState.StartFailed
-        this._onReadyCallbacks.reject(error)
-        this.error('Starting client failed ', error)
-      })
+    // When we start make all buffer handlers pending so that they
+    // get added.
+    for (const [method, handler] of this._notificationHandlers) {
+      if (!this._pendingNotificationHandlers.has(method)) {
+        this._pendingNotificationHandlers.set(method, handler)
+      }
+    }
+    for (const [method, handler] of this._requestHandlers) {
+      if (!this._pendingRequestHandlers.has(method)) {
+        this._pendingRequestHandlers.set(method, handler)
+      }
+    }
+    for (const [token, data] of this._progressHandlers) {
+      if (!this._pendingProgressHandlers.has(token)) {
+        this._pendingProgressHandlers.set(token, data)
+      }
+    }
+
+    this.$state = ClientState.Starting
+    try {
+      const connection = await this.createConnection()
+      this.handleConnectionEvents(connection)
+      connection.listen()
+      await this.initialize(connection)
+      resolve()
+    } catch (error) {
+      this.$state = ClientState.StartFailed
+      this.error(`${this._name} client: couldn't create connection to server.`, error)
+      reject(error)
+    }
+    return this._onStart
+  }
+
+  public start(): Disposable {
+    this._start().catch(error => this.error(`Restarting server failed`, error))
     return Disposable.create(() => {
       if (this.needsStop()) {
-        this.stop()
+        void this.stop()
       }
     })
   }
 
-  private resolveConnection(): Promise<IConnection> {
-    if (!this._connectionPromise) {
-      this._connectionPromise = this.createConnection()
+  private async $start(): Promise<Connection> {
+    if (this.$state === ClientState.StartFailed) {
+      throw new Error(`Previous start failed. Can't restart server.`)
     }
-    return this._connectionPromise
+    await this._start()
+    const connection = this.activeConnection()
+    if (connection === undefined) {
+      throw new Error(`Starting server failed`)
+    }
+    return connection
   }
 
-  private resolveRootPath(): string | null | false {
+  private handleConnectionEvents(connection: Connection) {
+    connection.onNotification(LogMessageNotification.type, message => {
+      switch (message.type) {
+        case MessageType.Error:
+          this.error(message.message)
+          break
+        case MessageType.Warning:
+          this.warn(message.message)
+          break
+        case MessageType.Info:
+          this.info(message.message)
+          break
+        default:
+          this.outputChannel.appendLine(message.message)
+      }
+      if (global.__TEST__) {
+        console.log(message.message)
+        return
+      }
+    })
+    connection.onNotification(ShowMessageNotification.type, message => {
+      switch (message.type) {
+        case MessageType.Error:
+          void window.showErrorMessage(message.message)
+          break
+        case MessageType.Warning:
+          void window.showWarningMessage(message.message)
+          break
+        case MessageType.Info:
+          void window.showInformationMessage(message.message)
+          break
+        default:
+          void window.showInformationMessage(message.message)
+      }
+    })
+    connection.onNotification(TelemetryEventNotification.type, data => {
+      // Not supported.
+      // this._telemetryEmitter.fire(data);
+    })
+    connection.onRequest(ShowMessageRequest.type, (params: ShowMessageRequestParams) => {
+      let messageFunc: <T extends MessageItem>(message: string, ...items: T[]) => Thenable<T>
+      switch (params.type) {
+        case MessageType.Error:
+          messageFunc = window.showErrorMessage.bind(window)
+          break
+        case MessageType.Warning:
+          messageFunc = window.showWarningMessage.bind(window)
+          break
+        case MessageType.Info:
+          messageFunc = window.showInformationMessage.bind(window)
+          break
+        default:
+          messageFunc = window.showInformationMessage.bind(window)
+      }
+      let actions: MessageActionItem[] = params.actions || []
+      return messageFunc(params.message, ...actions).then(res => {
+        return res == null ? null : res
+      })
+    })
+    connection.onRequest(ShowDocumentRequest.type, async (params): Promise<ShowDocumentResult> => {
+      const showDocument = async (params: ShowDocumentParams): Promise<ShowDocumentResult> => {
+        try {
+          if (params.external === true || /^https?:\/\//.test(params.uri)) {
+            await workspace.openResource(params.uri)
+            return { success: true }
+          } else {
+            let { selection, takeFocus } = params
+            if (takeFocus === false) {
+              await workspace.loadFile(params.uri)
+            } else {
+              await workspace.jumpTo(params.uri, selection?.start)
+              if (comparePosition(selection.start, selection.end) != 0) {
+                await window.selectRange(selection)
+              }
+            }
+            return { success: true }
+          }
+        } catch (error) {
+          return { success: true }
+        }
+      }
+      const middleware = this._clientOptions.middleware.window?.showDocument
+      if (middleware !== undefined) {
+        return middleware(params, showDocument)
+      } else {
+        return showDocument(params)
+      }
+    })
+  }
+
+  private createOnStartPromise(): [Promise<void>, () => void, (error: any) => void] {
+    let resolve!: () => void
+    let reject!: (error: any) => void
+    const promise: Promise<void> = new Promise((_resolve, _reject) => {
+      resolve = _resolve
+      reject = _reject
+    })
+    return [promise, resolve, reject]
+  }
+
+  private resolveRootPath(): string | null {
     if (this._clientOptions.workspaceFolder) {
       return URI.parse(this._clientOptions.workspaceFolder.uri).fsPath
     }
-    let { ignoredRootPaths } = this._clientOptions
-    let config = workspace.getConfiguration(this.id)
-    let rootPatterns = config.get<string[]>('rootPatterns', [])
-    let required = config.get<boolean>('requireRootPattern', false)
+    let { ignoredRootPaths, rootPatterns, requireRootPattern } = this._clientOptions
     let resolved: string
-    if (rootPatterns && rootPatterns.length) {
+    if (Array.isArray(rootPatterns) && rootPatterns.length > 0) {
       let doc = workspace.getDocument(workspace.bufnr)
       if (doc && doc.schema == 'file') {
         let dir = path.dirname(URI.parse(doc.uri).fsPath)
         resolved = resolveRoot(dir, rootPatterns, workspace.cwd)
+      } else {
+        resolved = resolveRoot(workspace.cwd, rootPatterns)
+      }
+      if (requireRootPattern && !resolved) {
+        throw new Error(`Required root pattern not resolved, server won't start.`)
       }
     }
-    if (required && !resolved) return false
+
     let rootPath = resolved || workspace.rootPath || workspace.cwd
     if (sameFile(rootPath, os.homedir()) || (Array.isArray(ignoredRootPaths) && ignoredRootPaths.some(p => sameFile(rootPath, p)))) {
       this.warn(`Ignored rootPath ${rootPath} of client "${this._id}"`)
@@ -3665,7 +981,7 @@ export abstract class BaseLanguageClient {
     return rootPath
   }
 
-  private initialize(connection: IConnection): Promise<InitializeResult> {
+  private initialize(connection: Connection): Promise<InitializeResult> {
     let { initializationOptions, progressOnInitialization } = this._clientOptions
     this.refreshTrace(connection, false)
     let rootPath = this._rootPath
@@ -3689,10 +1005,10 @@ export abstract class BaseLanguageClient {
       initParams.workDoneToken = token
       const part = new ProgressPart(this._id, connection, token)
       part.begin({ title: `Initializing ${this.id}`, kind: 'begin' })
-      return this.doInitialize(connection, initParams).then((result) => {
+      return this.doInitialize(connection, initParams).then(result => {
         part.done()
         return result
-      }, (error) => {
+      }, error => {
         part.cancel()
         throw error
       })
@@ -3701,13 +1017,17 @@ export abstract class BaseLanguageClient {
     }
   }
 
-  private doInitialize(connection: IConnection, initParams: InitializeParams): Promise<InitializeResult> {
-    return connection.initialize(initParams).then(result => {
-      this._resolvedConnection = connection
-      this._initializeResult = result
-      this.state = ClientState.Running
+  private async doInitialize(connection: Connection, initParams: InitializeParams): Promise<InitializeResult> {
+    try {
+      const result = await connection.initialize(initParams)
+      if (result.capabilities.positionEncoding !== undefined && result.capabilities.positionEncoding !== PositionEncodingKind.UTF16) {
+        throw new Error(`Unsupported position encoding (${result.capabilities.positionEncoding}) received from server ${this.name}`)
+      }
 
-      let textDocumentSyncOptions: TextDocumentSyncOptions | undefined = undefined
+      this._initializeResult = result
+      this.$state = ClientState.Running
+
+      let textDocumentSyncOptions: TextDocumentSyncOptions | undefined
       if (Is.number(result.capabilities.textDocumentSync)) {
         if (result.capabilities.textDocumentSync === TextDocumentSyncKind.None) {
           textDocumentSyncOptions = {
@@ -3724,124 +1044,143 @@ export abstract class BaseLanguageClient {
             }
           }
         }
-      } else if (result.capabilities.textDocumentSync != null && result.capabilities.textDocumentSync !== undefined) {
+      } else if (result.capabilities.textDocumentSync !== undefined && result.capabilities.textDocumentSync !== null) {
         textDocumentSyncOptions = result.capabilities.textDocumentSync as TextDocumentSyncOptions
       }
-      this._capabilities = Object.assign({}, result.capabilities, {
-        resolvedTextDocumentSync: textDocumentSyncOptions
-      })
-      connection.onDiagnostics(params => this.handleDiagnostics(params))
-      connection.onRequest(RegistrationRequest.type, params =>
-        this.handleRegistrationRequest(params)
-      )
-      // See https://github.com/Microsoft/vscode-languageserver-node/issues/199
-      connection.onRequest('client/registerFeature', params =>
-        this.handleRegistrationRequest(params)
-      )
-      connection.onRequest(UnregistrationRequest.type, params =>
-        this.handleUnregistrationRequest(params)
-      )
-      // See https://github.com/Microsoft/vscode-languageserver-node/issues/199
-      connection.onRequest('client/unregisterFeature', params =>
-        this.handleUnregistrationRequest(params)
-      )
-      connection.onRequest(ApplyWorkspaceEditRequest.type, params =>
-        this.handleApplyWorkspaceEdit(params)
-      )
+      this._capabilities = Object.assign({}, result.capabilities, { resolvedTextDocumentSync: textDocumentSyncOptions })
 
-      connection.sendNotification(InitializedNotification.type, {})
+      connection.onNotification(PublishDiagnosticsNotification.type, params => this.handleDiagnostics(params))
+      connection.onRequest(RegistrationRequest.type, params => this.handleRegistrationRequest(params))
+      // See https://github.com/Microsoft/vscode-languageserver-node/issues/199
+      connection.onRequest('client/registerFeature', params => this.handleRegistrationRequest(params))
+      connection.onRequest(UnregistrationRequest.type, params => this.handleUnregistrationRequest(params))
+      // See https://github.com/Microsoft/vscode-languageserver-node/issues/199
+      connection.onRequest('client/unregisterFeature', params => this.handleUnregistrationRequest(params))
+      connection.onRequest(ApplyWorkspaceEditRequest.type, params => this.handleApplyWorkspaceEdit(params))
+
+      // Add pending notification, request and progress handlers.
+      for (const [method, handler] of this._pendingNotificationHandlers) {
+        this._notificationDisposables.set(method, connection.onNotification(method, handler))
+      }
+      this._pendingNotificationHandlers.clear()
+      for (const [method, handler] of this._pendingRequestHandlers) {
+        this._requestDisposables.set(method, connection.onRequest(method, handler))
+      }
+      this._pendingRequestHandlers.clear()
+      for (const [token, data] of this._pendingProgressHandlers) {
+        this._progressDisposables.set(token, connection.onProgress(data.type, token, data.handler))
+      }
+      this._pendingProgressHandlers.clear()
+
+      await connection.sendNotification(InitializedNotification.type, {})
 
       this.hookFileEvents(connection)
       this.hookConfigurationChanged(connection)
       this.initializeFeatures(connection)
-      this._onReadyCallbacks.resolve()
+
       return result
-    }).then<InitializeResult>(undefined, error => {
+    } catch (error: any) {
       if (this._clientOptions.initializationFailedHandler) {
         if (this._clientOptions.initializationFailedHandler(error)) {
-          this.initialize(connection)
+          void this.initialize(connection)
         } else {
-          this.stop()
-          this._onReadyCallbacks.reject(error)
+          void this.stop()
         }
-      } else if (
-        error instanceof ResponseError &&
-        error.data &&
-        error.data.retry
-      ) {
-        window.showPrompt(error.message + ' Retry?').then(confirmed => {
-          if (confirmed) {
-            this.initialize(connection)
+      } else if (error instanceof ResponseError && error.data && error.data.retry) {
+        void window.showErrorMessage(error.message, { title: 'Retry', id: 'retry' }).then(item => {
+          if (item && item.id === 'retry') {
+            void this.initialize(connection)
           } else {
-            this.stop()
-            this._onReadyCallbacks.reject(error)
+            void this.stop()
           }
         })
       } else {
         if (error && error.message) {
-          window.showMessage(error.message, 'error')
+          void window.showErrorMessage(error.message)
         }
         this.error('Server initialization failed.', error)
-        this.stop()
-        this._onReadyCallbacks.reject(error)
+        void this.stop()
       }
       throw error
-    })
+    }
   }
 
-  public stop(): Promise<void> {
+  public stop(timeout = 2000): Promise<void> {
+    // Wait 2 seconds on stop
+    return this.shutdown('stop', timeout)
+  }
+
+  private async shutdown(mode: 'suspend' | 'stop', timeout: number): Promise<void> {
+    // If the client is stopped or in its initial state return.
+    if (this.$state === ClientState.Stopped || this.$state === ClientState.Initial) {
+      return
+    }
+
+    // If we are stopping the client and have a stop promise return it.
+    if (this.$state === ClientState.Stopping) {
+      if (this._onStop !== undefined) {
+        return this._onStop
+      } else {
+        throw new Error(`Client is stopping but no stop promise available.`)
+      }
+    }
+
+    const connection = this.activeConnection()
+    // We can't stop a client that is not running (e.g. has no connection). Especially not
+    // on that us starting since it can't be correctly synchronized.
+    if (connection === undefined || this.$state !== ClientState.Running) {
+      throw new Error(`Client is not running and can't be stopped. It's current state is: ${this.$state}`)
+    }
     this._initializeResult = undefined
-    if (!this._connectionPromise) {
-      this.state = ClientState.Stopped
-      return Promise.resolve()
-    }
-    if (this.state === ClientState.Stopping && this._onStop) {
-      return this._onStop
-    }
-    this.state = ClientState.Stopping
-    this.cleanUp()
-    const shutdown = this.resolveConnection().then(connection => {
-      let disposed = false
-      let timer = setTimeout(() => {
-        disposed = true
+    this.$state = ClientState.Stopping
+    this.cleanUp(mode)
+
+    const tp = new Promise<undefined>(c => { setTimeout(c, timeout) })
+    const shutdown = (async connection => {
+      await connection.shutdown()
+      await connection.exit()
+      return connection
+    })(connection)
+
+    return this._onStop = Promise.race([tp, shutdown]).then(connection => {
+      // The connection won the race with the timeout.
+      if (connection !== undefined) {
         connection.end()
         connection.dispose()
-      }, 2000)
-      return connection.shutdown().then(() => {
-        clearTimeout(timer)
-        connection.exit()
-        return connection
-      }, err => {
-        if (disposed) return
-        connection.end()
-        connection.dispose()
-        throw err
-      })
-    })
-    // unkook listeners
-    return (this._onStop = shutdown.then(connection => {
-      if (connection) connection.unlisten()
-    }, err => {
-      logger.error(`Stopping server failed:`, err)
-      this.error(`Stopping server failed`, err)
-      throw err
-    })).finally(() => {
-      this.state = ClientState.Stopped
-      this.cleanUpChannel()
+      } else {
+        this.error(`Stopping server timed out`, undefined)
+        throw new Error(`Stopping the server timed out`)
+      }
+    }, error => {
+      this.error(`Stopping server failed`, error)
+      throw error
+    }).finally(() => {
+      this.$state = ClientState.Stopped
+      mode === 'stop' && this.cleanUpChannel()
+      this._onStart = undefined
       this._onStop = undefined
-      this._connectionPromise = undefined
-      this._resolvedConnection = undefined
+      this._connection = undefined
+      this._ignoredRegistrations.clear()
     })
   }
 
-  private cleanUp(channel: boolean = true, diagnostics: boolean = true): void {
+  public dispose(timeout = 2000): Promise<void> {
+    try {
+      this._disposed = 'disposing'
+      return this.stop(timeout)
+    } finally {
+      this._disposed = 'disposed'
+    }
+  }
+
+  private cleanUp(mode: 'restart' | 'suspend' | 'stop'): void {
+    this._fileEventsMap.clear()
     if (this._listeners) {
       this._listeners.forEach(listener => listener.dispose())
-      this._listeners = undefined
+      this._listeners = []
     }
-    if (this._providers) {
-      this._providers.forEach(provider => provider.dispose())
-      this._providers = undefined
+    if (this._syncedDocuments) {
+      this._syncedDocuments.clear()
     }
     for (let feature of this._features.values()) {
       if (typeof feature.dispose === 'function') {
@@ -3850,19 +1189,9 @@ export abstract class BaseLanguageClient {
         logger.error(`Feature can't be disposed`, feature)
       }
     }
-    if (this._syncedDocuments) {
-      this._syncedDocuments.clear()
-    }
-    if (channel) {
-      this.cleanUpChannel()
-    }
-    if (this._diagnostics) {
-      if (diagnostics) {
-        this._diagnostics.dispose()
-        this._diagnostics = undefined
-      } else {
-        this._diagnostics.clear()
-      }
+    if (mode === 'stop' && this._diagnostics) {
+      this._diagnostics.dispose()
+      this._diagnostics = undefined
     }
   }
 
@@ -3873,25 +1202,32 @@ export abstract class BaseLanguageClient {
     }
   }
 
+  private _notifyFileEvent(): void {
+    let connection = this.activeConnection()
+    if (!connection) return
+    let map = this._fileEventsMap
+    if (map.size == 0) return
+    connection.sendNotification(DidChangeWatchedFilesNotification.type, { changes: Array.from(map.values()) }).catch(error => {
+      this.error(`Notify file events failed.`, error)
+    })
+    map.clear()
+  }
+
   private notifyFileEvent(event: FileEvent): void {
-    const client = this
-    function didChangeWatchedFile(this: void, event: FileEvent) {
-      client._fileEvents.push(event)
-      client._fileEventDelayer.trigger(() => {
-        client.onReady().then(() => {
-          client.resolveConnection().then(connection => {
-            if (client.isConnectionActive()) {
-              connection.didChangeWatchedFiles({ changes: client._fileEvents })
-            }
-            client._fileEvents = []
-          })
-        }, (error) => {
-          client.error(`Notify file events failed.`, error)
-        })
-      })
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let self = this
+    function didChangeWatchedFile(event: FileEvent): Promise<void> {
+      if (event) {
+        self._fileEventsMap.set(event.uri, event)
+        self.debouncedFileNotify()
+      }
+      return Promise.resolve()
     }
     const workSpaceMiddleware = this.clientOptions.middleware?.workspace
-    workSpaceMiddleware?.didChangeWatchedFile ? workSpaceMiddleware.didChangeWatchedFile(event, didChangeWatchedFile) : didChangeWatchedFile(event)
+    let promise = workSpaceMiddleware?.didChangeWatchedFile ? workSpaceMiddleware.didChangeWatchedFile(event, didChangeWatchedFile) : didChangeWatchedFile(event)
+    if (promise) promise.catch(error => {
+      this.error(`Notify file events failed.`, error)
+    })
   }
 
   private handleDiagnostics(params: PublishDiagnosticsParams) {
@@ -3912,11 +1248,9 @@ export abstract class BaseLanguageClient {
   }
 
   private setDiagnostics(uri: string, diagnostics: Diagnostic[] | undefined) {
-    if (!this._diagnostics) {
-      return
-    }
-
-    const separate = workspace.getConfiguration('diagnostic').get('separateRelatedInformationAsDiagnostics') as boolean
+    if (!this._diagnostics) return
+    const separate = this.clientOptions.separateDiagnostics
+    // TODO make is async
     if (separate && diagnostics.length > 0) {
       const entries: Map<string, Diagnostic[]> = new Map()
       entries.set(uri, diagnostics)
@@ -3945,83 +1279,78 @@ export abstract class BaseLanguageClient {
     encoding: string
   ): Promise<MessageTransports | null>
 
-  private createConnection(): Promise<IConnection> {
+  private async createConnection(): Promise<Connection> {
     let errorHandler = (error: Error, message: Message | undefined, count: number | undefined) => {
       logger.error('connection error:', error, message)
       this.handleConnectionError(error, message, count)
     }
-
     let closeHandler = () => {
       this.handleConnectionClosed()
     }
-
-    return this.createMessageTransports(
-      this._clientOptions.stdioEncoding || 'utf8'
-    ).then(transports => {
-      return createConnection(
-        transports.reader,
-        transports.writer,
-        errorHandler,
-        closeHandler,
-        this._clientOptions.connectionOptions
-      )
-    })
+    const transports = await this.createMessageTransports(this._clientOptions.stdioEncoding || 'utf8')
+    this._connection = createConnection(transports.reader, transports.writer, errorHandler, closeHandler, this._clientOptions.connectionOptions)
+    return this._connection
   }
 
   protected handleConnectionClosed() {
     // Check whether this is a normal shutdown in progress or the client stopped normally.
-    if (this.state === ClientState.Stopped) {
-      logger.debug(`client ${this._id} normal close`)
+    if (this.$state === ClientState.Stopped) {
+      logger.debug(`client ${this._id} normal closed`)
       return
     }
     try {
-      if (this._resolvedConnection) {
-        this._resolvedConnection.dispose()
+      if (this._connection) {
+        this._connection.dispose()
       }
     } catch (error) {
       // Disposing a connection could fail if error cases.
     }
     let action = CloseAction.DoNotRestart
-    if (this.state !== ClientState.Stopping) {
+    if (this.$state !== ClientState.Stopping) {
       try {
         action = this._clientOptions.errorHandler!.closed()
       } catch (error) {
         // Ignore errors coming from the error handler.
       }
     }
-    this._connectionPromise = undefined
-    this._resolvedConnection = undefined
+    this._connection = undefined
     if (action === CloseAction.DoNotRestart) {
       this.error('Connection to server got closed. Server will not be restarted.')
-      if (this.state === ClientState.Starting) {
-        this._onReadyCallbacks.reject(new Error(`Connection to server got closed. Server will not be restarted.`))
-        this.state = ClientState.StartFailed
+      this.cleanUp('stop')
+      if (this.$state === ClientState.Starting) {
+        this.$state = ClientState.StartFailed
       } else {
-        this.state = ClientState.Stopped
+        this.$state = ClientState.Stopped
       }
-      this.cleanUp(false, true)
+      this._onStop = Promise.resolve()
+      this._onStart = undefined
     } else if (action === CloseAction.Restart) {
       this.info('Connection to server got closed. Server will restart.')
-      this.cleanUp(false, true)
-      this.state = ClientState.Initial
-      this.start()
+      this.cleanUp('restart')
+      this.$state = ClientState.Initial
+      this._onStop = Promise.resolve()
+      this._onStart = undefined
+      this._start().catch(error => this.error(`Restarting server failed`, error))
     }
   }
 
-  public restart(): void {
-    this.cleanUp(true, false)
-    this.start()
+  private checkState() {
+    if (this.$state === ClientState.StartFailed || this.$state === ClientState.Stopping || this.$state === ClientState.Stopped) {
+      throw new ResponseError(ErrorCodes.ConnectionInactive, `Client is not running`)
+    }
   }
 
   private handleConnectionError(error: Error, message: Message, count: number) {
     let action = this._clientOptions.errorHandler!.error(error, message, count)
     if (action === ErrorAction.Shutdown) {
       this.error('Connection to server is erroring. Shutting down server.')
-      this.stop()
+      this.stop().catch(error => {
+        this.error(`Stopping server failed`, error)
+      })
     }
   }
 
-  private hookConfigurationChanged(connection: IConnection): void {
+  private hookConfigurationChanged(connection: Connection): void {
     workspace.onDidChangeConfiguration(e => {
       if (e.affectsConfiguration(this._id)) {
         this.refreshTrace(connection, true)
@@ -4030,15 +1359,14 @@ export abstract class BaseLanguageClient {
   }
 
   private refreshTrace(
-    connection: IConnection,
-    sendNotification: boolean = false
+    connection: Connection,
+    sendNotification = false
   ): void {
     let config = workspace.getConfiguration(this._id)
     let trace: Trace = Trace.Off
     let traceFormat: TraceFormat = TraceFormat.Text
     if (config) {
       const traceConfig = config.get('trace.server', 'off')
-
       if (typeof traceConfig === 'string') {
         trace = Trace.fromString(traceConfig)
       } else {
@@ -4054,17 +1382,17 @@ export abstract class BaseLanguageClient {
     connection.trace(this._trace, this._tracer, {
       sendNotification,
       traceFormat: this._traceFormat
-    })
+    }).catch(error => { this.error(`Updating trace failed with error`, error) })
   }
 
-  private hookFileEvents(_connection: IConnection): void {
+  private hookFileEvents(_connection: Connection): void {
     let fileEvents = this._clientOptions.synchronize.fileEvents
     if (!fileEvents) return
     let watchers: FileWatcher[]
     if (Array.isArray(fileEvents)) {
-      watchers = <FileWatcher[]>fileEvents
+      watchers = fileEvents
     } else {
-      watchers = [<FileWatcher>fileEvents]
+      watchers = [fileEvents]
     }
     if (!watchers) {
       return
@@ -4084,11 +1412,13 @@ export abstract class BaseLanguageClient {
     features: (StaticFeature | DynamicFeature<any>)[]
   ): void {
     for (let feature of features) {
-      this.registerFeature(feature)
+      this.registerFeature(feature, '')
     }
   }
 
-  public registerFeature(feature: StaticFeature | DynamicFeature<any>): void {
+  public registerFeature(feature: StaticFeature | DynamicFeature<any>, name: string): void {
+    let { disabledFeatures } = this._clientOptions
+    if (disabledFeatures.length > 0 && disabledFeatures.includes(name)) return
     this._features.push(feature)
     if (DynamicFeature.is(feature)) {
       const registrationType = feature.registrationType
@@ -4096,12 +1426,12 @@ export abstract class BaseLanguageClient {
     }
   }
 
-  public getFeature(request: typeof DidOpenTextDocumentNotification.method): DynamicFeature<TextDocumentRegistrationOptions> & NotificationFeature<(textDocument: TextDocument) => void>
-  public getFeature(request: typeof DidChangeTextDocumentNotification.method): DynamicFeature<TextDocumentRegistrationOptions> & NotificationFeature<(textDocument: TextDocument) => void>
-  public getFeature(request: typeof WillSaveTextDocumentNotification.method): DynamicFeature<TextDocumentRegistrationOptions> & NotificationFeature<(textDocument: TextDocument) => void>
-  public getFeature(request: typeof WillSaveTextDocumentWaitUntilRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & NotificationFeature<(textDocument: TextDocument) => ProviderResult<TextEdit[]>>
-  public getFeature(request: typeof DidSaveTextDocumentNotification.method): DynamicFeature<TextDocumentRegistrationOptions> & NotificationFeature<(textDocument: TextDocument) => void>
-  public getFeature(request: typeof DidCloseTextDocumentNotification.method): DynamicFeature<TextDocumentRegistrationOptions> & NotificationFeature<(textDocument: TextDocument) => void>
+  public getFeature(request: typeof DidOpenTextDocumentNotification.method): DidOpenTextDocumentFeatureShape
+  public getFeature(request: typeof DidChangeTextDocumentNotification.method): DidChangeTextDocumentFeatureShape
+  public getFeature(request: typeof WillSaveTextDocumentNotification.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentSendFeature<(textDocument: TextDocument) => Promise<void>>
+  public getFeature(request: typeof WillSaveTextDocumentWaitUntilRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentSendFeature<(textDocument: TextDocument) => ProviderResult<TextEdit[]>>
+  public getFeature(request: typeof DidSaveTextDocumentNotification.method): DidSaveTextDocumentFeatureShape
+  public getFeature(request: typeof DidCloseTextDocumentNotification.method): DidCloseTextDocumentFeatureShape
   public getFeature(request: typeof DidCreateFilesNotification.method): DynamicFeature<FileOperationRegistrationOptions> & { send: (event: FileCreateEvent) => Promise<void> }
   public getFeature(request: typeof DidRenameFilesNotification.method): DynamicFeature<FileOperationRegistrationOptions> & { send: (event: FileRenameEvent) => Promise<void> }
   public getFeature(request: typeof DidDeleteFilesNotification.method): DynamicFeature<FileOperationRegistrationOptions> & { send: (event: FileDeleteEvent) => Promise<void> }
@@ -4115,6 +1445,7 @@ export abstract class BaseLanguageClient {
   public getFeature(request: typeof ReferencesRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<ReferenceProvider>
   public getFeature(request: typeof DocumentHighlightRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<DocumentHighlightProvider>
   public getFeature(request: typeof CodeActionRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<CodeActionProvider>
+  public getFeature(request: typeof CodeLensRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<CodeLensProviderShape>
   public getFeature(request: typeof DocumentFormattingRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<DocumentFormattingEditProvider>
   public getFeature(request: typeof DocumentRangeFormattingRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<DocumentRangeFormattingEditProvider>
   public getFeature(request: typeof DocumentOnTypeFormattingRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<OnTypeFormattingEditProvider>
@@ -4128,82 +1459,68 @@ export abstract class BaseLanguageClient {
   public getFeature(request: typeof SelectionRangeRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<SelectionRangeProvider>
   public getFeature(request: typeof TypeDefinitionRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<TypeDefinitionProvider>
   public getFeature(request: typeof CallHierarchyPrepareRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<CallHierarchyProvider>
-  public getFeature(request: typeof SemanticTokensRegistrationType.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<SemanticTokensProviders>
+  public getFeature(request: typeof SemanticTokensRegistrationType.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<SemanticTokensProviderShape>
   public getFeature(request: typeof LinkedEditingRangeRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<LinkedEditingRangeProvider>
-  public getFeature(request: typeof WorkspaceSymbolRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & WorkspaceProviderFeature<WorkspaceSymbolProvider>
-  public getFeature(request: typeof InlayHintRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<InlayHintsProviderShape>
-  public getFeature(request: typeof InlineValueRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<InlineValueProviderShape>
   public getFeature(request: typeof TypeHierarchyPrepareRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<TypeHierarchyProvider>
-  public getFeature(request: typeof DocumentDiagnosticRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<DiagnosticProviderShape>
+  public getFeature(request: typeof InlineValueRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<InlineValueProviderShape>
+  public getFeature(request: typeof InlayHintRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<InlayHintsProviderShape>
+  public getFeature(request: typeof WorkspaceSymbolRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & WorkspaceProviderFeature<WorkspaceSymbolProvider>
+  public getFeature(request: typeof DocumentDiagnosticRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<DiagnosticProviderShape> | undefined
   public getFeature(request: string): DynamicFeature<any> | undefined {
     return this._dynamicFeatures.get(request)
   }
 
   protected registerBuiltinFeatures() {
-    let { disabledFeatures } = this._clientOptions
-    if (!disabledFeatures.includes('configuration')) {
-      this.registerFeature(new ConfigurationFeature(this))
-    }
-    this.registerFeature(new DidOpenTextDocumentFeature(this, this._syncedDocuments))
-    this.registerFeature(new DidChangeTextDocumentFeature(this))
-    this.registerFeature(new DidCloseTextDocumentFeature(this, this._syncedDocuments))
-    if (!disabledFeatures.includes('willSave')) {
-      this.registerFeature(new WillSaveFeature(this))
-    }
-    if (!disabledFeatures.includes('willSaveWaitUntil')) {
-      this.registerFeature(new WillSaveWaitUntilFeature(this))
-    }
-    if (!disabledFeatures.includes('didSave')) {
-      this.registerFeature(new DidSaveTextDocumentFeature(this))
-    }
-    if (!disabledFeatures.includes('fileSystemWatcher')) {
-      this.registerFeature(new FileSystemWatcherFeature(this, event => this.notifyFileEvent(event)))
-    }
-    if (!disabledFeatures.includes('completion')) {
-      this.registerFeature(new CompletionItemFeature(this))
-    }
-    if (!disabledFeatures.includes('hover')) {
-      this.registerFeature(new HoverFeature(this))
-    }
-    if (!disabledFeatures.includes('signatureHelp')) {
-      this.registerFeature(new SignatureHelpFeature(this))
-    }
-    if (!disabledFeatures.includes('references')) {
-      this.registerFeature(new ReferencesFeature(this))
-    }
-    if (!disabledFeatures.includes('definition')) {
-      this.registerFeature(new DefinitionFeature(this))
-    }
-    if (!disabledFeatures.includes('documentHighlight')) {
-      this.registerFeature(new DocumentHighlightFeature(this))
-    }
-    if (!disabledFeatures.includes('documentSymbol')) {
-      this.registerFeature(new DocumentSymbolFeature(this))
-    }
-    if (!disabledFeatures.includes('codeAction')) {
-      this.registerFeature(new CodeActionFeature(this))
-    }
-    if (!disabledFeatures.includes('codeLens')) {
-      this.registerFeature(new CodeLensFeature(this))
-    }
-    if (!disabledFeatures.includes('documentFormatting')) {
-      this.registerFeature(new DocumentFormattingFeature(this))
-    }
-    if (!disabledFeatures.includes('documentRangeFormatting')) {
-      this.registerFeature(new DocumentRangeFormattingFeature(this))
-    }
-    if (!disabledFeatures.includes('documentOnTypeFormatting')) {
-      this.registerFeature(new DocumentOnTypeFormattingFeature(this))
-    }
-    if (!disabledFeatures.includes('rename')) {
-      this.registerFeature(new RenameFeature(this))
-    }
-    if (!disabledFeatures.includes('documentLink')) {
-      this.registerFeature(new DocumentLinkFeature(this))
-    }
-    if (!disabledFeatures.includes('executeCommand')) {
-      this.registerFeature(new ExecuteCommandFeature(this))
-    }
+    this.registerFeature(new SyncConfigurationFeature(this), 'configuration')
+    this.registerFeature(new DidOpenTextDocumentFeature(this, this._syncedDocuments), 'document')
+    this.registerFeature(new DidChangeTextDocumentFeature(this), 'document')
+    this.registerFeature(new DidCloseTextDocumentFeature(this, this._syncedDocuments), 'document')
+    this.registerFeature(new WillSaveFeature(this), 'willSave')
+    this.registerFeature(new WillSaveWaitUntilFeature(this), 'willSaveWaitUntil')
+    this.registerFeature(new DidSaveTextDocumentFeature(this), 'didSave')
+    this.registerFeature(new FileSystemWatcherFeature(this, event => this.notifyFileEvent(event)), 'fileSystemWatcher')
+    this.registerFeature(new CompletionItemFeature(this), 'completion')
+    this.registerFeature(new HoverFeature(this), 'hover')
+    this.registerFeature(new SignatureHelpFeature(this), 'signatureHelp')
+    this.registerFeature(new ReferencesFeature(this), 'references')
+    this.registerFeature(new DefinitionFeature(this), 'definition')
+    this.registerFeature(new DocumentHighlightFeature(this), 'documentHighlight')
+    this.registerFeature(new DocumentSymbolFeature(this), 'documentSymbol')
+    this.registerFeature(new CodeActionFeature(this), 'codeAction')
+    this.registerFeature(new CodeLensFeature(this), 'codeLens')
+    this.registerFeature(new DocumentFormattingFeature(this), 'documentFormatting')
+    this.registerFeature(new DocumentRangeFormattingFeature(this), 'documentRangeFormatting')
+    this.registerFeature(new DocumentOnTypeFormattingFeature(this), 'documentOnTypeFormatting')
+    this.registerFeature(new RenameFeature(this), 'rename')
+    this.registerFeature(new DocumentLinkFeature(this), 'documentLink')
+    this.registerFeature(new ExecuteCommandFeature(this), 'executeCommand')
+    this.registerFeature(new PullConfigurationFeature(this), 'pullConfiguration')
+    this.registerFeature(new TypeDefinitionFeature(this), 'typeDefinition')
+    this.registerFeature(new ImplementationFeature(this), 'implementation')
+    this.registerFeature(new DeclarationFeature(this), 'declaration')
+    this.registerFeature(new ColorProviderFeature(this), 'colorProvider')
+    this.registerFeature(new FoldingRangeFeature(this), 'foldingRange')
+    this.registerFeature(new SelectionRangeFeature(this), 'selectionRange')
+    this.registerFeature(new CallHierarchyFeature(this), 'callHierarchy')
+    this.registerFeature(new ProgressFeature(this), 'progress')
+    this.registerFeature(new LinkedEditingFeature(this), 'linkedEditing')
+    this.registerFeature(new DidCreateFilesFeature(this), 'fileEvents')
+    this.registerFeature(new DidRenameFilesFeature(this), 'fileEvents')
+    this.registerFeature(new DidDeleteFilesFeature(this), 'fileEvents')
+    this.registerFeature(new WillCreateFilesFeature(this), 'fileEvents')
+    this.registerFeature(new WillRenameFilesFeature(this), 'fileEvents')
+    this.registerFeature(new WillDeleteFilesFeature(this), 'fileEvents')
+    this.registerFeature(new SemanticTokensFeature(this), 'semanticTokens')
+    this.registerFeature(new InlayHintsFeature(this), 'inlayHint')
+    this.registerFeature(new InlineValueFeature(this), 'inlineValue')
+    this.registerFeature(new DiagnosticFeature(this), 'pullDiagnostic')
+    this.registerFeature(new TypeHierarchyFeature(this), 'typeHierarchy')
+    this.registerFeature(new WorkspaceSymbolFeature(this), 'workspaceSymbol')
+    this.registerFeature(new WorkspaceFoldersFeature(this), 'workspaceFolders')
+  }
+
+  public registerProposedFeatures() {
+    this.registerFeatures(ProposedFeatures.createAll(this))
   }
 
   private fillInitializeParams(params: InitializeParams): void {
@@ -4246,19 +1563,23 @@ export abstract class BaseLanguageClient {
     // if (this._clientOptions.markdown.supportHtml) {
     //   generalCapabilities.markdown.allowedTags = ['ul', 'li', 'p', 'code', 'blockquote', 'ol', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'em', 'pre', 'table', 'thead', 'tbody', 'tr', 'th', 'td', 'div', 'del', 'a', 'strong', 'br', 'img', 'span']
     // }
-    // generalCapabilities.staleRequestSupport = {
-    //   cancel: true,
-    //   retryOnContentModified: Array.from(BaseLanguageClient.RequestsToCancelOnContentModified)
-    // }
-
+    generalCapabilities.staleRequestSupport = {
+      cancel: true,
+      retryOnContentModified: Array.from(BaseLanguageClient.RequestsToCancelOnContentModified)
+    }
     for (let feature of this._features) {
       feature.fillClientCapabilities(result)
     }
     return result
   }
 
-  private initializeFeatures(_connection: IConnection): void {
+  private initializeFeatures(_connection: Connection): void {
     let documentSelector = this._clientOptions.documentSelector
+    for (let feature of this._features) {
+      if (Is.func(feature.preInitialize)) {
+        feature.preInitialize(this._capabilities, documentSelector)
+      }
+    }
     for (let feature of this._features) {
       feature.initialize(this._capabilities, documentSelector)
     }
@@ -4268,15 +1589,20 @@ export abstract class BaseLanguageClient {
     params: RegistrationParams
   ): Promise<void> {
     if (this.clientOptions.disableDynamicRegister) return Promise.resolve()
+    // We will not receive a registration call before a client is running
+    // from a server. However if we stop or shutdown we might which might
+    // try to restart the server. So ignore registrations if we are not running
+    if (!this.isRunning()) {
+      for (const registration of params.registrations) {
+        this._ignoredRegistrations.add(registration.id)
+      }
+      return
+    }
     return new Promise<void>((resolve, reject) => {
       for (const registration of params.registrations) {
         const feature = this._dynamicFeatures.get(registration.method)
         if (!feature) {
-          reject(
-            new Error(
-              `No feature implementation for ${registration.method} found. Registration failed.`
-            )
-          )
+          reject(new Error(`No feature implementation for ${registration.method} found. Registration failed.`))
           return
         }
         const options = registration.registerOptions || {}
@@ -4301,13 +1627,10 @@ export abstract class BaseLanguageClient {
   ): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       for (let unregistration of params.unregisterations) {
+        if (this._ignoredRegistrations.has(unregistration.id)) continue
         const feature = this._dynamicFeatures.get(unregistration.method)
         if (!feature) {
-          reject(
-            new Error(
-              `No feature implementation for ${unregistration.method} found. Unregistration failed.`
-            )
-          )
+          reject(new Error(`No feature implementation for ${unregistration.method} found. Unregistration failed.`))
           return
         }
         feature.unregister(unregistration.id)
@@ -4316,14 +1639,12 @@ export abstract class BaseLanguageClient {
     })
   }
 
-  private handleApplyWorkspaceEdit(
-    params: ApplyWorkspaceEditParams
-  ): Promise<ApplyWorkspaceEditResponse> {
+  private handleApplyWorkspaceEdit(params: ApplyWorkspaceEditParams): Promise<ApplyWorkspaceEditResult> {
     // This is some sort of workaround since the version check should be done by VS Code in the Workspace.applyEdit.
     // However doing it here adds some safety since the server can lag more behind then an extension.
     let workspaceEdit: WorkspaceEdit = params.edit
     let openTextDocuments: Map<string, TextDocument> = new Map<string, TextDocument>()
-    workspace.textDocuments.forEach((document) => openTextDocuments.set(document.uri.toString(), document))
+    workspace.textDocuments.forEach(document => openTextDocuments.set(document.uri.toString(), document))
     let versionMismatch = false
     if (workspaceEdit.documentChanges) {
       for (const change of workspaceEdit.documentChanges) {
@@ -4347,7 +1668,6 @@ export abstract class BaseLanguageClient {
   private getLocale(): string {
     const lang = process.env.LANG
     if (!lang) return 'en'
-
     return lang.split('.')[0]
   }
 
@@ -4360,11 +1680,13 @@ export abstract class BaseLanguageClient {
   public handleFailedRequest<T>(type: MessageSignature, token: CancellationToken | undefined, error: unknown, defaultValue: T): T {
     // If we get a request cancel or a content modified don't log anything.
     if (error instanceof ResponseError) {
+      // The connection got disposed while we were waiting for a response.
+      // Simply return the default value. Is the best we can do.
+      if (error.code === ErrorCodes.PendingResponseRejected || error.code === ErrorCodes.ConnectionInactive) {
+        return defaultValue
+      }
       if (error.code === LSPErrorCodes.RequestCancelled || error.code === LSPErrorCodes.ServerCancelled) {
-        if (token !== undefined && token.isCancellationRequested) {
-          return defaultValue
-        }
-        // do not throw error
+        return defaultValue
       } else if (error.code === LSPErrorCodes.ContentModified) {
         return defaultValue
       }
@@ -4379,5 +1701,14 @@ export abstract class BaseLanguageClient {
       return
     }
     this.error(`Request ${type.method} failed.`, error)
+  }
+}
+
+// Exporting proposed protocol.
+export namespace ProposedFeatures {
+  export function createAll(_client: FeatureClient<Middleware, LanguageClientOptions>): (StaticFeature | DynamicFeature<any>)[] {
+    let result: (StaticFeature | DynamicFeature<any>)[] = [
+    ]
+    return result
   }
 }

--- a/src/language-client/codeAction.ts
+++ b/src/language-client/codeAction.ts
@@ -1,0 +1,173 @@
+'use strict'
+import { CancellationToken, ClientCapabilities, CodeAction, CodeActionContext, CodeActionKind, CodeActionOptions, CodeActionParams, CodeActionRegistrationOptions, CodeActionRequest, CodeActionResolveRequest, Command, Disposable, DocumentSelector, ExecuteCommandParams, ExecuteCommandRequest, Range, ServerCapabilities } from 'vscode-languageserver-protocol'
+import { TextDocument } from "vscode-languageserver-textdocument"
+import commands from '../commands'
+import languages from '../languages'
+import { CodeActionProvider, ProviderResult } from '../provider'
+import { ExecuteCommandMiddleware, ExecuteCommandSignature } from './executeCommand'
+import { ensure, FeatureClient, TextDocumentLanguageFeature } from './features'
+import * as UUID from './utils/uuid'
+
+export interface ProvideCodeActionsSignature {
+  (
+    this: void,
+    document: TextDocument,
+    range: Range,
+    context: CodeActionContext,
+    token: CancellationToken
+  ): ProviderResult<(Command | CodeAction)[]>
+}
+
+export interface ResolveCodeActionSignature {
+  (this: void, item: CodeAction, token: CancellationToken): ProviderResult<CodeAction>
+}
+
+export interface CodeActionMiddleware {
+  provideCodeActions?: (
+    this: void,
+    document: TextDocument,
+    range: Range,
+    context: CodeActionContext,
+    token: CancellationToken,
+    next: ProvideCodeActionsSignature
+  ) => ProviderResult<(Command | CodeAction)[]>
+  resolveCodeAction?: (
+    this: void,
+    item: CodeAction,
+    token: CancellationToken,
+    next: ResolveCodeActionSignature
+  ) => ProviderResult<CodeAction>
+}
+
+export class CodeActionFeature extends TextDocumentLanguageFeature<boolean | CodeActionOptions, CodeActionRegistrationOptions, CodeActionProvider, CodeActionMiddleware & ExecuteCommandMiddleware> {
+  private disposables: Disposable[] = []
+  constructor(client: FeatureClient<CodeActionMiddleware>) {
+    super(client, CodeActionRequest.type)
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    const cap = ensure(ensure(capabilities, 'textDocument')!, 'codeAction')!
+    cap.dynamicRegistration = true
+    cap.isPreferredSupport = true
+    cap.disabledSupport = true
+    cap.dataSupport = true
+    cap.honorsChangeAnnotations = false
+    cap.resolveSupport = {
+      properties: ['edit']
+    }
+    cap.codeActionLiteralSupport = {
+      codeActionKind: {
+        valueSet: [
+          CodeActionKind.Empty,
+          CodeActionKind.QuickFix,
+          CodeActionKind.Refactor,
+          CodeActionKind.RefactorExtract,
+          CodeActionKind.RefactorInline,
+          CodeActionKind.RefactorRewrite,
+          CodeActionKind.Source,
+          CodeActionKind.SourceOrganizeImports
+        ]
+      }
+    }
+  }
+
+  public initialize(
+    capabilities: ServerCapabilities,
+    documentSelector: DocumentSelector
+  ): void {
+    const options = this.getRegistrationOptions(documentSelector, capabilities.codeActionProvider)
+    if (!options) {
+      return
+    }
+
+    this.register({
+      id: UUID.generateUuid(),
+      registerOptions: options
+    })
+  }
+
+  protected registerLanguageProvider(
+    options: CodeActionRegistrationOptions
+  ): [Disposable, CodeActionProvider] {
+    const registCommand = (id: string) => {
+      if (commands.has(id)) return
+      const client = this._client
+      const executeCommand: ExecuteCommandSignature = (command: string, args: any[]): any => {
+        const params: ExecuteCommandParams = {
+          command,
+          arguments: args
+        }
+        return client.sendRequest(ExecuteCommandRequest.type, params).then(undefined, error => {
+          client.handleFailedRequest(ExecuteCommandRequest.type, undefined, error, undefined)
+          throw error
+        })
+      }
+      const middleware = client.middleware!
+      this.disposables.push(commands.registerCommand(id, (...args: any[]) => {
+        return middleware.executeCommand
+          ? middleware.executeCommand(id, args, executeCommand)
+          : executeCommand(id, args)
+      }, null, true))
+    }
+    const provider: CodeActionProvider = {
+      provideCodeActions: (document, range, context, token) => {
+        const client = this._client
+        const _provideCodeActions: ProvideCodeActionsSignature = (document, range, context, token) => {
+          const params: CodeActionParams = {
+            textDocument: {
+              uri: document.uri
+            },
+            range,
+            context,
+          }
+          return client.sendRequest(CodeActionRequest.type, params, token).then(
+            values => {
+              if (token.isCancellationRequested || values === undefined || values === null) {
+                return undefined
+              }
+              // some server may not registered commands to client.
+              values.forEach(val => {
+                let cmd = Command.is(val) ? val.command : val.command?.command
+                if (cmd && !commands.has(cmd)) registCommand(cmd)
+              })
+              return values
+            },
+            error => {
+              return client.handleFailedRequest(CodeActionRequest.type, token, error, null)
+            }
+          )
+        }
+        const middleware = client.middleware!
+        return middleware.provideCodeActions
+          ? middleware.provideCodeActions(document, range, context, token, _provideCodeActions)
+          : _provideCodeActions(document, range, context, token)
+      },
+      resolveCodeAction: options.resolveProvider
+        ? (item: CodeAction, token: CancellationToken) => {
+          const client = this._client
+          const middleware = this._client.middleware!
+          const resolveCodeAction: ResolveCodeActionSignature = (item, token) => {
+            return client.sendRequest(CodeActionResolveRequest.type, item, token).then(
+              values => token.isCancellationRequested ? item : values,
+              error => {
+                return client.handleFailedRequest(CodeActionResolveRequest.type, token, error, item)
+              }
+            )
+          }
+          return middleware.resolveCodeAction
+            ? middleware.resolveCodeAction(item, token, resolveCodeAction)
+            : resolveCodeAction(item, token)
+        }
+        : undefined
+    }
+    return [languages.registerCodeActionProvider(options.documentSelector, provider, this._client.id, options.codeActionKinds), provider]
+  }
+
+  public dispose(): void {
+    this.disposables.forEach(o => {
+      o.dispose()
+    })
+    this.disposables = []
+    super.dispose()
+  }
+}

--- a/src/language-client/codeLens.ts
+++ b/src/language-client/codeLens.ts
@@ -1,0 +1,106 @@
+'use strict'
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import {
+  ClientCapabilities, CancellationToken, CodeLens, ServerCapabilities, DocumentSelector, CodeLensOptions, CodeLensRegistrationOptions, CodeLensRequest, CodeLensRefreshRequest, CodeLensResolveRequest, Emitter, Disposable
+} from 'vscode-languageserver-protocol'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import * as UUID from './utils/uuid'
+import { TextDocumentLanguageFeature, FeatureClient, ensure } from './features'
+import { CodeLensProvider, ProviderResult } from '../provider'
+import * as cv from './utils/converter'
+import languages from '../languages'
+
+export interface ProvideCodeLensesSignature {
+  (this: void, document: TextDocument, token: CancellationToken): ProviderResult<CodeLens[]>
+}
+
+export interface ResolveCodeLensSignature {
+  (this: void, codeLens: CodeLens, token: CancellationToken): ProviderResult<CodeLens>
+}
+
+export interface CodeLensMiddleware {
+  provideCodeLenses?: (this: void, document: TextDocument, token: CancellationToken, next: ProvideCodeLensesSignature) => ProviderResult<CodeLens[]>
+  resolveCodeLens?: (this: void, codeLens: CodeLens, token: CancellationToken, next: ResolveCodeLensSignature) => ProviderResult<CodeLens>
+}
+
+export interface CodeLensProviderShape {
+  provider?: CodeLensProvider
+  onDidChangeCodeLensEmitter: Emitter<void>
+}
+
+export class CodeLensFeature extends TextDocumentLanguageFeature<CodeLensOptions, CodeLensRegistrationOptions, CodeLensProviderShape, CodeLensMiddleware> {
+
+  constructor(client: FeatureClient<CodeLensMiddleware>) {
+    super(client, CodeLensRequest.type)
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    ensure(ensure(capabilities, 'textDocument')!, 'codeLens')!.dynamicRegistration = true
+    ensure(ensure(capabilities, 'workspace')!, 'codeLens')!.refreshSupport = true
+  }
+
+  public initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {
+    const client = this._client
+    client.onRequest(CodeLensRefreshRequest.type, async () => {
+      for (const provider of this.getAllProviders()) {
+        provider.onDidChangeCodeLensEmitter.fire()
+      }
+    })
+    const options = this.getRegistrationOptions(documentSelector, capabilities.codeLensProvider)
+    if (!options) {
+      return
+    }
+    this.register({ id: UUID.generateUuid(), registerOptions: options })
+  }
+
+  protected registerLanguageProvider(options: CodeLensRegistrationOptions): [Disposable, CodeLensProviderShape] {
+    const emitter: Emitter<void> = new Emitter<void>()
+    const provider: CodeLensProvider = {
+      onDidChangeCodeLenses: emitter.event,
+      provideCodeLenses: (document, token) => {
+        const client = this._client
+        const provideCodeLenses: ProvideCodeLensesSignature = (document, token) => {
+          return client.sendRequest(
+            CodeLensRequest.type,
+            cv.asCodeLensParams(document),
+            token
+          ).then(
+            res => token.isCancellationRequested ? null : res,
+            error => {
+              return client.handleFailedRequest(CodeLensRequest.type, token, error, null)
+            })
+        }
+        const middleware = client.middleware!
+        return middleware.provideCodeLenses
+          ? middleware.provideCodeLenses(document, token, provideCodeLenses)
+          : provideCodeLenses(document, token)
+      },
+      resolveCodeLens: (options.resolveProvider)
+        ? (codeLens: CodeLens, token: CancellationToken): ProviderResult<CodeLens> => {
+          const client = this._client
+          const resolveCodeLens: ResolveCodeLensSignature = (codeLens, token) => {
+            return client.sendRequest(
+              CodeLensResolveRequest.type,
+              codeLens,
+              token
+            ).then(
+              res => token.isCancellationRequested ? codeLens : res,
+              error => {
+                return client.handleFailedRequest(CodeLensResolveRequest.type, token, error, codeLens)
+              })
+          }
+          const middleware = client.middleware!
+          return middleware.resolveCodeLens
+            ? middleware.resolveCodeLens(codeLens, token, resolveCodeLens)
+            : resolveCodeLens(codeLens, token)
+        }
+        : undefined
+    }
+
+    return [languages.registerCodeLensProvider(options.documentSelector, provider), { provider, onDidChangeCodeLensEmitter: emitter }]
+  }
+}

--- a/src/language-client/colorProvider.ts
+++ b/src/language-client/colorProvider.ts
@@ -1,15 +1,9 @@
 'use strict'
-/* --------------------------------------------------------------------------------------------
- * Copyright (c) Microsoft Corporation. All rights reserved.
- * Licensed under the MIT License. See License.txt in the project root for license information.
- * ------------------------------------------------------------------------------------------ */
-'use strict'
-
 import { CancellationToken, ClientCapabilities, Color, ColorInformation, ColorPresentation, ColorPresentationRequest, Disposable, DocumentColorOptions, DocumentColorRegistrationOptions, DocumentColorRequest, DocumentSelector, Range, ServerCapabilities } from 'vscode-languageserver-protocol'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import languages from '../languages'
 import { DocumentColorProvider, ProviderResult } from '../provider'
-import { BaseLanguageClient, ensure, TextDocumentFeature } from './client'
+import { TextDocumentLanguageFeature, FeatureClient, ensure } from './features'
 
 export type ProvideDocumentColorsSignature = (document: TextDocument, token: CancellationToken) => ProviderResult<ColorInformation[]>
 
@@ -35,10 +29,10 @@ export interface ColorProviderMiddleware {
   ) => ProviderResult<ColorPresentation[]>
 }
 
-export class ColorProviderFeature extends TextDocumentFeature<
-  boolean | DocumentColorOptions, DocumentColorRegistrationOptions, DocumentColorProvider
-  > {
-  constructor(client: BaseLanguageClient) {
+export class ColorProviderFeature extends TextDocumentLanguageFeature<
+  boolean | DocumentColorOptions, DocumentColorRegistrationOptions, DocumentColorProvider, ColorProviderMiddleware
+> {
+  constructor(client: FeatureClient<ColorProviderMiddleware>) {
     super(client, DocumentColorRequest.type)
   }
 
@@ -77,7 +71,7 @@ export class ColorProviderFeature extends TextDocumentFeature<
             }
           )
         }
-        const middleware = client.clientOptions.middleware
+        const middleware = client.middleware
         return middleware.provideColorPresentations
           ? middleware.provideColorPresentations(color, context, token, provideColorPresentations)
           : provideColorPresentations(color, context, token)
@@ -95,7 +89,7 @@ export class ColorProviderFeature extends TextDocumentFeature<
             }
           )
         }
-        const middleware = client.clientOptions.middleware
+        const middleware = client.middleware
         return middleware.provideDocumentColors
           ? middleware.provideDocumentColors(document, token, provideDocumentColors)
           : provideDocumentColors(document, token)

--- a/src/language-client/completion.ts
+++ b/src/language-client/completion.ts
@@ -1,0 +1,189 @@
+'use strict'
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+import { CancellationToken, ClientCapabilities, CompletionContext, CompletionItem, CompletionItemKind, CompletionItemTag, CompletionList, CompletionOptions, CompletionRegistrationOptions, CompletionRequest, CompletionResolveRequest, Disposable, DocumentSelector, InsertTextMode, Position, ServerCapabilities } from 'vscode-languageserver-protocol'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import languages from '../languages'
+import { CompletionItemProvider, ProviderResult } from '../provider'
+import sources from '../sources'
+import * as cv from './utils/converter'
+
+import { ensure, FeatureClient, TextDocumentLanguageFeature } from './features'
+
+import * as UUID from './utils/uuid'
+
+const SupportedCompletionItemKinds: CompletionItemKind[] = [
+  CompletionItemKind.Text,
+  CompletionItemKind.Method,
+  CompletionItemKind.Function,
+  CompletionItemKind.Constructor,
+  CompletionItemKind.Field,
+  CompletionItemKind.Variable,
+  CompletionItemKind.Class,
+  CompletionItemKind.Interface,
+  CompletionItemKind.Module,
+  CompletionItemKind.Property,
+  CompletionItemKind.Unit,
+  CompletionItemKind.Value,
+  CompletionItemKind.Enum,
+  CompletionItemKind.Keyword,
+  CompletionItemKind.Snippet,
+  CompletionItemKind.Color,
+  CompletionItemKind.File,
+  CompletionItemKind.Reference,
+  CompletionItemKind.Folder,
+  CompletionItemKind.EnumMember,
+  CompletionItemKind.Constant,
+  CompletionItemKind.Struct,
+  CompletionItemKind.Event,
+  CompletionItemKind.Operator,
+  CompletionItemKind.TypeParameter
+]
+
+export interface ProvideCompletionItemsSignature {
+  (
+    this: void,
+    document: TextDocument,
+    position: Position,
+    context: CompletionContext,
+    token: CancellationToken,
+  ): ProviderResult<CompletionItem[] | CompletionList>
+}
+
+export interface ResolveCompletionItemSignature {
+  (this: void, item: CompletionItem, token: CancellationToken): ProviderResult<CompletionItem>
+}
+
+export interface CompletionMiddleware {
+  provideCompletionItem?: (
+    this: void,
+    document: TextDocument,
+    position: Position,
+    context: CompletionContext,
+    token: CancellationToken,
+    next: ProvideCompletionItemsSignature
+  ) => ProviderResult<CompletionItem[] | CompletionList>
+  resolveCompletionItem?: (
+    this: void,
+    item: CompletionItem,
+    token: CancellationToken,
+    next: ResolveCompletionItemSignature
+  ) => ProviderResult<CompletionItem>
+}
+
+export interface $CompletionOptions {
+  disableSnippetCompletion?: boolean
+}
+
+export class CompletionItemFeature extends TextDocumentLanguageFeature<CompletionOptions, CompletionRegistrationOptions, CompletionItemProvider, CompletionMiddleware, $CompletionOptions> {
+  private index: number
+  constructor(client: FeatureClient<CompletionMiddleware, $CompletionOptions>) {
+    super(client, CompletionRequest.type)
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    let snippetSupport = this._client.clientOptions.disableSnippetCompletion !== true
+    let completion = ensure(ensure(capabilities, 'textDocument')!, 'completion')!
+    completion.dynamicRegistration = true
+    completion.contextSupport = true
+    completion.completionItem = {
+      snippetSupport,
+      commitCharactersSupport: true,
+      documentationFormat: this._client.supportedMarkupKind,
+      deprecatedSupport: true,
+      preselectSupport: true,
+      insertReplaceSupport: true,
+      tagSupport: { valueSet: [CompletionItemTag.Deprecated] },
+      resolveSupport: { properties: ['documentation', 'detail', 'additionalTextEdits'] },
+      labelDetailsSupport: true,
+      insertTextModeSupport: { valueSet: [InsertTextMode.asIs, InsertTextMode.adjustIndentation] }
+    }
+    completion.completionItemKind = { valueSet: SupportedCompletionItemKinds }
+    completion.insertTextMode = InsertTextMode.adjustIndentation
+    completion.completionList = {
+      itemDefaults: [
+        'commitCharacters', 'editRange', 'insertTextFormat', 'insertTextMode'
+      ]
+    }
+  }
+
+  public initialize(
+    capabilities: ServerCapabilities,
+    documentSelector: DocumentSelector
+  ): void {
+    this.index = 0
+    const options = this.getRegistrationOptions(documentSelector, capabilities.completionProvider)
+    if (!options) return
+    this.register({
+      id: UUID.generateUuid(),
+      registerOptions: options
+    })
+  }
+
+  protected registerLanguageProvider(options: CompletionRegistrationOptions): [Disposable, CompletionItemProvider] {
+    let triggerCharacters = options.triggerCharacters || []
+    let allCommitCharacters = options.allCommitCharacters || []
+    let priority = (options as any).priority as number
+    const provider: CompletionItemProvider = {
+      provideCompletionItems: (document: TextDocument, position: Position, token: CancellationToken, context: CompletionContext): ProviderResult<CompletionList | CompletionItem[]> => {
+        const client = this._client
+        const middleware = this._client.middleware
+        const provideCompletionItems: ProvideCompletionItemsSignature = (document, position, context, token) => {
+          return client.sendRequest(
+            CompletionRequest.type,
+            cv.asCompletionParams(document, position, context),
+            token
+          ).then(
+            res => {
+              if (token.isCancellationRequested) return []
+              if (!res || Array.isArray(res) || res.itemDefaults == null) return res
+              return cv.asCompletionList(res, token)
+            },
+            error => {
+              return client.handleFailedRequest(CompletionRequest.type, token, error, [])
+            }
+          )
+        }
+
+        return middleware.provideCompletionItem
+          ? middleware.provideCompletionItem(document, position, context, token, provideCompletionItems)
+          : provideCompletionItems(document, position, context, token)
+      },
+      resolveCompletionItem: options.resolveProvider
+        ? (item: CompletionItem, token: CancellationToken): ProviderResult<CompletionItem> => {
+          const client = this._client
+          const middleware = this._client.middleware!
+          const resolveCompletionItem: ResolveCompletionItemSignature = (item, token) => {
+            return client.sendRequest(
+              CompletionResolveRequest.type,
+              item,
+              token
+            ).then(
+              res => token.isCancellationRequested ? item : res,
+              error => {
+                return client.handleFailedRequest(CompletionResolveRequest.type, token, error, item)
+              })
+          }
+
+          return middleware.resolveCompletionItem
+            ? middleware.resolveCompletionItem(item, token, resolveCompletionItem)
+            : resolveCompletionItem(item, token)
+        } : undefined
+    }
+    // index is needed since one language server could create many sources.
+    let name = this._client.id + (this.index ? '-' + this.index : '')
+    sources.removeSource(name)
+    const disposable = languages.registerCompletionItemProvider(
+      name,
+      'LS',
+      options.documentSelector,
+      provider,
+      triggerCharacters,
+      priority,
+      allCommitCharacters)
+    this.index = this.index + 1
+    return [disposable, provider]
+  }
+}

--- a/src/language-client/configuration.ts
+++ b/src/language-client/configuration.ts
@@ -1,20 +1,49 @@
 'use strict'
-/* --------------------------------------------------------------------------------------------
- * Copyright (c) Microsoft Corporation. All rights reserved.
- * Licensed under the MIT License. See License.txt in the project root for license information.
- * ------------------------------------------------------------------------------------------ */
-import { ClientCapabilities, ConfigurationRequest } from 'vscode-languageserver-protocol'
+import { ClientCapabilities, ConfigurationRequest, DidChangeConfigurationNotification, DidChangeConfigurationRegistrationOptions, Disposable, RegistrationType, WorkspaceFolder } from 'vscode-languageserver-protocol'
 import workspace from '../workspace'
-import { BaseLanguageClient, StaticFeature } from './client'
+import * as UUID from './utils/uuid'
+import * as Is from '../util/is'
+import { FeatureState, RegistrationData, StaticFeature, DynamicFeature, ensure, FeatureClient } from './features'
+import { FileSystemWatcher, ConfigurationChangeEvent } from '../types'
+import { mergeConfigProperties } from '../configuration/util'
 const logger = require('../util/logger')('languageclient-configuration')
 
-export interface ConfigurationWorkspaceMiddleware {
+export interface ConfigurationMiddleware {
   configuration?: ConfigurationRequest.MiddlewareSignature
 }
 
-export class ConfigurationFeature implements StaticFeature {
+interface ConfigurationWorkspaceMiddleware {
+  workspace?: ConfigurationMiddleware
+}
+
+export interface SynchronizeOptions {
+  /**
+   * The configuration sections to synchronize. Pushing settings from the
+   * client to the server is deprecated in favour of the new pull model
+   * that allows servers to query settings scoped on resources. In this
+   * model the client can only deliver an empty change event since the
+   * actually setting value can vary on the provided resource scope.
+   *
+   * @deprecated Use the new pull model (`workspace/configuration` request)
+   */
+  configurationSection?: string | string[]
+
+  /**
+   * Asks the client to send file change events to the server. Watchers
+   * operate on workspace folders. The LSP client doesn't support watching
+   * files outside a workspace folder.
+   */
+  fileEvents?: FileSystemWatcher | FileSystemWatcher[]
+}
+
+export interface $ConfigurationOptions {
+  synchronize?: SynchronizeOptions
+  workspaceFolder?: WorkspaceFolder
+}
+
+export class PullConfigurationFeature implements StaticFeature {
   private languageserverSection: string | undefined
-  constructor(private _client: BaseLanguageClient) {
+  constructor(private _client: FeatureClient<ConfigurationWorkspaceMiddleware, $ConfigurationOptions>) {
     let section = this._client.clientOptions.synchronize?.configurationSection
     if (typeof section === 'string' && section.startsWith('languageserver.')) {
       this.languageserverSection = section
@@ -24,6 +53,10 @@ export class ConfigurationFeature implements StaticFeature {
   public fillClientCapabilities(capabilities: ClientCapabilities): void {
     capabilities.workspace = capabilities.workspace || {}
     capabilities.workspace.configuration = true
+  }
+
+  public getState(): FeatureState {
+    return { kind: 'static' }
   }
 
   public initialize(): void {
@@ -36,7 +69,7 @@ export class ConfigurationFeature implements StaticFeature {
         }
         return result
       }
-      let middleware = client.clientOptions.middleware.workspace
+      let middleware = client.middleware.workspace
       return middleware && middleware.configuration
         ? middleware.configuration(params, token, configuration)
         : configuration(params, token)
@@ -92,4 +125,138 @@ export function toJSONObject(obj: any): any {
     }
   }
   return obj
+}
+
+export interface DidChangeConfigurationSignature {
+  (this: void, sections: string[] | undefined): Promise<void>
+}
+
+export interface DidChangeConfigurationMiddleware {
+  didChangeConfiguration?: (this: void, sections: string[] | undefined, next: DidChangeConfigurationSignature) => void
+}
+
+interface DidChangeConfigurationWorkspaceMiddleware {
+  workspace?: DidChangeConfigurationMiddleware
+}
+
+export class SyncConfigurationFeature implements DynamicFeature<DidChangeConfigurationRegistrationOptions> {
+  private _listeners: Map<string, Disposable> = new Map<string, Disposable>()
+
+  constructor(private _client: FeatureClient<DidChangeConfigurationWorkspaceMiddleware, $ConfigurationOptions>) {}
+
+  public getState(): FeatureState {
+    return { kind: 'workspace', id: this.registrationType.method, registrations: this._listeners.size > 0 }
+  }
+
+  public get registrationType(): RegistrationType<DidChangeConfigurationRegistrationOptions> {
+    return DidChangeConfigurationNotification.type
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    ensure(ensure(capabilities, 'workspace')!, 'didChangeConfiguration')!.dynamicRegistration = true
+  }
+
+  public initialize(): void {
+    let section = this._client.clientOptions.synchronize?.configurationSection
+    if (section !== undefined) {
+      this.register({
+        id: UUID.generateUuid(),
+        registerOptions: {
+          section
+        }
+      })
+    }
+  }
+
+  public register(
+    data: RegistrationData<DidChangeConfigurationRegistrationOptions>
+  ): void {
+    let { section } = data.registerOptions
+    let disposable = workspace.onDidChangeConfiguration(event => {
+      this.onDidChangeConfiguration(data.registerOptions.section, event)
+    })
+    this._listeners.set(data.id, disposable)
+    if (section != undefined) {
+      this.onDidChangeConfiguration(section, undefined)
+    }
+  }
+
+  public unregister(id: string): void {
+    let disposable = this._listeners.get(id)
+    if (disposable) {
+      this._listeners.delete(id)
+      disposable.dispose()
+    }
+  }
+
+  public dispose(): void {
+    for (let disposable of this._listeners.values()) {
+      disposable.dispose()
+    }
+    this._listeners.clear()
+  }
+
+  private onDidChangeConfiguration(configurationSection: string | string[] | undefined, event: ConfigurationChangeEvent | undefined): void {
+    let isConfigured = typeof configurationSection === 'string' && configurationSection.startsWith('languageserver.')
+    let sections: string[] | undefined
+    if (Is.string(configurationSection)) {
+      sections = [configurationSection]
+    } else {
+      sections = configurationSection
+    }
+    if (sections != null && event != null) {
+      let affected = sections.some(section => event.affectsConfiguration(section))
+      if (!affected) return
+    }
+    let didChangeConfiguration = (sections: string[] | undefined): Promise<void> => {
+      if (sections == null) {
+        return this._client.sendNotification(DidChangeConfigurationNotification.type, { settings: null })
+      }
+      return this._client.sendNotification(DidChangeConfigurationNotification.type, {
+        settings: isConfigured ? this.getConfiguredSettings(sections[0]) : this.extractSettingsInformation(sections)
+      })
+    }
+    let middleware = this._client.middleware.workspace?.didChangeConfiguration
+    middleware ? middleware(sections, didChangeConfiguration) : didChangeConfiguration(sections).catch(error => {
+      this._client.error(`Sending notification ${DidChangeConfigurationNotification.type.method} failed`, error)
+    })
+  }
+
+  // for configured languageserver
+  private getConfiguredSettings(key: string): any {
+    let len = '.settings'.length
+    let config = workspace.getConfiguration(key.slice(0, - len))
+    return mergeConfigProperties(config.get<any>('settings', {}))
+  }
+
+  private extractSettingsInformation(keys: string[]): any {
+    function ensurePath(config: any, path: string[]): any {
+      let current = config
+      for (let i = 0; i < path.length - 1; i++) {
+        let obj = current[path[i]]
+        if (!obj) {
+          obj = Object.create(null)
+          current[path[i]] = obj
+        }
+        current = obj
+      }
+      return current
+    }
+    let result = Object.create(null)
+    for (let i = 0; i < keys.length; i++) {
+      let key = keys[i]
+      let index: number = key.indexOf('.')
+      let config: any = null
+      if (index >= 0) {
+        config = workspace.getConfiguration(key.substr(0, index)).get(key.substr(index + 1))
+      } else {
+        config = workspace.getConfiguration(key)
+      }
+      if (config) {
+        let path = keys[i].split('.')
+        ensurePath(result, path)[path[path.length - 1]] = config
+      }
+    }
+    return result
+  }
 }

--- a/src/language-client/declaration.ts
+++ b/src/language-client/declaration.ts
@@ -1,15 +1,9 @@
 'use strict'
-/* --------------------------------------------------------------------------------------------
- * Copyright (c) Microsoft Corporation. All rights reserved.
- * Licensed under the MIT License. See License.txt in the project root for license information.
- * ------------------------------------------------------------------------------------------ */
-'use strict'
-
 import { CancellationToken, ClientCapabilities, Declaration, DeclarationLink, DeclarationOptions, DeclarationRegistrationOptions, DeclarationRequest, Disposable, DocumentSelector, Position, ServerCapabilities } from 'vscode-languageserver-protocol'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import languages from '../languages'
 import { DeclarationProvider, ProviderResult } from '../provider'
-import { BaseLanguageClient, ensure, TextDocumentFeature } from './client'
+import { TextDocumentLanguageFeature, FeatureClient, ensure } from './features'
 import { asTextDocumentPositionParams } from './utils/converter'
 
 export interface ProvideDeclarationSignature {
@@ -20,9 +14,9 @@ export interface DeclarationMiddleware {
   provideDeclaration?: (this: void, document: TextDocument, position: Position, token: CancellationToken, next: ProvideDeclarationSignature) => ProviderResult<Declaration | DeclarationLink[]>
 }
 
-export class DeclarationFeature extends TextDocumentFeature<boolean | DeclarationOptions, DeclarationRegistrationOptions, DeclarationProvider> {
+export class DeclarationFeature extends TextDocumentLanguageFeature<boolean | DeclarationOptions, DeclarationRegistrationOptions, DeclarationProvider, DeclarationMiddleware> {
 
-  constructor(client: BaseLanguageClient) {
+  constructor(client: FeatureClient<DeclarationMiddleware>) {
     super(client, DeclarationRequest.type)
   }
 
@@ -49,7 +43,7 @@ export class DeclarationFeature extends TextDocumentFeature<boolean | Declaratio
             return client.handleFailedRequest(DeclarationRequest.type, token, error, null)
           }
         )
-        const middleware = client.clientOptions.middleware
+        const middleware = client.middleware
         return middleware.provideDeclaration
           ? middleware.provideDeclaration(document, position, token, provideDeclaration)
           : provideDeclaration(document, position, token)

--- a/src/language-client/definition.ts
+++ b/src/language-client/definition.ts
@@ -1,0 +1,86 @@
+'use strict'
+/* ---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { CancellationToken, ClientCapabilities, Definition, DefinitionLink, DefinitionOptions, DefinitionRegistrationOptions, DefinitionRequest, Disposable, DocumentSelector, Position, ServerCapabilities } from 'vscode-languageserver-protocol'
+import { TextDocument } from "vscode-languageserver-textdocument"
+import languages from '../languages'
+import { DefinitionProvider, ProviderResult } from '../provider'
+import { FeatureClient, ensure, TextDocumentLanguageFeature } from './features'
+import * as cv from './utils/converter'
+import * as UUID from './utils/uuid'
+
+export interface ProvideDefinitionSignature {
+  (
+    this: void,
+    document: TextDocument,
+    position: Position,
+    token: CancellationToken
+  ): ProviderResult<Definition | DefinitionLink[]>
+}
+
+export interface DefinitionMiddleware {
+  provideDefinition?: (
+    this: void,
+    document: TextDocument,
+    position: Position,
+    token: CancellationToken,
+    next: ProvideDefinitionSignature
+  ) => ProviderResult<Definition | DefinitionLink[]>
+}
+
+export class DefinitionFeature extends TextDocumentLanguageFeature<
+  boolean | DefinitionOptions, DefinitionRegistrationOptions, DefinitionProvider, DefinitionMiddleware
+> {
+  constructor(client: FeatureClient<DefinitionMiddleware>) {
+    super(client, DefinitionRequest.type)
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    let definitionSupport = ensure(ensure(capabilities, 'textDocument')!, 'definition')!
+    definitionSupport.dynamicRegistration = true
+    // definitionSupport.linkSupport = true
+  }
+
+  public initialize(
+    capabilities: ServerCapabilities,
+    documentSelector: DocumentSelector
+  ): void {
+    const options = this.getRegistrationOptions(documentSelector, capabilities.definitionProvider)
+    if (!options) {
+      return
+    }
+    this.register({
+      id: UUID.generateUuid(),
+      registerOptions: options
+    })
+  }
+
+  protected registerLanguageProvider(
+    options: DefinitionRegistrationOptions
+  ): [Disposable, DefinitionProvider] {
+    const provider: DefinitionProvider = {
+      provideDefinition: (document, position, token) => {
+        const client = this._client
+        const provideDefinition: ProvideDefinitionSignature = (document, position, token) => {
+          return client.sendRequest(
+            DefinitionRequest.type,
+            cv.asTextDocumentPositionParams(document, position),
+            token
+          ).then(
+            res => token.isCancellationRequested ? null : res,
+            error => {
+              return client.handleFailedRequest(DefinitionRequest.type, token, error, null)
+            })
+        }
+        const middleware = client.middleware!
+        return middleware.provideDefinition
+          ? middleware.provideDefinition(document, position, token, provideDefinition)
+          : provideDefinition(document, position, token)
+      }
+    }
+
+    return [languages.registerDefinitionProvider(options.documentSelector!, provider), provider]
+  }
+}

--- a/src/language-client/documentHighlight.ts
+++ b/src/language-client/documentHighlight.ts
@@ -1,0 +1,82 @@
+'use strict'
+import { CancellationToken, ClientCapabilities, Disposable, DocumentHighlight, DocumentHighlightOptions, DocumentHighlightRegistrationOptions, DocumentHighlightRequest, DocumentSelector, Position, ServerCapabilities, TextDocumentRegistrationOptions } from 'vscode-languageserver-protocol'
+import { TextDocument } from "vscode-languageserver-textdocument"
+import languages from '../languages'
+import { DocumentHighlightProvider, ProviderResult } from '../provider'
+import { ensure, FeatureClient, TextDocumentLanguageFeature } from './features'
+import * as cv from './utils/converter'
+import * as UUID from './utils/uuid'
+
+export interface ProvideDocumentHighlightsSignature {
+  (
+    this: void,
+    document: TextDocument,
+    position: Position,
+    token: CancellationToken
+  ): ProviderResult<DocumentHighlight[]>
+}
+
+export interface DocumentHighlightMiddleware {
+  provideDocumentHighlights?: (
+    this: void,
+    document: TextDocument,
+    position: Position,
+    token: CancellationToken,
+    next: ProvideDocumentHighlightsSignature
+  ) => ProviderResult<DocumentHighlight[]>
+}
+
+export class DocumentHighlightFeature extends TextDocumentLanguageFeature<
+  boolean | DocumentHighlightOptions, DocumentHighlightRegistrationOptions, DocumentHighlightProvider, DocumentHighlightMiddleware
+> {
+  constructor(client: FeatureClient<DocumentHighlightMiddleware>) {
+    super(client, DocumentHighlightRequest.type)
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    ensure(
+      ensure(capabilities, 'textDocument')!,
+      'documentHighlight'
+    )!.dynamicRegistration = true
+  }
+
+  public initialize(
+    capabilities: ServerCapabilities,
+    documentSelector: DocumentSelector
+  ): void {
+    const options = this.getRegistrationOptions(documentSelector, capabilities.documentHighlightProvider)
+    if (!options) {
+      return
+    }
+    this.register({
+      id: UUID.generateUuid(),
+      registerOptions: options
+    })
+  }
+
+  protected registerLanguageProvider(
+    options: TextDocumentRegistrationOptions
+  ): [Disposable, DocumentHighlightProvider] {
+    const provider: DocumentHighlightProvider = {
+      provideDocumentHighlights: (document, position, token) => {
+        const client = this._client
+        const _provideDocumentHighlights: ProvideDocumentHighlightsSignature = (document, position, token) => {
+          return client.sendRequest(
+            DocumentHighlightRequest.type,
+            cv.asTextDocumentPositionParams(document, position),
+            token
+          ).then(
+            res => token.isCancellationRequested ? null : res,
+            error => {
+              return client.handleFailedRequest(DocumentHighlightRequest.type, token, error, null)
+            })
+        }
+        const middleware = client.middleware!
+        return middleware.provideDocumentHighlights
+          ? middleware.provideDocumentHighlights(document, position, token, _provideDocumentHighlights)
+          : _provideDocumentHighlights(document, position, token)
+      }
+    }
+    return [languages.registerDocumentHighlightProvider(options.documentSelector!, provider), provider]
+  }
+}

--- a/src/language-client/documentLink.ts
+++ b/src/language-client/documentLink.ts
@@ -1,0 +1,101 @@
+'use strict'
+import { CancellationToken, ClientCapabilities, Disposable, DocumentLink, DocumentLinkOptions, DocumentLinkRegistrationOptions, DocumentLinkRequest, DocumentLinkResolveRequest, DocumentSelector, ServerCapabilities } from 'vscode-languageserver-protocol'
+import { TextDocument } from "vscode-languageserver-textdocument"
+import languages from '../languages'
+import { DocumentLinkProvider, ProviderResult } from '../provider'
+import { ensure, FeatureClient, TextDocumentLanguageFeature } from './features'
+import * as UUID from './utils/uuid'
+
+export interface ProvideDocumentLinksSignature {
+  (this: void, document: TextDocument, token: CancellationToken): ProviderResult<DocumentLink[]>
+}
+
+export interface ResolveDocumentLinkSignature {
+  (this: void, link: DocumentLink, token: CancellationToken): ProviderResult<DocumentLink>
+}
+
+export interface DocumentLinkMiddleware {
+  provideDocumentLinks?: (
+    this: void,
+    document: TextDocument,
+    token: CancellationToken,
+    next: ProvideDocumentLinksSignature
+  ) => ProviderResult<DocumentLink[]>
+  resolveDocumentLink?: (
+    this: void,
+    link: DocumentLink,
+    token: CancellationToken,
+    next: ResolveDocumentLinkSignature
+  ) => ProviderResult<DocumentLink>
+}
+
+export class DocumentLinkFeature extends TextDocumentLanguageFeature<DocumentLinkOptions, DocumentLinkRegistrationOptions, DocumentLinkProvider, DocumentLinkMiddleware> {
+  constructor(client: FeatureClient<DocumentLinkMiddleware>) {
+    super(client, DocumentLinkRequest.type)
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    const documentLinkCapabilities = ensure(ensure(capabilities, 'textDocument')!, 'documentLink')!
+    documentLinkCapabilities.dynamicRegistration = true
+    documentLinkCapabilities.tooltipSupport = true
+  }
+
+  public initialize(
+    capabilities: ServerCapabilities,
+    documentSelector: DocumentSelector
+  ): void {
+    const options = this.getRegistrationOptions(documentSelector, capabilities.documentLinkProvider)
+    if (!options) {
+      return
+    }
+    this.register({
+      id: UUID.generateUuid(),
+      registerOptions: options
+    })
+  }
+
+  protected registerLanguageProvider(
+    options: DocumentLinkRegistrationOptions
+  ): [Disposable, DocumentLinkProvider] {
+    const provider: DocumentLinkProvider = {
+      provideDocumentLinks: (document: TextDocument, token: CancellationToken): ProviderResult<DocumentLink[]> => {
+        const client = this._client
+        const provideDocumentLinks: ProvideDocumentLinksSignature = (document, token) => {
+          return client.sendRequest(
+            DocumentLinkRequest.type,
+            {
+              textDocument: { uri: document.uri }
+            },
+            token
+          ).then(
+            res => token.isCancellationRequested ? null : res,
+            error => {
+              return client.handleFailedRequest(DocumentLinkRequest.type, token, error, null)
+            })
+        }
+        const middleware = client.middleware!
+        return middleware.provideDocumentLinks
+          ? middleware.provideDocumentLinks(document, token, provideDocumentLinks)
+          : provideDocumentLinks(document, token)
+      },
+      resolveDocumentLink: options.resolveProvider
+        ? (link, token) => {
+          const client = this._client
+          let resolveDocumentLink: ResolveDocumentLinkSignature = (link, token) => {
+            return client.sendRequest(DocumentLinkResolveRequest.type, link, token).then(
+              res => token.isCancellationRequested ? link : res,
+              error => {
+                return client.handleFailedRequest(DocumentLinkResolveRequest.type, token, error, link)
+              })
+          }
+          const middleware = client.middleware!
+          return middleware.resolveDocumentLink
+            ? middleware.resolveDocumentLink(link, token, resolveDocumentLink)
+            : resolveDocumentLink(link, token)
+        }
+        : undefined
+    }
+
+    return [languages.registerDocumentLinkProvider(options.documentSelector, provider), provider]
+  }
+}

--- a/src/language-client/executeCommand.ts
+++ b/src/language-client/executeCommand.ts
@@ -1,0 +1,86 @@
+'use strict'
+import { Disposable, ExecuteCommandRegistrationOptions, ExecuteCommandRequest, ClientCapabilities, ServerCapabilities, RegistrationType, ExecuteCommandParams } from 'vscode-languageserver-protocol'
+import { ProviderResult } from '../provider'
+import { ensure, RegistrationData, DynamicFeature, FeatureClient, FeatureState } from './features'
+import commands from '../commands'
+import * as UUID from './utils/uuid'
+
+export interface ExecuteCommandSignature {
+  (this: void, command: string, args: any[]): ProviderResult<any>
+}
+
+export interface ExecuteCommandMiddleware {
+  executeCommand?: (this: void, command: string, args: any[], next: ExecuteCommandSignature) => ProviderResult<any>
+}
+
+export class ExecuteCommandFeature implements DynamicFeature<ExecuteCommandRegistrationOptions> {
+  private _commands: Map<string, Disposable[]> = new Map<string, Disposable[]>()
+  constructor(private _client: FeatureClient<ExecuteCommandMiddleware>) {}
+
+  public getState(): FeatureState {
+    return { kind: 'workspace', id: this.registrationType.method, registrations: this._commands.size > 0 }
+  }
+
+  public get registrationType(): RegistrationType<ExecuteCommandRegistrationOptions> {
+    return ExecuteCommandRequest.type
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    ensure(
+      ensure(capabilities, 'workspace')!,
+      'executeCommand'
+    )!.dynamicRegistration = true
+  }
+
+  public initialize(capabilities: ServerCapabilities): void {
+    if (!capabilities.executeCommandProvider) {
+      return
+    }
+    this.register({
+      id: UUID.generateUuid(),
+      registerOptions: Object.assign({}, capabilities.executeCommandProvider)
+    })
+  }
+
+  public register(
+    data: RegistrationData<ExecuteCommandRegistrationOptions>
+  ): void {
+    const client = this._client
+    const middleware = client.middleware!
+    const executeCommand: ExecuteCommandSignature = (command: string, args: any[]): any => {
+      const params: ExecuteCommandParams = {
+        command,
+        arguments: args
+      }
+      return client.sendRequest(ExecuteCommandRequest.type, params).then(undefined, error => {
+        client.handleFailedRequest(ExecuteCommandRequest.type, undefined, error, undefined)
+        throw error
+      })
+    }
+    if (data.registerOptions.commands) {
+      let disposables: Disposable[] = []
+      for (const command of data.registerOptions.commands) {
+        disposables.push(commands.registerCommand(command, (...args: any[]) => {
+          return middleware.executeCommand
+            ? middleware.executeCommand(command, args, executeCommand)
+            : executeCommand(command, args)
+        }, null, true))
+      }
+      this._commands.set(data.id, disposables)
+    }
+  }
+
+  public unregister(id: string): void {
+    let disposables = this._commands.get(id)
+    if (disposables) {
+      disposables.forEach(disposable => disposable.dispose())
+    }
+  }
+
+  public dispose(): void {
+    this._commands.forEach(value => {
+      value.forEach(disposable => disposable.dispose())
+    })
+    this._commands.clear()
+  }
+}

--- a/src/language-client/features.ts
+++ b/src/language-client/features.ts
@@ -1,0 +1,683 @@
+'use strict'
+import {
+  TraceOptions,
+  CallHierarchyPrepareRequest, CancellationToken, ClientCapabilities, CodeActionRequest, CodeLensRequest, CompletionRequest, DeclarationRequest, DefinitionRequest,
+  DidChangeTextDocumentNotification, DidCloseTextDocumentNotification, DidCreateFilesNotification, DidDeleteFilesNotification, DidOpenTextDocumentNotification,
+  DidRenameFilesNotification, DidSaveTextDocumentNotification, Disposable, DocumentColorRequest, DocumentDiagnosticRequest, DocumentFormattingRequest, DocumentHighlightRequest,
+  DocumentLinkRequest, DocumentOnTypeFormattingRequest, DocumentRangeFormattingRequest, DocumentSelector, DocumentSymbolRequest, Emitter, Event, FileOperationRegistrationOptions,
+  FoldingRangeRequest, GenericNotificationHandler, GenericRequestHandler, HoverRequest, ImplementationRequest, InitializeParams, InitializeResult, InlayHintRequest, InlineValueRequest,
+  LinkedEditingRangeRequest, MarkupKind, MessageSignature, NotificationHandler, NotificationHandler0,
+  NotificationType, NotificationType0, ProgressType, ProtocolNotificationType, ProtocolNotificationType0, ProtocolRequestType, ProtocolRequestType0, ReferencesRequest,
+  RegistrationType, RenameRequest, RequestHandler, RequestHandler0, RequestType, RequestType0, SelectionRangeRequest, SemanticTokensRegistrationType, ServerCapabilities,
+  SignatureHelpRequest, StaticRegistrationOptions, TextDocumentRegistrationOptions, TextEdit, Trace, Tracer, TypeDefinitionRequest, TypeHierarchyPrepareRequest, WillCreateFilesRequest,
+  WillDeleteFilesRequest, WillRenameFilesRequest, WillSaveTextDocumentNotification, WillSaveTextDocumentWaitUntilRequest, WorkDoneProgressOptions, WorkspaceSymbolRequest
+} from 'vscode-languageserver-protocol'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import { CallHierarchyProvider, CodeActionProvider, CompletionItemProvider, DeclarationProvider, DefinitionProvider, DocumentColorProvider, DocumentFormattingEditProvider, DocumentHighlightProvider, DocumentLinkProvider, DocumentRangeFormattingEditProvider, DocumentSymbolProvider, FoldingRangeProvider, HoverProvider, ImplementationProvider, LinkedEditingRangeProvider, OnTypeFormattingEditProvider, ReferenceProvider, RenameProvider, SelectionRangeProvider, SignatureHelpProvider, TypeDefinitionProvider, TypeHierarchyProvider, WorkspaceSymbolProvider } from '../provider'
+import { FileCreateEvent, FileDeleteEvent, FileRenameEvent, FileWillCreateEvent, FileWillDeleteEvent, FileWillRenameEvent } from '../types'
+import * as Is from '../util/is'
+import workspace from '../workspace'
+import * as UUID from './utils/uuid'
+import { CancellationError } from '../util/errors'
+
+export interface Connection {
+  /**
+   * A timestamp indicating when the connection was last used (.e.g a request
+   * or notification has been sent)
+   */
+  lastUsed: number
+
+  resetLastUsed(): void
+
+  listen(): void
+
+  hasPendingResponse(): boolean
+  sendRequest<R, PR, E, RO>(type: ProtocolRequestType0<R, PR, E, RO>, token?: CancellationToken): Promise<R>
+  sendRequest<P, R, PR, E, RO>(type: ProtocolRequestType<P, R, PR, E, RO>, params: P, token?: CancellationToken): Promise<R>
+  sendRequest<R, E>(type: RequestType0<R, E>, token?: CancellationToken): Promise<R>
+  sendRequest<P, R, E>(type: RequestType<P, R, E>, params: P, token?: CancellationToken): Promise<R>
+  sendRequest<R>(method: string, token?: CancellationToken): Promise<R>
+  sendRequest<R>(method: string, param: any, token?: CancellationToken): Promise<R>
+  sendRequest<R>(type: string | MessageSignature, ...params: any[]): Promise<R>
+
+  onRequest<R, PR, E, RO>(type: ProtocolRequestType0<R, PR, E, RO>, handler: RequestHandler0<R, E>): Disposable
+  onRequest<P, R, PR, E, RO>(type: ProtocolRequestType<P, R, PR, E, RO>, handler: RequestHandler<P, R, E>): Disposable
+  onRequest<R, E>(type: RequestType0<R, E>, handler: RequestHandler0<R, E>): Disposable
+  onRequest<P, R, E>(type: RequestType<P, R, E>, handler: RequestHandler<P, R, E>): Disposable
+  onRequest<R, E>(method: string | MessageSignature, handler: GenericRequestHandler<R, E>): Disposable
+
+  sendNotification<RO>(type: ProtocolNotificationType0<RO>): Promise<void>
+  sendNotification<P, RO>(type: ProtocolNotificationType<P, RO>, params?: P): Promise<void>
+  sendNotification(type: NotificationType0): Promise<void>
+  sendNotification<P>(type: NotificationType<P>, params?: P): Promise<void>
+  sendNotification(method: string | MessageSignature, params?: any): Promise<void>
+
+  onNotification<RO>(type: ProtocolNotificationType0<RO>, handler: NotificationHandler0): Disposable
+  onNotification<P, RO>(type: ProtocolNotificationType<P, RO>, handler: NotificationHandler<P>): Disposable
+  onNotification(type: NotificationType0, handler: NotificationHandler0): Disposable
+  onNotification<P>(type: NotificationType<P>, handler: NotificationHandler<P>): Disposable
+  onNotification(method: string | MessageSignature, handler: GenericNotificationHandler): Disposable
+
+  onProgress<P>(type: ProgressType<P>, token: string | number, handler: NotificationHandler<P>): Disposable
+  sendProgress<P>(type: ProgressType<P>, token: string | number, value: P): Promise<void>
+
+  trace(value: Trace, tracer: Tracer, sendNotification?: boolean | TraceOptions): Promise<void>
+  initialize(params: InitializeParams): Promise<InitializeResult>
+  shutdown(): Promise<void>
+  exit(): Promise<void>
+  end(): void
+  dispose(): void
+}
+
+export class LSPCancellationError extends CancellationError {
+  public readonly data: object | Object
+  constructor(data: object | Object) {
+    super()
+    this.data = data
+  }
+}
+
+export interface RegistrationData<T> {
+  id: string
+  registerOptions: T
+}
+
+export interface NextSignature<P, R> {
+  (this: void, data: P, next: (data: P) => R): R
+}
+
+export function ensure<T, K extends keyof T>(target: T, key: K): T[K] {
+  if (target[key] === undefined) {
+    target[key] = {} as any
+  }
+  return target[key]
+}
+
+export interface TextDocumentProviderFeature<T> {
+  /**
+   * Triggers the corresponding RPC method.
+   */
+  getProvider(textDocument: TextDocument): T | undefined
+}
+
+export type FeatureStateKind = 'document' | 'workspace' | 'static' | 'window'
+
+export type FeatureState = {
+  kind: 'document'
+
+  /**
+   * The features's id. This is usually the method names used during
+   * registration.
+   */
+  id: string
+
+  /**
+   * Has active registrations.
+   */
+  registrations: boolean
+
+  /**
+   * A registration matches an open document.
+   */
+  matches: boolean
+
+} | {
+  kind: 'workspace'
+
+  /**
+   * The features's id. This is usually the method names used during
+   * registration.
+   */
+  id: string
+
+  /**
+   * Has active registrations.
+   */
+  registrations: boolean
+} | {
+  kind: 'window'
+
+  /**
+   * The features's id. This is usually the method names used during
+   * registration.
+   */
+  id: string
+
+  /**
+   * Has active registrations.
+   */
+  registrations: boolean
+} | {
+  kind: 'static'
+}
+
+interface TextDocumentFeatureRegistration<RO, PR> {
+  disposable: Disposable
+  data: RegistrationData<RO>
+  provider: PR
+}
+
+/**
+ * A static feature. A static feature can't be dynamically activated via the
+ * server. It is wired during the initialize sequence.
+ */
+export interface StaticFeature {
+  /**
+   * Called to fill the initialize params.
+   *
+   * @params the initialize params.
+   */
+  fillInitializeParams?: (params: InitializeParams) => void
+
+  /**
+   * Called to fill in the client capabilities this feature implements.
+   *
+   * @param capabilities The client capabilities to fill.
+   */
+  fillClientCapabilities(capabilities: ClientCapabilities): void
+
+  /**
+   * A preflight where the server capabilities are shown to all features
+   * before a feature is actually initialized. This allows feature to
+   * capture some state if they are a pre-requisite for other features.
+   *
+   * @param capabilities the server capabilities
+   * @param documentSelector the document selector pass to the client's constructor.
+   * May be `undefined` if the client was created without a selector.
+   */
+  preInitialize?: (capabilities: ServerCapabilities, documentSelector: DocumentSelector | undefined) => void
+
+  /**
+   * Initialize the feature. This method is called on a feature instance
+   * when the client has successfully received the initialize request from
+   * the server and before the client sends the initialized notification
+   * to the server.
+   *
+   * @param capabilities the server capabilities
+   * @param documentSelector the document selector pass to the client's constructor.
+   * May be `undefined` if the client was created without a selector.
+   */
+  initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector | undefined): void
+
+  /**
+   * Returns the state the feature is in.
+   */
+  getState?(): FeatureState
+
+  /**
+   * Called when the client is stopped to dispose this feature. Usually a feature
+   * un-registers listeners registered hooked up with the VS Code extension host.
+   */
+  dispose(): void
+}
+
+// eslint-disable-next-line no-redeclare
+export namespace StaticFeature {
+  export function is(value: any): value is StaticFeature {
+    const candidate: StaticFeature = value
+    return candidate !== undefined && candidate !== null &&
+      Is.func(candidate.fillClientCapabilities) && Is.func(candidate.initialize) && Is.func(candidate.dispose) &&
+      (candidate.fillInitializeParams === undefined || Is.func(candidate.fillInitializeParams))
+  }
+}
+
+/**
+ * A dynamic feature can be activated via the server.
+ */
+export interface DynamicFeature<RO> {
+
+  /**
+   * Called to fill the initialize params.
+   *
+   * @params the initialize params.
+   */
+  fillInitializeParams?: (params: InitializeParams) => void
+
+  /**
+   * Called to fill in the client capabilities this feature implements.
+   *
+   * @param capabilities The client capabilities to fill.
+   */
+  fillClientCapabilities(capabilities: ClientCapabilities): void
+
+  /**
+   * A preflight where the server capabilities are shown to all features
+   * before a feature is actually initialized. This allows feature to
+   * capture some state if they are a pre-requisite for other features.
+   *
+   * @param capabilities the server capabilities
+   * @param documentSelector the document selector pass to the client's constructor.
+   * May be `undefined` if the client was created without a selector.
+   */
+  preInitialize?: (capabilities: ServerCapabilities, documentSelector: DocumentSelector | undefined) => void
+
+  /**
+   * Initialize the feature. This method is called on a feature instance
+   * when the client has successfully received the initialize request from
+   * the server and before the client sends the initialized notification
+   * to the server.
+   *
+   * @param capabilities the server capabilities.
+   * @param documentSelector the document selector pass to the client's constructor.
+   * May be `undefined` if the client was created without a selector.
+   */
+  initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector | undefined): void
+
+  /**
+   * Returns the state the feature is in.
+   */
+  getState?(): FeatureState
+
+  /**
+   * The signature (e.g. method) for which this features support dynamic activation / registration.
+   */
+  registrationType: RegistrationType<RO>
+
+  /**
+   * Is called when the server send a register request for the given message.
+   *
+   * @param data additional registration data as defined in the protocol.
+   */
+  register(data: RegistrationData<RO>): void
+
+  /**
+   * Is called when the server wants to unregister a feature.
+   *
+   * @param id the id used when registering the feature.
+   */
+  unregister(id: string): void
+
+  /**
+   * Called when the client is stopped to dispose this feature. Usually a feature
+   * un-registers listeners registered hooked up with the VS Code extension host.
+   */
+  dispose(): void
+}
+
+// eslint-disable-next-line no-redeclare
+export namespace DynamicFeature {
+  export function is<T>(value: any): value is DynamicFeature<T> {
+    const candidate: DynamicFeature<T> = value
+    return candidate !== undefined && candidate !== null &&
+      Is.func(candidate.fillClientCapabilities) && Is.func(candidate.initialize) && Is.func(candidate.dispose) &&
+      (candidate.fillInitializeParams === undefined || Is.func(candidate.fillInitializeParams)) && Is.func(candidate.register) &&
+      Is.func(candidate.unregister) && candidate.registrationType !== undefined
+  }
+}
+
+interface CreateParamsSignature<E, P> {
+  (data: E): P
+}
+
+/**
+ * An abstract dynamic feature implementation that operates on documents (e.g. text
+ * documents or notebooks).
+ */
+export abstract class DynamicDocumentFeature<RO, MW, CO = object> implements DynamicFeature<RO> {
+  protected readonly _client: FeatureClient<MW, CO>
+  constructor(client: FeatureClient<MW, CO>) {
+    this._client = client
+  }
+
+  // Repeat from interface.
+  public abstract fillClientCapabilities(capabilities: ClientCapabilities): void
+  public abstract initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector | undefined): void
+  public abstract registrationType: RegistrationType<RO>
+  public abstract register(data: RegistrationData<RO>): void
+  public abstract unregister(id: string): void
+  public abstract dispose(): void
+
+  /**
+   * Returns the state the feature is in.
+   */
+  public getState(): FeatureState {
+    const selectors = this.getDocumentSelectors()
+    let count = 0
+    for (const selector of selectors) {
+      count++
+      for (const document of workspace.textDocuments) {
+        if (workspace.match(selector, document) > 0) {
+          return { kind: 'document', id: this.registrationType.method, registrations: true, matches: true }
+        }
+      }
+    }
+    const registrations = count > 0
+    return { kind: 'document', id: this.registrationType.method, registrations, matches: false }
+
+  }
+
+  protected abstract getDocumentSelectors(): IterableIterator<DocumentSelector>
+}
+
+/**
+ * A mixin type that allows to send notification or requests using a registered
+ * provider.
+ */
+export interface TextDocumentSendFeature<T extends Function> {
+  /**
+   * Returns a provider for the given text document.
+   */
+  getProvider(document: TextDocument): { send: T } | undefined
+}
+
+export interface NotificationSendEvent<E, P> {
+  original: E
+  type: ProtocolNotificationType<P, TextDocumentRegistrationOptions>
+  params: P
+}
+
+export interface NotifyingFeature<E, P> {
+  onNotificationSent: Event<NotificationSendEvent<E, P>>
+}
+
+export abstract class TextDocumentEventFeature<P, E, M> extends DynamicDocumentFeature<TextDocumentRegistrationOptions, M> implements TextDocumentSendFeature<(data: E) => Promise<void>>, NotifyingFeature<E, P> {
+
+  private readonly _event: Event<E>
+  protected readonly _type: ProtocolNotificationType<P, TextDocumentRegistrationOptions>
+  protected readonly _middleware: () => NextSignature<E, Promise<void>> | undefined
+  protected readonly _createParams: CreateParamsSignature<E, P>
+  protected readonly _textDocument: (data: E) => TextDocument
+  protected readonly _selectorFilter?: (selectors: IterableIterator<DocumentSelector>, data: E) => boolean
+
+  private _listener: Disposable | undefined
+  protected readonly _selectors: Map<string, DocumentSelector>
+  private readonly _onNotificationSent: Emitter<NotificationSendEvent<E, P>>
+
+  public static textDocumentFilter(
+    selectors: IterableIterator<DocumentSelector>,
+    textDocument: TextDocument
+  ): boolean {
+    for (const selector of selectors) {
+      if (workspace.match(selector, textDocument) > 0) {
+        return true
+      }
+    }
+    return false
+  }
+
+  constructor(client: FeatureClient<M>, event: Event<E>, type: ProtocolNotificationType<P, TextDocumentRegistrationOptions>,
+    middleware: () => NextSignature<E, Promise<void>> | undefined, createParams: CreateParamsSignature<E, P>,
+    textDocument: (data: E) => TextDocument,
+    selectorFilter?: (selectors: IterableIterator<DocumentSelector>, data: E) => boolean
+  ) {
+    super(client)
+    this._event = event
+    this._type = type
+    this._middleware = middleware
+    this._createParams = createParams
+    this._textDocument = textDocument
+    this._selectorFilter = selectorFilter
+
+    this._selectors = new Map<string, DocumentSelector>()
+    this._onNotificationSent = new Emitter<NotificationSendEvent<E, P>>()
+  }
+
+  protected getDocumentSelectors(): IterableIterator<DocumentSelector> {
+    return this._selectors.values()
+  }
+
+  public register(data: RegistrationData<TextDocumentRegistrationOptions>): void {
+
+    if (!data.registerOptions.documentSelector) {
+      return
+    }
+    if (!this._listener) {
+      this._listener = this._event(data => {
+        this.callback(data).catch(error => {
+          this._client.error(`Sending document notification ${this._type.method} failed.`, error)
+        })
+      })
+    }
+    this._selectors.set(data.id, data.registerOptions.documentSelector)
+  }
+
+  private async callback(data: E): Promise<void> {
+    const doSend = async (data: E): Promise<void> => {
+      const params = this._createParams(data)
+      await this._client.sendNotification(this._type, params).catch()
+      this.notificationSent(data, this._type, params)
+    }
+    if (this.matches(data)) {
+      const middleware = this._middleware()
+      return Promise.resolve(middleware ? middleware(data, data => doSend(data)) : doSend(data))
+    }
+  }
+
+  private matches(data: E): boolean {
+    return !this._selectorFilter || this._selectorFilter(this._selectors.values(), data)
+  }
+
+  public get onNotificationSent(): Event<NotificationSendEvent<E, P>> {
+    return this._onNotificationSent.event
+  }
+
+  protected notificationSent(data: E, type: ProtocolNotificationType<P, TextDocumentRegistrationOptions>, params: P): void {
+    this._onNotificationSent.fire({ original: data, type, params })
+  }
+
+  public unregister(id: string): void {
+    this._selectors.delete(id)
+    if (this._selectors.size === 0 && this._listener) {
+      this._listener.dispose()
+      this._listener = undefined
+    }
+  }
+
+  public dispose(): void {
+    this._selectors.clear()
+    this._onNotificationSent.dispose()
+    if (this._listener) {
+      this._listener.dispose()
+      this._listener = undefined
+    }
+  }
+
+  public getProvider(document: TextDocument): { send: (data: E) => Promise<void> } | undefined {
+    for (const selector of this.getDocumentSelectors()) {
+      if (workspace.match(selector, document) > 0) {
+        return {
+          send: (data: E) => {
+            return this.callback(data)
+          }
+        }
+      }
+    }
+    return undefined
+  }
+}
+/**
+ * A abstract feature implementation that registers language providers
+ * for text documents using a given document selector.
+ */
+export abstract class TextDocumentLanguageFeature<PO, RO extends TextDocumentRegistrationOptions & PO, PR, MW, CO = object> extends DynamicDocumentFeature<RO, MW, CO> {
+
+  private readonly _registrationType: RegistrationType<RO>
+  private readonly _registrations: Map<string, TextDocumentFeatureRegistration<RO, PR>>
+
+  constructor(client: FeatureClient<MW, CO>, registrationType: RegistrationType<RO>) {
+    super(client)
+    this._registrationType = registrationType
+    this._registrations = new Map()
+  }
+
+  protected *getDocumentSelectors(): IterableIterator<DocumentSelector> {
+    for (const registration of this._registrations.values()) {
+      const selector = registration.data.registerOptions.documentSelector
+      if (selector === null) {
+        continue
+      }
+      yield selector
+    }
+  }
+
+  public get registrationType(): RegistrationType<RO> {
+    return this._registrationType
+  }
+
+  public abstract fillClientCapabilities(capabilities: ClientCapabilities): void
+
+  public abstract initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void
+
+  public register(data: RegistrationData<RO>): void {
+    if (!data.registerOptions.documentSelector) {
+      return
+    }
+    let registration = this.registerLanguageProvider(data.registerOptions, data.id)
+    this._registrations.set(data.id, { disposable: registration[0], data, provider: registration[1] })
+  }
+
+  protected abstract registerLanguageProvider(options: RO, id: string): [Disposable, PR]
+
+  public unregister(id: string): void {
+    let registration = this._registrations.get(id)
+    if (registration !== undefined) {
+      registration.disposable.dispose()
+    }
+  }
+
+  public dispose(): void {
+    this._registrations.forEach(value => {
+      value.disposable.dispose()
+    })
+    this._registrations.clear()
+  }
+
+  protected getRegistration(documentSelector: DocumentSelector | undefined, capability: undefined | PO | (RO & StaticRegistrationOptions)): [string | undefined, (RO & { documentSelector: DocumentSelector }) | undefined] {
+    if (!capability) {
+      return [undefined, undefined]
+    } else if (TextDocumentRegistrationOptions.is(capability)) {
+      const id = StaticRegistrationOptions.hasId(capability) ? capability.id : UUID.generateUuid()
+      const selector = capability.documentSelector || documentSelector
+      if (selector) {
+        return [id, Object.assign({}, capability, { documentSelector: selector })]
+      }
+    } else if (Is.boolean(capability) && capability === true || WorkDoneProgressOptions.is(capability)) {
+      if (!documentSelector) {
+        return [undefined, undefined]
+      }
+      let options: RO & { documentSelector: DocumentSelector } = (Is.boolean(capability) && capability === true ? { documentSelector } : Object.assign({}, capability, { documentSelector })) as any
+      return [UUID.generateUuid(), options]
+    }
+    return [undefined, undefined]
+  }
+
+  protected getRegistrationOptions(documentSelector: DocumentSelector | undefined, capability: undefined | PO): (RO & { documentSelector: DocumentSelector }) | undefined {
+    if (!documentSelector || !capability) {
+      return undefined
+    }
+    return (Is.boolean(capability) && capability === true ? { documentSelector } : Object.assign({}, capability, { documentSelector })) as RO & { documentSelector: DocumentSelector }
+  }
+
+  public getProvider(textDocument: TextDocument): PR | undefined {
+    for (const registration of this._registrations.values()) {
+      let selector = registration.data.registerOptions.documentSelector
+      if (selector !== null && workspace.match(selector, textDocument) > 0) {
+        return registration.provider
+      }
+    }
+    return undefined
+  }
+
+  protected getAllProviders(): Iterable<PR> {
+    const result: PR[] = []
+    for (const item of this._registrations.values()) {
+      result.push(item.provider)
+    }
+    return result
+  }
+}
+
+import { ProviderResult } from '../provider'
+import { CodeLensProviderShape } from './codeLens'
+import { DiagnosticProviderShape } from './diagnostic'
+import { InlayHintsProviderShape } from './inlayHint'
+import { InlineValueProviderShape } from './inlineValue'
+import { DidChangeTextDocumentFeatureShape, DidCloseTextDocumentFeatureShape, DidOpenTextDocumentFeatureShape, DidSaveTextDocumentFeatureShape } from './textSynchronization'
+import { WorkspaceProviderFeature } from './workspaceSymbol'
+import { SemanticTokensProviderShape } from './semanticTokens'
+
+export interface FeatureClient<M, CO = object> {
+  clientOptions: CO
+  middleware: M
+  readonly id: string
+  supportedMarkupKind: MarkupKind[]
+
+  start(): Disposable
+  isRunning(): boolean
+  stop(): Promise<void>
+
+  sendRequest<R, PR, E, RO>(type: ProtocolRequestType0<R, PR, E, RO>, token?: CancellationToken): Promise<R>
+  sendRequest<P, R, PR, E, RO>(type: ProtocolRequestType<P, R, PR, E, RO>, params: P, token?: CancellationToken): Promise<R>
+  sendRequest<R, E>(type: RequestType0<R, E>, token?: CancellationToken): Promise<R>
+  sendRequest<P, R, E>(type: RequestType<P, R, E>, params: P, token?: CancellationToken): Promise<R>
+  sendRequest<R>(method: string, token?: CancellationToken): Promise<R>
+  sendRequest<R>(method: string, param: any, token?: CancellationToken): Promise<R>
+
+  onRequest<R, PR, E, RO>(type: ProtocolRequestType0<R, PR, E, RO>, handler: RequestHandler0<R, E>): Disposable
+  onRequest<P, R, PR, E, RO>(type: ProtocolRequestType<P, R, PR, E, RO>, handler: RequestHandler<P, R, E>): Disposable
+  onRequest<R, E>(type: RequestType0<R, E>, handler: RequestHandler0<R, E>): Disposable
+  onRequest<P, R, E>(type: RequestType<P, R, E>, handler: RequestHandler<P, R, E>): Disposable
+  onRequest<R, E>(method: string, handler: GenericRequestHandler<R, E>): Disposable
+
+  sendNotification<RO>(type: ProtocolNotificationType0<RO>): Promise<void>
+  sendNotification<P, RO>(type: ProtocolNotificationType<P, RO>, params?: P): Promise<void>
+  sendNotification(type: NotificationType0): Promise<void>
+  sendNotification<P>(type: NotificationType<P>, params?: P): Promise<void>
+  sendNotification(method: string, params?: any): Promise<void>
+
+  onNotification<RO>(type: ProtocolNotificationType0<RO>, handler: NotificationHandler0): Disposable
+  onNotification<P, RO>(type: ProtocolNotificationType<P, RO>, handler: NotificationHandler<P>): Disposable
+  onNotification(type: NotificationType0, handler: NotificationHandler0): Disposable
+  onNotification<P>(type: NotificationType<P>, handler: NotificationHandler<P>): Disposable
+  onNotification(method: string, handler: GenericNotificationHandler): Disposable
+
+  onProgress<P>(type: ProgressType<P>, token: string | number, handler: NotificationHandler<P>): Disposable
+
+  info(message: string, data?: any, showNotification?: boolean): void
+  warn(message: string, data?: any, showNotification?: boolean): void
+  error(message: string, data?: any, showNotification?: boolean | 'force'): void
+
+  handleFailedRequest<T>(type: MessageSignature, token: CancellationToken | undefined, error: any, defaultValue: T, showNotification?: boolean): T
+
+  getFeature(request: typeof DidOpenTextDocumentNotification.method): DidOpenTextDocumentFeatureShape
+  getFeature(request: typeof DidChangeTextDocumentNotification.method): DidChangeTextDocumentFeatureShape
+  getFeature(request: typeof WillSaveTextDocumentNotification.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentSendFeature<(textDocument: TextDocument) => Promise<void>>
+  getFeature(request: typeof WillSaveTextDocumentWaitUntilRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentSendFeature<(textDocument: TextDocument) => ProviderResult<TextEdit[]>>
+  getFeature(request: typeof DidSaveTextDocumentNotification.method): DidSaveTextDocumentFeatureShape
+  getFeature(request: typeof DidCloseTextDocumentNotification.method): DidCloseTextDocumentFeatureShape
+  getFeature(request: typeof DidCreateFilesNotification.method): DynamicFeature<FileOperationRegistrationOptions> & { send: (event: FileCreateEvent) => Promise<void> }
+  getFeature(request: typeof DidRenameFilesNotification.method): DynamicFeature<FileOperationRegistrationOptions> & { send: (event: FileRenameEvent) => Promise<void> }
+  getFeature(request: typeof DidDeleteFilesNotification.method): DynamicFeature<FileOperationRegistrationOptions> & { send: (event: FileDeleteEvent) => Promise<void> }
+  getFeature(request: typeof WillCreateFilesRequest.method): DynamicFeature<FileOperationRegistrationOptions> & { send: (event: FileWillCreateEvent) => Promise<void> }
+  getFeature(request: typeof WillRenameFilesRequest.method): DynamicFeature<FileOperationRegistrationOptions> & { send: (event: FileWillRenameEvent) => Promise<void> }
+  getFeature(request: typeof WillDeleteFilesRequest.method): DynamicFeature<FileOperationRegistrationOptions> & { send: (event: FileWillDeleteEvent) => Promise<void> }
+  getFeature(request: typeof CompletionRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<CompletionItemProvider>
+  getFeature(request: typeof HoverRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<HoverProvider>
+  getFeature(request: typeof SignatureHelpRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<SignatureHelpProvider>
+  getFeature(request: typeof DefinitionRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<DefinitionProvider>
+  getFeature(request: typeof ReferencesRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<ReferenceProvider>
+  getFeature(request: typeof DocumentHighlightRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<DocumentHighlightProvider>
+  getFeature(request: typeof CodeActionRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<CodeActionProvider>
+  getFeature(request: typeof CodeLensRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<CodeLensProviderShape>
+  getFeature(request: typeof DocumentFormattingRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<DocumentFormattingEditProvider>
+  getFeature(request: typeof DocumentRangeFormattingRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<DocumentRangeFormattingEditProvider>
+  getFeature(request: typeof DocumentOnTypeFormattingRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<OnTypeFormattingEditProvider>
+  getFeature(request: typeof RenameRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<RenameProvider>
+  getFeature(request: typeof DocumentSymbolRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<DocumentSymbolProvider>
+  getFeature(request: typeof DocumentLinkRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<DocumentLinkProvider>
+  getFeature(request: typeof DocumentColorRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<DocumentColorProvider>
+  getFeature(request: typeof DeclarationRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<DeclarationProvider>
+  getFeature(request: typeof FoldingRangeRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<FoldingRangeProvider>
+  getFeature(request: typeof ImplementationRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<ImplementationProvider>
+  getFeature(request: typeof SelectionRangeRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<SelectionRangeProvider>
+  getFeature(request: typeof TypeDefinitionRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<TypeDefinitionProvider>
+  getFeature(request: typeof CallHierarchyPrepareRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<CallHierarchyProvider>
+  getFeature(request: typeof SemanticTokensRegistrationType.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<SemanticTokensProviderShape>
+  getFeature(request: typeof LinkedEditingRangeRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<LinkedEditingRangeProvider>
+  getFeature(request: typeof TypeHierarchyPrepareRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<TypeHierarchyProvider>
+  getFeature(request: typeof InlineValueRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<InlineValueProviderShape>
+  getFeature(request: typeof InlayHintRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<InlayHintsProviderShape>
+  getFeature(request: typeof WorkspaceSymbolRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & WorkspaceProviderFeature<WorkspaceSymbolProvider>
+  getFeature(request: typeof DocumentDiagnosticRequest.method): DynamicFeature<TextDocumentRegistrationOptions> & TextDocumentProviderFeature<DiagnosticProviderShape> | undefined
+  // getFeature(request: typeof NotebookDocumentSyncRegistrationType.method): DynamicFeature<NotebookDocumentSyncRegistrationOptions> & NotebookDocumentProviderShape | undefined;
+}

--- a/src/language-client/fileSystemWatcher.ts
+++ b/src/language-client/fileSystemWatcher.ts
@@ -1,0 +1,142 @@
+'use strict'
+import {
+  ClientCapabilities, DidChangeWatchedFilesNotification, DidChangeWatchedFilesRegistrationOptions, Disposable, DocumentSelector, FileChangeType, FileEvent, RegistrationType,
+  ServerCapabilities, WatchKind
+} from 'vscode-languageserver-protocol'
+import { FileSystemWatcher } from '../types'
+import * as Is from '../util/is'
+import workspace from '../workspace'
+import { DynamicFeature, ensure, FeatureClient, FeatureState, RegistrationData } from './features'
+import * as cv from './utils/converter'
+
+export class FileSystemWatcherFeature implements DynamicFeature<DidChangeWatchedFilesRegistrationOptions> {
+  private _watchers: Map<string, Disposable[]> = new Map<string, Disposable[]>()
+
+  constructor(
+    _client: FeatureClient<object>,
+    private _notifyFileEvent: (event: FileEvent) => void
+  ) {}
+
+  public getState(): FeatureState {
+    return { kind: 'workspace', id: this.registrationType.method, registrations: this._watchers.size > 0 }
+  }
+
+  public get registrationType(): RegistrationType<DidChangeWatchedFilesRegistrationOptions> {
+    return DidChangeWatchedFilesNotification.type
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    ensure(ensure(capabilities, 'workspace')!, 'didChangeWatchedFiles')!.dynamicRegistration = true
+  }
+
+  public initialize(
+    _capabilities: ServerCapabilities,
+    _documentSelector: DocumentSelector
+  ): void {}
+
+  public register(
+    data: RegistrationData<DidChangeWatchedFilesRegistrationOptions>
+  ): void {
+    if (!Array.isArray(data.registerOptions.watchers)) {
+      return
+    }
+    let disposables: Disposable[] = []
+    for (let watcher of data.registerOptions.watchers) {
+      if (!Is.string(watcher.globPattern)) {
+        continue
+      }
+      let watchCreate = true
+      let watchChange = true
+      let watchDelete = true
+      if (watcher.kind != null) {
+        watchCreate = (watcher.kind & WatchKind.Create) !== 0
+        watchChange = (watcher.kind & WatchKind.Change) != 0
+        watchDelete = (watcher.kind & WatchKind.Delete) != 0
+      }
+      let fileSystemWatcher = workspace.createFileSystemWatcher(
+        watcher.globPattern,
+        !watchCreate,
+        !watchChange,
+        !watchDelete
+      )
+      this.hookListeners(
+        fileSystemWatcher,
+        watchCreate,
+        watchChange,
+        watchDelete,
+        disposables
+      )
+      disposables.push(fileSystemWatcher)
+    }
+    this._watchers.set(data.id, disposables)
+  }
+
+  public registerRaw(id: string, fileSystemWatchers: FileSystemWatcher[]) {
+    let disposables: Disposable[] = []
+    for (let fileSystemWatcher of fileSystemWatchers) {
+      disposables.push(fileSystemWatcher)
+      this.hookListeners(fileSystemWatcher, true, true, true, disposables)
+    }
+    this._watchers.set(id, disposables)
+  }
+
+  private hookListeners(
+    fileSystemWatcher: FileSystemWatcher,
+    watchCreate: boolean,
+    watchChange: boolean,
+    watchDelete: boolean,
+    listeners: Disposable[]
+  ): void {
+    if (watchCreate) {
+      fileSystemWatcher.onDidCreate(
+        resource =>
+          this._notifyFileEvent({
+            uri: cv.asUri(resource),
+            type: FileChangeType.Created
+          }),
+        null,
+        listeners
+      )
+    }
+    if (watchChange) {
+      fileSystemWatcher.onDidChange(
+        resource =>
+          this._notifyFileEvent({
+            uri: cv.asUri(resource),
+            type: FileChangeType.Changed
+          }),
+        null,
+        listeners
+      )
+    }
+    if (watchDelete) {
+      fileSystemWatcher.onDidDelete(
+        resource =>
+          this._notifyFileEvent({
+            uri: cv.asUri(resource),
+            type: FileChangeType.Deleted
+          }),
+        null,
+        listeners
+      )
+    }
+  }
+
+  public unregister(id: string): void {
+    let disposables = this._watchers.get(id)
+    if (disposables) {
+      for (let disposable of disposables) {
+        disposable.dispose()
+      }
+    }
+  }
+
+  public dispose(): void {
+    this._watchers.forEach(disposables => {
+      for (let disposable of disposables) {
+        disposable.dispose()
+      }
+    })
+    this._watchers.clear()
+  }
+}

--- a/src/language-client/foldingRange.ts
+++ b/src/language-client/foldingRange.ts
@@ -1,15 +1,9 @@
 'use strict'
-/* --------------------------------------------------------------------------------------------
- * Copyright (c) Microsoft Corporation. All rights reserved.
- * Licensed under the MIT License. See License.txt in the project root for license information.
- * ------------------------------------------------------------------------------------------ */
-'use strict'
-
 import { CancellationToken, ClientCapabilities, Disposable, DocumentSelector, FoldingRange, FoldingRangeOptions, FoldingRangeParams, FoldingRangeRegistrationOptions, FoldingRangeRequest, ServerCapabilities } from 'vscode-languageserver-protocol'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import languages from '../languages'
 import { FoldingContext, FoldingRangeProvider, ProviderResult } from '../provider'
-import { BaseLanguageClient, ensure, TextDocumentFeature } from './client'
+import { TextDocumentLanguageFeature, FeatureClient, ensure } from './features'
 
 export type ProvideFoldingRangeSignature = (
   this: void,
@@ -28,10 +22,10 @@ export interface FoldingRangeProviderMiddleware {
   ) => ProviderResult<FoldingRange[]>
 }
 
-export class FoldingRangeFeature extends TextDocumentFeature<
-  boolean | FoldingRangeOptions, FoldingRangeRegistrationOptions, FoldingRangeProvider
-  > {
-  constructor(client: BaseLanguageClient) {
+export class FoldingRangeFeature extends TextDocumentLanguageFeature<
+  boolean | FoldingRangeOptions, FoldingRangeRegistrationOptions, FoldingRangeProvider, FoldingRangeProviderMiddleware
+> {
+  constructor(client: FeatureClient<FoldingRangeProviderMiddleware>) {
     super(client, FoldingRangeRequest.type)
   }
 
@@ -69,7 +63,7 @@ export class FoldingRangeFeature extends TextDocumentFeature<
             }
           )
         }
-        const middleware = client.clientOptions.middleware
+        const middleware = client.middleware
         return middleware.provideFoldingRanges
           ? middleware.provideFoldingRanges(document, context, token, provideFoldingRanges)
           : provideFoldingRanges(document, context, token)

--- a/src/language-client/formatting.ts
+++ b/src/language-client/formatting.ts
@@ -1,0 +1,239 @@
+'use strict'
+import { CancellationToken, ClientCapabilities, Disposable, DocumentFormattingOptions, DocumentFormattingParams, DocumentFormattingRequest, DocumentHighlightRegistrationOptions, DocumentOnTypeFormattingOptions, DocumentOnTypeFormattingParams, DocumentOnTypeFormattingRegistrationOptions, DocumentOnTypeFormattingRequest, DocumentRangeFormattingOptions, DocumentRangeFormattingParams, DocumentRangeFormattingRegistrationOptions, DocumentRangeFormattingRequest, DocumentSelector, FormattingOptions, Position, Range, ServerCapabilities, TextDocumentRegistrationOptions, TextEdit } from 'vscode-languageserver-protocol'
+import { TextDocument } from "vscode-languageserver-textdocument"
+import languages from '../languages'
+import { DocumentFormattingEditProvider, DocumentRangeFormattingEditProvider, OnTypeFormattingEditProvider, ProviderResult } from '../provider'
+import * as cv from './utils/converter'
+import * as UUID from './utils/uuid'
+import { TextDocumentLanguageFeature, FeatureClient, ensure } from './features'
+
+export interface ProvideDocumentFormattingEditsSignature {
+  (
+    this: void,
+    document: TextDocument,
+    options: FormattingOptions,
+    token: CancellationToken
+  ): ProviderResult<TextEdit[]>
+}
+
+export interface ProvideDocumentRangeFormattingEditsSignature {
+  (
+    this: void,
+    document: TextDocument,
+    range: Range,
+    options: FormattingOptions,
+    token: CancellationToken
+  ): ProviderResult<TextEdit[]>
+}
+
+export interface ProvideOnTypeFormattingEditsSignature {
+  (
+    this: void,
+    document: TextDocument,
+    position: Position,
+    ch: string,
+    options: FormattingOptions,
+    token: CancellationToken
+  ): ProviderResult<TextEdit[]>
+}
+
+export interface $FormattingOptions {
+  formatterPriority?: number
+}
+
+export interface FormattingMiddleware {
+  provideDocumentFormattingEdits?: (
+    this: void,
+    document: TextDocument,
+    options: FormattingOptions,
+    token: CancellationToken,
+    next: ProvideDocumentFormattingEditsSignature
+  ) => ProviderResult<TextEdit[]>
+  provideDocumentRangeFormattingEdits?: (
+    this: void,
+    document: TextDocument,
+    range: Range,
+    options: FormattingOptions,
+    token: CancellationToken,
+    next: ProvideDocumentRangeFormattingEditsSignature
+  ) => ProviderResult<TextEdit[]>
+  provideOnTypeFormattingEdits?: (
+    this: void,
+    document: TextDocument,
+    position: Position,
+    ch: string,
+    options: FormattingOptions,
+    token: CancellationToken,
+    next: ProvideOnTypeFormattingEditsSignature
+  ) => ProviderResult<TextEdit[]>
+}
+
+export class DocumentFormattingFeature extends TextDocumentLanguageFeature<
+  boolean | DocumentFormattingOptions, DocumentHighlightRegistrationOptions, DocumentFormattingEditProvider, FormattingMiddleware, $FormattingOptions
+> {
+
+  constructor(client: FeatureClient<FormattingMiddleware>) {
+    super(client, DocumentFormattingRequest.type)
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    ensure(
+      ensure(capabilities, 'textDocument')!,
+      'formatting'
+    )!.dynamicRegistration = true
+  }
+
+  public initialize(
+    capabilities: ServerCapabilities,
+    documentSelector: DocumentSelector
+  ): void {
+    const options = this.getRegistrationOptions(documentSelector, capabilities.documentFormattingProvider)
+    if (!options) {
+      return
+    }
+    this.register({
+      id: UUID.generateUuid(),
+      registerOptions: options
+    })
+  }
+
+  protected registerLanguageProvider(
+    options: TextDocumentRegistrationOptions
+  ): [Disposable, DocumentFormattingEditProvider] {
+    const provider: DocumentFormattingEditProvider = {
+      provideDocumentFormattingEdits: (document, options, token) => {
+        const client = this._client
+        const provideDocumentFormattingEdits: ProvideDocumentFormattingEditsSignature = (document, options, token) => {
+          const params: DocumentFormattingParams = {
+            textDocument: { uri: document.uri },
+            options
+          }
+          return client.sendRequest(DocumentFormattingRequest.type, params, token).then(
+            res => token.isCancellationRequested ? null : res,
+            error => {
+              return client.handleFailedRequest(DocumentFormattingRequest.type, token, error, null)
+            })
+        }
+        const middleware = client.middleware!
+        return middleware.provideDocumentFormattingEdits
+          ? middleware.provideDocumentFormattingEdits(document, options, token, provideDocumentFormattingEdits)
+          : provideDocumentFormattingEdits(document, options, token)
+      }
+    }
+
+    return [
+      languages.registerDocumentFormatProvider(options.documentSelector!, provider, this._client.clientOptions.formatterPriority),
+      provider
+    ]
+  }
+}
+
+export class DocumentRangeFormattingFeature extends TextDocumentLanguageFeature<
+  boolean | DocumentRangeFormattingOptions, DocumentRangeFormattingRegistrationOptions, DocumentRangeFormattingEditProvider, FormattingMiddleware
+> {
+  constructor(client: FeatureClient<FormattingMiddleware>) {
+    super(client, DocumentRangeFormattingRequest.type)
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    ensure(
+      ensure(capabilities, 'textDocument')!,
+      'rangeFormatting'
+    )!.dynamicRegistration = true
+  }
+
+  public initialize(
+    capabilities: ServerCapabilities,
+    documentSelector: DocumentSelector
+  ): void {
+    const options = this.getRegistrationOptions(documentSelector, capabilities.documentRangeFormattingProvider)
+    if (!options) {
+      return
+    }
+    this.register({
+      id: UUID.generateUuid(),
+      registerOptions: options
+    })
+  }
+
+  protected registerLanguageProvider(
+    options: TextDocumentRegistrationOptions
+  ): [Disposable, DocumentRangeFormattingEditProvider] {
+    const provider: DocumentRangeFormattingEditProvider = {
+      provideDocumentRangeFormattingEdits: (document, range, options, token) => {
+        const client = this._client
+        const provideDocumentRangeFormattingEdits: ProvideDocumentRangeFormattingEditsSignature = (document, range, options, token) => {
+          const params: DocumentRangeFormattingParams = {
+            textDocument: { uri: document.uri },
+            range,
+            options,
+          }
+          return client.sendRequest(DocumentRangeFormattingRequest.type, params, token).then(
+            res => token.isCancellationRequested ? null : res,
+            error => {
+              return client.handleFailedRequest(DocumentRangeFormattingRequest.type, token, error, null)
+            })
+        }
+        const middleware = client.middleware!
+        return middleware.provideDocumentRangeFormattingEdits
+          ? middleware.provideDocumentRangeFormattingEdits(document, range, options, token, provideDocumentRangeFormattingEdits)
+          : provideDocumentRangeFormattingEdits(document, range, options, token)
+      }
+    }
+
+    return [languages.registerDocumentRangeFormatProvider(options.documentSelector, provider), provider]
+  }
+}
+
+export class DocumentOnTypeFormattingFeature extends TextDocumentLanguageFeature<
+  DocumentOnTypeFormattingOptions, DocumentOnTypeFormattingRegistrationOptions, OnTypeFormattingEditProvider, FormattingMiddleware
+> {
+
+  constructor(client: FeatureClient<FormattingMiddleware>) {
+    super(client, DocumentOnTypeFormattingRequest.type)
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    ensure(ensure(capabilities, 'textDocument')!, 'onTypeFormatting')!.dynamicRegistration = true
+  }
+
+  public initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {
+    const options = this.getRegistrationOptions(documentSelector, capabilities.documentOnTypeFormattingProvider)
+    if (!options) {
+      return
+    }
+    this.register({
+      id: UUID.generateUuid(),
+      registerOptions: options
+    })
+  }
+
+  protected registerLanguageProvider(options: DocumentOnTypeFormattingRegistrationOptions): [Disposable, OnTypeFormattingEditProvider] {
+    const provider: OnTypeFormattingEditProvider = {
+      provideOnTypeFormattingEdits: (document, position, ch, options, token) => {
+        const client = this._client
+        const provideOnTypeFormattingEdits: ProvideOnTypeFormattingEditsSignature = (document, position, ch, options, token) => {
+          const params: DocumentOnTypeFormattingParams = {
+            textDocument: cv.asVersionedTextDocumentIdentifier(document),
+            position,
+            ch,
+            options
+          }
+          return client.sendRequest(DocumentOnTypeFormattingRequest.type, params, token).then(
+            res => token.isCancellationRequested ? null : res,
+            error => {
+              return client.handleFailedRequest(DocumentOnTypeFormattingRequest.type, token, error, null)
+            })
+        }
+        const middleware = client.middleware!
+        return middleware.provideOnTypeFormattingEdits
+          ? middleware.provideOnTypeFormattingEdits(document, position, ch, options, token, provideOnTypeFormattingEdits)
+          : provideOnTypeFormattingEdits(document, position, ch, options, token)
+      }
+    }
+
+    const moreTriggerCharacter = options.moreTriggerCharacter || []
+    const characters = [options.firstTriggerCharacter, ...moreTriggerCharacter]
+    return [languages.registerOnTypeFormattingEditProvider(options.documentSelector!, provider, characters), provider]
+  }
+}

--- a/src/language-client/hover.ts
+++ b/src/language-client/hover.ts
@@ -1,0 +1,91 @@
+'use strict'
+/* ---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+/* eslint-disable */
+import { CancellationToken, ClientCapabilities, Disposable, DocumentSelector, Hover, HoverOptions, HoverRegistrationOptions, HoverRequest, Position, ServerCapabilities } from 'vscode-languageserver-protocol'
+import { TextDocument } from "vscode-languageserver-textdocument"
+import languages from '../languages'
+import { HoverProvider, ProviderResult } from '../provider'
+import { ensure, FeatureClient } from './features'
+import * as cv from './utils/converter'
+import * as UUID from './utils/uuid'
+import { TextDocumentLanguageFeature } from './features'
+
+export interface ProvideHoverSignature {
+  (
+    this: void,
+    document: TextDocument,
+    position: Position,
+    token: CancellationToken
+  ): ProviderResult<Hover>
+}
+
+export interface HoverMiddleware {
+  provideHover?: (
+    this: void,
+    document: TextDocument,
+    position: Position,
+    token: CancellationToken,
+    next: ProvideHoverSignature
+  ) => ProviderResult<Hover>
+}
+
+export class HoverFeature extends TextDocumentLanguageFeature<
+  boolean | HoverOptions, HoverRegistrationOptions, HoverProvider, HoverMiddleware
+> {
+  constructor(client: FeatureClient<HoverMiddleware>) {
+    super(client, HoverRequest.type)
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    const hoverCapability = ensure(
+      ensure(capabilities, 'textDocument')!,
+      'hover'
+    )!
+    hoverCapability.dynamicRegistration = true
+    hoverCapability.contentFormat = this._client.supportedMarkupKind
+  }
+
+  public initialize(
+    capabilities: ServerCapabilities,
+    documentSelector: DocumentSelector
+  ): void {
+    const options = this.getRegistrationOptions(documentSelector, capabilities.hoverProvider)
+    if (!options) {
+      return
+    }
+    this.register({
+      id: UUID.generateUuid(),
+      registerOptions: options
+    })
+  }
+
+  protected registerLanguageProvider(
+    options: HoverRegistrationOptions
+  ): [Disposable, HoverProvider] {
+    const provider: HoverProvider = {
+      provideHover: (document, position, token) => {
+        const client = this._client
+        const provideHover: ProvideHoverSignature = (document, position, token) => {
+          return client.sendRequest(
+            HoverRequest.type,
+            cv.asTextDocumentPositionParams(document, position),
+            token
+          ).then(
+            res => token.isCancellationRequested ? null : res,
+            error => {
+              return client.handleFailedRequest(HoverRequest.type, token, error, null)
+            })
+        }
+
+        const middleware = client.middleware!
+        return middleware.provideHover
+          ? middleware.provideHover(document, position, token, provideHover)
+          : provideHover(document, position, token)
+      }
+    }
+    return [languages.registerHoverProvider(options.documentSelector!, provider), provider]
+  }
+}

--- a/src/language-client/implementation.ts
+++ b/src/language-client/implementation.ts
@@ -7,7 +7,7 @@ import { CancellationToken, ClientCapabilities, Definition, DefinitionLink, Disp
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import languages from '../languages'
 import { ImplementationProvider, ProviderResult } from '../provider'
-import { BaseLanguageClient, ensure, TextDocumentFeature } from './client'
+import { ensure, FeatureClient, TextDocumentLanguageFeature } from './features'
 import * as cv from './utils/converter'
 
 export interface ProvideImplementationSignature {
@@ -18,9 +18,9 @@ export interface ImplementationMiddleware {
   provideImplementation?: (this: void, document: TextDocument, position: Position, token: CancellationToken, next: ProvideImplementationSignature) => ProviderResult<Definition | DefinitionLink[]>
 }
 
-export class ImplementationFeature extends TextDocumentFeature<boolean | ImplementationOptions, ImplementationRegistrationOptions, ImplementationProvider> {
+export class ImplementationFeature extends TextDocumentLanguageFeature<boolean | ImplementationOptions, ImplementationRegistrationOptions, ImplementationProvider, ImplementationMiddleware> {
 
-  constructor(client: BaseLanguageClient) {
+  constructor(client: FeatureClient<ImplementationMiddleware>) {
     super(client, ImplementationRequest.type)
   }
 
@@ -47,7 +47,7 @@ export class ImplementationFeature extends TextDocumentFeature<boolean | Impleme
             return client.handleFailedRequest(ImplementationRequest.type, token, error, null)
           }
         )
-        const middleware = client.clientOptions.middleware
+        const middleware = client.middleware
         return middleware.provideImplementation
           ? middleware.provideImplementation(document, position, token, provideImplementation)
           : provideImplementation(document, position, token)

--- a/src/language-client/inlayHint.ts
+++ b/src/language-client/inlayHint.ts
@@ -10,7 +10,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument'
 import { InlayHint } from '../inlayHint'
 import languages from '../languages'
 import { InlayHintsProvider, ProviderResult } from '../provider'
-import { BaseLanguageClient, ensure, Middleware, TextDocumentFeature } from './client'
+import { TextDocumentLanguageFeature, FeatureClient, ensure } from './features'
 import * as cv from './utils/converter'
 const logger = require('../util/logger')('language-client-inlayHint')
 
@@ -27,8 +27,10 @@ export interface InlayHintsProviderShape {
   onDidChangeInlayHints: Emitter<void>
 }
 
-export class InlayHintsFeature extends TextDocumentFeature<boolean | InlayHintOptions, InlayHintRegistrationOptions, InlayHintsProviderShape> {
-  constructor(client: BaseLanguageClient) {
+export class InlayHintsFeature extends TextDocumentLanguageFeature<
+  boolean | InlayHintOptions, InlayHintRegistrationOptions, InlayHintsProviderShape, InlayHintsMiddleware
+> {
+  constructor(client: FeatureClient<InlayHintsMiddleware>) {
     super(client, InlayHintRequest.type)
   }
 
@@ -76,7 +78,7 @@ export class InlayHintsFeature extends TextDocumentFeature<boolean | InlayHintOp
             return client.handleFailedRequest(InlayHintRequest.type, token, error, [])
           }
         }
-        const middleware = client.clientOptions.middleware!
+        const middleware = client.middleware!
         return middleware.provideInlayHints
           ? middleware.provideInlayHints(document, range, token, provideInlayHints)
           : provideInlayHints(document, range, token)
@@ -96,7 +98,7 @@ export class InlayHintsFeature extends TextDocumentFeature<boolean | InlayHintOp
             return client.handleFailedRequest(InlayHintResolveRequest.type, token, error, null)
           }
         }
-        const middleware = client.clientOptions.middleware!
+        const middleware = client.middleware!
         return middleware.resolveInlayHint
           ? middleware.resolveInlayHint(hint, token, resolveInlayHint)
           : resolveInlayHint(hint, token)

--- a/src/language-client/progress.ts
+++ b/src/language-client/progress.ts
@@ -3,20 +3,23 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
-'use strict'
 
 import { ClientCapabilities, WorkDoneProgressCreateParams, WorkDoneProgressCreateRequest } from 'vscode-languageserver-protocol'
-import { BaseLanguageClient, ensure, StaticFeature } from './client'
 import { ProgressPart } from './progressPart'
+import { FeatureState, StaticFeature, ensure, FeatureClient } from './features'
 // const logger = require('../util/logger')('language-client-progress')
 
 export class ProgressFeature implements StaticFeature {
   private activeParts: Set<ProgressPart> = new Set()
-  constructor(private _client: BaseLanguageClient) {
+  constructor(private _client: FeatureClient<object>) {
   }
 
   public fillClientCapabilities(capabilities: ClientCapabilities): void {
     ensure(capabilities, 'window')!.workDoneProgress = true
+  }
+
+  public getState(): FeatureState {
+    return { kind: 'window', id: WorkDoneProgressCreateRequest.method, registrations: this.activeParts.size > 0 }
   }
 
   public initialize(): void {

--- a/src/language-client/reference.ts
+++ b/src/language-client/reference.ts
@@ -1,0 +1,84 @@
+'use strict'
+import { CancellationToken, ClientCapabilities, Disposable, DocumentSelector, Location, Position, ReferenceOptions, ReferenceRegistrationOptions, ReferencesRequest, ServerCapabilities, TextDocumentRegistrationOptions } from 'vscode-languageserver-protocol'
+import { TextDocument } from "vscode-languageserver-textdocument"
+import languages from '../languages'
+import { ProviderResult, ReferenceProvider } from '../provider'
+import { ensure, FeatureClient, TextDocumentLanguageFeature } from './features'
+import * as cv from './utils/converter'
+import * as UUID from './utils/uuid'
+
+export interface ProvideReferencesSignature {
+  (
+    this: void,
+    document: TextDocument,
+    position: Position,
+    options: { includeDeclaration: boolean },
+    token: CancellationToken
+  ): ProviderResult<Location[]>
+}
+
+export interface ReferencesMiddleware {
+  provideReferences?: (
+    this: void,
+    document: TextDocument,
+    position: Position,
+    options: { includeDeclaration: boolean },
+    token: CancellationToken,
+    next: ProvideReferencesSignature
+  ) => ProviderResult<Location[]>
+}
+
+export class ReferencesFeature extends TextDocumentLanguageFeature<
+  boolean | ReferenceOptions, ReferenceRegistrationOptions, ReferenceProvider, ReferencesMiddleware
+> {
+  constructor(client: FeatureClient<ReferencesMiddleware>) {
+    super(client, ReferencesRequest.type)
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    ensure(
+      ensure(capabilities, 'textDocument')!,
+      'references'
+    )!.dynamicRegistration = true
+  }
+
+  public initialize(
+    capabilities: ServerCapabilities,
+    documentSelector: DocumentSelector
+  ): void {
+    const options = this.getRegistrationOptions(documentSelector, capabilities.referencesProvider)
+    if (!options) {
+      return
+    }
+    this.register({
+      id: UUID.generateUuid(),
+      registerOptions: options
+    })
+  }
+
+  protected registerLanguageProvider(
+    options: TextDocumentRegistrationOptions
+  ): [Disposable, ReferenceProvider] {
+    const provider: ReferenceProvider = {
+      provideReferences: (document, position, options, token) => {
+        const client = this._client
+        const _providerReferences: ProvideReferencesSignature = (document, position, options, token) => {
+          return client.sendRequest(
+            ReferencesRequest.type,
+            cv.asReferenceParams(document, position, options),
+            token
+          ).then(
+            res => token.isCancellationRequested ? null : res,
+            error => {
+              return client.handleFailedRequest(ReferencesRequest.type, token, error, null)
+            })
+        }
+        const middleware = client.middleware!
+        return middleware.provideReferences
+          ? middleware.provideReferences(document, position, options, token, _providerReferences)
+          : _providerReferences(document, position, options, token)
+      }
+    }
+    return [languages.registerReferencesProvider(options.documentSelector!, provider), provider]
+  }
+}

--- a/src/language-client/rename.ts
+++ b/src/language-client/rename.ts
@@ -1,0 +1,144 @@
+'use strict'
+import { CancellationToken, ClientCapabilities, Disposable, DocumentSelector, Position, PrepareRenameRequest, Range, RenameOptions, RenameParams, RenameRegistrationOptions, RenameRequest, ResponseError, ServerCapabilities, TextDocumentPositionParams, WorkspaceEdit } from 'vscode-languageserver-protocol'
+import { TextDocument } from "vscode-languageserver-textdocument"
+import languages from '../languages'
+import { ProviderResult, RenameProvider } from '../provider'
+import * as Is from '../util/is'
+import { ensure, FeatureClient, TextDocumentLanguageFeature } from './features'
+import * as cv from './utils/converter'
+import * as UUID from './utils/uuid'
+
+interface DefaultBehavior {
+  defaultBehavior: boolean
+}
+
+export interface PrepareRenameSignature {
+  (this: void, document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Range | { range: Range, placeholder: string }>
+}
+
+export interface ProvideRenameEditsSignature {
+  (
+    this: void,
+    document: TextDocument,
+    position: Position,
+    newName: string,
+    token: CancellationToken
+  ): ProviderResult<WorkspaceEdit>
+}
+
+export interface RenameMiddleware {
+  prepareRename?: (
+    this: void, document: TextDocument,
+    position: Position,
+    token: CancellationToken,
+    next: PrepareRenameSignature
+  ) => ProviderResult<Range | { range: Range, placeholder: string }>
+  provideRenameEdits?: (
+    this: void,
+    document: TextDocument,
+    position: Position,
+    newName: string,
+    token: CancellationToken,
+    next: ProvideRenameEditsSignature
+  ) => ProviderResult<WorkspaceEdit>
+}
+
+export class RenameFeature extends TextDocumentLanguageFeature<boolean | RenameOptions, RenameRegistrationOptions, RenameProvider, RenameMiddleware> {
+  constructor(client: FeatureClient<RenameMiddleware>) {
+    super(client, RenameRequest.type)
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    let rename = ensure(ensure(capabilities, 'textDocument')!, 'rename')!
+    rename.dynamicRegistration = true
+    rename.prepareSupport = true
+    rename.honorsChangeAnnotations = true
+    // Some language server report bug, renable when it's useful
+    // rename.prepareSupportDefaultBehavior = PrepareSupportDefaultBehavior.Identifier
+  }
+
+  public initialize(
+    capabilities: ServerCapabilities,
+    documentSelector: DocumentSelector
+  ): void {
+    const options = this.getRegistrationOptions(documentSelector, capabilities.renameProvider)
+    if (!options) {
+      return
+    }
+    if (Is.boolean(capabilities.renameProvider)) {
+      options.prepareProvider = false
+    }
+    this.register({
+      id: UUID.generateUuid(),
+      registerOptions: options
+    })
+  }
+
+  protected registerLanguageProvider(options: RenameRegistrationOptions): [Disposable, RenameProvider] {
+    const provider: RenameProvider = {
+      provideRenameEdits: (document, position, newName, token) => {
+        const client = this._client
+        const provideRenameEdits: ProvideRenameEditsSignature = (document, position, newName, token) => {
+          const params: RenameParams = {
+            textDocument: { uri: document.uri },
+            position,
+            newName
+          }
+          return client.sendRequest(RenameRequest.type, params, token).then(
+            res => token.isCancellationRequested ? null : res,
+            error => {
+              return client.handleFailedRequest(RenameRequest.type, token, error, null)
+            })
+        }
+        const middleware = client.middleware!
+        return middleware.provideRenameEdits
+          ? middleware.provideRenameEdits(document, position, newName, token, provideRenameEdits)
+          : provideRenameEdits(document, position, newName, token)
+      },
+      prepareRename: options.prepareProvider
+        ? (document, position, token) => {
+          const client = this._client
+          const prepareRename: PrepareRenameSignature = (document, position, token) => {
+            const params: TextDocumentPositionParams = {
+              textDocument: cv.asTextDocumentIdentifier(document),
+              position
+            }
+            return client.sendRequest(PrepareRenameRequest.type, params, token).then(
+              result => {
+                if (token.isCancellationRequested) {
+                  return null
+                }
+                if (Range.is(result)) {
+                  return result
+                } else if (this.isDefaultBehavior(result)) {
+                  return result.defaultBehavior === true ? null : Promise.reject(new Error(`The element can't be renamed.`))
+                } else if (result && Range.is(result.range)) {
+                  return {
+                    range: result.range,
+                    placeholder: result.placeholder
+                  }
+                }
+                // To cancel the rename vscode API expects a rejected promise.
+                return Promise.reject(new Error(`The element can't be renamed.`))
+              },
+              (error: ResponseError<void>) => {
+                return client.handleFailedRequest(PrepareRenameRequest.type, token, error, undefined)
+              }
+            )
+          }
+          const middleware = client.middleware!
+          return middleware.prepareRename
+            ? middleware.prepareRename(document, position, token, prepareRename)
+            : prepareRename(document, position, token)
+        }
+        : undefined
+    }
+
+    return [languages.registerRenameProvider(options.documentSelector, provider), provider]
+  }
+
+  private isDefaultBehavior(value: any): value is DefaultBehavior {
+    const candidate: DefaultBehavior = value
+    return candidate && Is.boolean(candidate.defaultBehavior)
+  }
+}

--- a/src/language-client/selectionRange.ts
+++ b/src/language-client/selectionRange.ts
@@ -1,15 +1,9 @@
 'use strict'
-/* --------------------------------------------------------------------------------------------
- * Copyright (c) Microsoft Corporation. All rights reserved.
- * Licensed under the MIT License. See License.txt in the project root for license information.
- * ------------------------------------------------------------------------------------------ */
-'use strict'
-
 import { CancellationToken, ClientCapabilities, Disposable, DocumentSelector, Position, SelectionRange, SelectionRangeClientCapabilities, SelectionRangeOptions, SelectionRangeParams, SelectionRangeRegistrationOptions, SelectionRangeRequest, ServerCapabilities } from 'vscode-languageserver-protocol'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import languages from '../languages'
 import { ProviderResult, SelectionRangeProvider } from '../provider'
-import { BaseLanguageClient, ensure, TextDocumentFeature } from './client'
+import { TextDocumentLanguageFeature, FeatureClient, ensure } from './features'
 
 export interface ProvideSelectionRangeSignature {
   (this: void, document: TextDocument, positions: Position[], token: CancellationToken): ProviderResult<SelectionRange[]>
@@ -19,8 +13,8 @@ export interface SelectionRangeProviderMiddleware {
   provideSelectionRanges?: (this: void, document: TextDocument, positions: Position[], token: CancellationToken, next: ProvideSelectionRangeSignature) => ProviderResult<SelectionRange[]>
 }
 
-export class SelectionRangeFeature extends TextDocumentFeature<boolean | SelectionRangeOptions, SelectionRangeRegistrationOptions, SelectionRangeProvider> {
-  constructor(client: BaseLanguageClient) {
+export class SelectionRangeFeature extends TextDocumentLanguageFeature<boolean | SelectionRangeOptions, SelectionRangeRegistrationOptions, SelectionRangeProvider, SelectionRangeProviderMiddleware> {
+  constructor(client: FeatureClient<SelectionRangeProviderMiddleware>) {
     super(client, SelectionRangeRequest.type)
   }
 
@@ -53,7 +47,7 @@ export class SelectionRangeFeature extends TextDocumentFeature<boolean | Selecti
             }
           )
         }
-        const middleware = client.clientOptions.middleware
+        const middleware = client.middleware
         return middleware.provideSelectionRanges
           ? middleware.provideSelectionRanges(document, positions, token, provideSelectionRanges)
           : provideSelectionRanges(document, positions, token)

--- a/src/language-client/signatureHelp.ts
+++ b/src/language-client/signatureHelp.ts
@@ -1,0 +1,96 @@
+'use strict'
+/* ---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { CancellationToken, ClientCapabilities, Disposable, DocumentSelector, Position, ServerCapabilities, SignatureHelp, SignatureHelpContext, SignatureHelpOptions, SignatureHelpRegistrationOptions, SignatureHelpRequest } from 'vscode-languageserver-protocol'
+import { TextDocument } from "vscode-languageserver-textdocument"
+import languages from '../languages'
+import { ProviderResult, SignatureHelpProvider } from '../provider'
+import { ensure, FeatureClient, TextDocumentLanguageFeature } from './features'
+import * as cv from './utils/converter'
+import * as UUID from './utils/uuid'
+
+export interface ProvideSignatureHelpSignature {
+  (
+    this: void,
+    document: TextDocument,
+    position: Position,
+    context: SignatureHelpContext,
+    token: CancellationToken
+  ): ProviderResult<SignatureHelp>
+}
+
+export interface SignatureHelpMiddleware {
+  provideSignatureHelp?: (
+    this: void,
+    document: TextDocument,
+    position: Position,
+    context: SignatureHelpContext,
+    token: CancellationToken,
+    next: ProvideSignatureHelpSignature
+  ) => ProviderResult<SignatureHelp>
+}
+
+export class SignatureHelpFeature extends TextDocumentLanguageFeature<SignatureHelpOptions, SignatureHelpRegistrationOptions, SignatureHelpProvider, SignatureHelpMiddleware> {
+  constructor(client: FeatureClient<SignatureHelpMiddleware>) {
+    super(client, SignatureHelpRequest.type)
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    let config = ensure(ensure(capabilities, 'textDocument')!, 'signatureHelp')!
+    config.dynamicRegistration = true
+    config.contextSupport = true
+    config.signatureInformation = {
+      documentationFormat: this._client.supportedMarkupKind,
+      activeParameterSupport: true,
+      parameterInformation: {
+        labelOffsetSupport: true
+      }
+    }
+  }
+
+  public initialize(
+    capabilities: ServerCapabilities,
+    documentSelector: DocumentSelector
+  ): void {
+    const options = this.getRegistrationOptions(documentSelector, capabilities.signatureHelpProvider)
+    if (!options) {
+      return
+    }
+    this.register({
+      id: UUID.generateUuid(),
+      registerOptions: options
+    })
+  }
+
+  protected registerLanguageProvider(
+    options: SignatureHelpRegistrationOptions
+  ): [Disposable, SignatureHelpProvider] {
+    const provider: SignatureHelpProvider = {
+      provideSignatureHelp: (document, position, token, context) => {
+        const client = this._client
+        const providerSignatureHelp: ProvideSignatureHelpSignature = (document, position, context, token) => {
+          return client.sendRequest(
+            SignatureHelpRequest.type,
+            cv.asSignatureHelpParams(document, position, context),
+            token
+          ).then(
+            res => token.isCancellationRequested ? null : res,
+            error => {
+              return client.handleFailedRequest(SignatureHelpRequest.type, token, error, null)
+            })
+        }
+
+        const middleware = client.middleware!
+        return middleware.provideSignatureHelp
+          ? middleware.provideSignatureHelp(document, position, context, token, providerSignatureHelp)
+          : providerSignatureHelp(document, position, context, token)
+      }
+    }
+
+    const triggerCharacters = options.triggerCharacters || []
+    const disposable = languages.registerSignatureHelpProvider(options.documentSelector!, provider, triggerCharacters)
+    return [disposable, provider]
+  }
+}

--- a/src/language-client/textSynchronization.ts
+++ b/src/language-client/textSynchronization.ts
@@ -1,0 +1,497 @@
+'use strict'
+import { ClientCapabilities, DidChangeTextDocumentNotification, DidChangeTextDocumentParams, DidCloseTextDocumentNotification, DidCloseTextDocumentParams, DidOpenTextDocumentNotification, DidOpenTextDocumentParams, DidSaveTextDocumentNotification, DidSaveTextDocumentParams, Disposable, DocumentSelector, Emitter, Event, ProtocolNotificationType, RegistrationType, SaveOptions, ServerCapabilities, TextDocumentChangeRegistrationOptions, TextDocumentRegistrationOptions, TextDocumentSaveRegistrationOptions, TextDocumentSyncKind, TextDocumentSyncOptions, TextEdit, WillSaveTextDocumentNotification, WillSaveTextDocumentParams, WillSaveTextDocumentWaitUntilRequest } from 'vscode-languageserver-protocol'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import { DidChangeTextDocumentParams as TextDocumentChangeEvent, TextDocumentWillSaveEvent } from '../types'
+import workspace from '../workspace'
+import { DynamicDocumentFeature, DynamicFeature, ensure, FeatureClient, NextSignature, NotificationSendEvent, NotifyingFeature, RegistrationData, TextDocumentEventFeature, TextDocumentSendFeature } from './features'
+import * as cv from './utils/converter'
+import * as UUID from './utils/uuid'
+
+export interface TextDocumentSynchronizationMiddleware {
+  didOpen?: NextSignature<TextDocument, Promise<void>>
+  didChange?: NextSignature<TextDocumentChangeEvent, Promise<void>>
+  willSave?: NextSignature<TextDocumentWillSaveEvent, Promise<void>>
+  willSaveWaitUntil?: NextSignature<TextDocumentWillSaveEvent, Thenable<TextEdit[]>>
+  didSave?: NextSignature<TextDocument, Promise<void>>
+  didClose?: NextSignature<TextDocument, Promise<void>>
+}
+
+export interface ResolvedTextDocumentSyncCapabilities {
+  resolvedTextDocumentSync?: TextDocumentSyncOptions
+}
+
+export interface DidOpenTextDocumentFeatureShape extends DynamicFeature<TextDocumentRegistrationOptions>, TextDocumentSendFeature<(textDocument: TextDocument) => Promise<void>>, NotifyingFeature<TextDocument, DidOpenTextDocumentParams> {
+  openDocuments: Iterable<TextDocument>
+}
+
+export interface DidChangeTextDocumentFeatureShape extends DynamicFeature<TextDocumentChangeRegistrationOptions>, TextDocumentSendFeature<(event: TextDocumentChangeEvent) => Promise<void>>, NotifyingFeature<TextDocumentChangeEvent, DidChangeTextDocumentParams> {
+}
+
+export interface DidSaveTextDocumentFeatureShape extends DynamicFeature<TextDocumentRegistrationOptions>, TextDocumentSendFeature<(textDocument: TextDocument) => Promise<void>>, NotifyingFeature<TextDocument, DidSaveTextDocumentParams> {
+}
+
+export interface DidCloseTextDocumentFeatureShape extends DynamicFeature<TextDocumentRegistrationOptions>, TextDocumentSendFeature<(textDocument: TextDocument) => Promise<void>>, NotifyingFeature<TextDocument, DidCloseTextDocumentParams> {
+}
+
+export class DidOpenTextDocumentFeature extends TextDocumentEventFeature<DidOpenTextDocumentParams, TextDocument, TextDocumentSynchronizationMiddleware> {
+  constructor(client: FeatureClient<TextDocumentSynchronizationMiddleware>, private _syncedDocuments: Map<string, TextDocument>) {
+    super(
+      client,
+      workspace.onDidOpenTextDocument,
+      DidOpenTextDocumentNotification.type,
+      () => client.middleware.didOpen,
+      textDocument => cv.asOpenTextDocumentParams(textDocument),
+      data => data,
+      TextDocumentEventFeature.textDocumentFilter
+    )
+  }
+
+  public get registrationType(): RegistrationType<TextDocumentRegistrationOptions> {
+    return DidOpenTextDocumentNotification.type
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    ensure(ensure(capabilities, 'textDocument')!, 'synchronization')!.dynamicRegistration = true
+  }
+
+  public initialize(
+    capabilities: ServerCapabilities,
+    documentSelector: DocumentSelector
+  ): void {
+    let textDocumentSyncOptions = (capabilities as ResolvedTextDocumentSyncCapabilities).resolvedTextDocumentSync
+    if (documentSelector && textDocumentSyncOptions && textDocumentSyncOptions.openClose) {
+      this.register({
+        id: UUID.generateUuid(),
+        registerOptions: { documentSelector }
+      })
+    }
+  }
+
+  public register(
+    data: RegistrationData<TextDocumentRegistrationOptions>
+  ): void {
+    super.register(data)
+    if (!data.registerOptions.documentSelector) {
+      return
+    }
+    let documentSelector = data.registerOptions.documentSelector
+    workspace.textDocuments.forEach(textDocument => {
+      let uri: string = textDocument.uri.toString()
+      if (this._syncedDocuments.has(uri)) {
+        return
+      }
+      if (workspace.match(documentSelector, textDocument) > 0) {
+        let middleware = this._client.middleware!
+        let didOpen = (textDocument: TextDocument) => {
+          return this._client.sendNotification(
+            this._type,
+            this._createParams(textDocument)
+          )
+        }
+        let promise: Promise<void>
+        if (middleware.didOpen) {
+          promise = middleware.didOpen(textDocument, didOpen)
+        } else {
+          promise = didOpen(textDocument)
+        }
+        if (promise) {
+          promise.catch(error => {
+            this._client.error(`Sending document notification ${this._type.method} failed`, error)
+          })
+        }
+        this._syncedDocuments.set(uri, textDocument)
+      }
+    })
+  }
+
+  protected notificationSent(textDocument: TextDocument, type: ProtocolNotificationType<DidOpenTextDocumentParams, TextDocumentRegistrationOptions>, params: DidOpenTextDocumentParams): void {
+    super.notificationSent(textDocument, type, params)
+    this._syncedDocuments.set(textDocument.uri.toString(), textDocument)
+  }
+}
+
+export class DidCloseTextDocumentFeature extends TextDocumentEventFeature<DidCloseTextDocumentParams, TextDocument, TextDocumentSynchronizationMiddleware> implements DidCloseTextDocumentFeatureShape {
+  constructor(
+    client: FeatureClient<TextDocumentSynchronizationMiddleware>,
+    private _syncedDocuments: Map<string, TextDocument>
+  ) {
+    super(
+      client,
+      workspace.onDidCloseTextDocument,
+      DidCloseTextDocumentNotification.type,
+      () => client.middleware!.didClose,
+      textDocument => cv.asCloseTextDocumentParams(textDocument),
+      data => data,
+      TextDocumentEventFeature.textDocumentFilter
+    )
+  }
+
+  public get registrationType(): RegistrationType<TextDocumentRegistrationOptions> {
+    return DidCloseTextDocumentNotification.type
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    ensure(
+      ensure(capabilities, 'textDocument')!,
+      'synchronization'
+    )!.dynamicRegistration = true
+  }
+
+  public initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {
+    let textDocumentSyncOptions = (capabilities as ResolvedTextDocumentSyncCapabilities).resolvedTextDocumentSync
+    if (
+      documentSelector &&
+      textDocumentSyncOptions &&
+      textDocumentSyncOptions.openClose
+    ) {
+      this.register({
+        id: UUID.generateUuid(),
+        registerOptions: { documentSelector }
+      })
+    }
+  }
+
+  protected notificationSent(textDocument: TextDocument, type: ProtocolNotificationType<DidCloseTextDocumentParams, TextDocumentRegistrationOptions>, params: DidCloseTextDocumentParams): void {
+    super.notificationSent(textDocument, type, params)
+    this._syncedDocuments.delete(textDocument.uri.toString())
+  }
+
+  public unregister(id: string): void {
+    let selector = this._selectors.get(id)!
+    // The super call removed the selector from the map
+    // of selectors.
+    super.unregister(id)
+    let selectors = this._selectors.values()
+    this._syncedDocuments.forEach(textDocument => {
+      if (
+        workspace.match(selector, textDocument) > 0 &&
+        !this._selectorFilter!(selectors, textDocument)
+      ) {
+        let middleware = this._client.middleware!
+        let didClose = (textDocument: TextDocument) => {
+          return this._client.sendNotification(this._type, this._createParams(textDocument))
+        }
+        this._syncedDocuments.delete(textDocument.uri.toString())
+        let promise = middleware.didClose ? middleware.didClose(textDocument, didClose) : didClose(textDocument)
+        if (promise) {
+          promise.catch(error => {
+            this._client.error(`Sending document notification ${this._type.method} failed`, error)
+          })
+        }
+      }
+    })
+  }
+}
+
+interface DidChangeTextDocumentData {
+  syncKind: 0 | 1 | 2
+  documentSelector: DocumentSelector
+}
+
+export class DidChangeTextDocumentFeature extends DynamicDocumentFeature<TextDocumentChangeRegistrationOptions, TextDocumentSynchronizationMiddleware> implements DidChangeTextDocumentFeatureShape {
+  private _listener: Disposable | undefined
+  private readonly _changeData: Map<string, DidChangeTextDocumentData>
+  private _onNotificationSent: Emitter<NotificationSendEvent<TextDocumentChangeEvent, DidChangeTextDocumentParams>>
+
+  constructor(client: FeatureClient<TextDocumentSynchronizationMiddleware>) {
+    super(client)
+    this._changeData = new Map<string, DidChangeTextDocumentData>()
+    this._onNotificationSent = new Emitter()
+  }
+
+  public *getDocumentSelectors(): IterableIterator<DocumentSelector> {
+    for (const data of this._changeData.values()) {
+      yield data.documentSelector
+    }
+  }
+
+  public get registrationType(): RegistrationType<TextDocumentChangeRegistrationOptions> {
+    return DidChangeTextDocumentNotification.type
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    ensure(ensure(capabilities, 'textDocument')!, 'synchronization')!.dynamicRegistration = true
+  }
+
+  public initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {
+    let textDocumentSyncOptions = (capabilities as ResolvedTextDocumentSyncCapabilities).resolvedTextDocumentSync
+    if (
+      documentSelector &&
+      textDocumentSyncOptions &&
+      textDocumentSyncOptions.change !== undefined &&
+      textDocumentSyncOptions.change !== TextDocumentSyncKind.None
+    ) {
+      this.register({
+        id: UUID.generateUuid(),
+        registerOptions: Object.assign(
+          {},
+          { documentSelector },
+          { syncKind: textDocumentSyncOptions.change }
+        )
+      })
+    }
+  }
+
+  public register(
+    data: RegistrationData<TextDocumentChangeRegistrationOptions>
+  ): void {
+    if (!data.registerOptions.documentSelector) {
+      return
+    }
+    if (!this._listener) {
+      this._listener = workspace.onDidChangeTextDocument(this.callback, this)
+    }
+    this._changeData.set(data.id, {
+      documentSelector: data.registerOptions.documentSelector,
+      syncKind: data.registerOptions.syncKind
+    })
+  }
+
+  private callback(event: TextDocumentChangeEvent): Promise<void> {
+    // Text document changes are send for dirty changes as well. We don't
+    // have dirty / undirty events in the LSP so we ignore content changes
+    // with length zero.
+    if (event.contentChanges.length === 0) {
+      return
+    }
+    let doc = workspace.getDocument(event.textDocument.uri)
+    if (!doc) return
+    let { textDocument } = doc
+    const promises: Promise<void>[] = []
+    for (const changeData of this._changeData.values()) {
+      if (workspace.match(changeData.documentSelector, textDocument) > 0) {
+        let middleware = this._client.middleware!
+        let promise: Promise<void> | undefined
+        if (changeData.syncKind === TextDocumentSyncKind.Incremental) {
+          let didChange = async (event): Promise<void> => {
+            const params = cv.asChangeTextDocumentParams(event)
+            await this._client.sendNotification(DidChangeTextDocumentNotification.type, params)
+            this.notificationSent(event, DidChangeTextDocumentNotification.type, params)
+          }
+          promise = middleware.didChange ? middleware.didChange(event, didChange) : didChange(event)
+        } else if (changeData.syncKind === TextDocumentSyncKind.Full) {
+          let didChange = async (event: TextDocumentChangeEvent): Promise<void> => {
+            const params = cv.asFullChangeTextDocumentParams(textDocument)
+            await this._client.sendNotification(DidChangeTextDocumentNotification.type, params)
+            this.notificationSent(event, DidChangeTextDocumentNotification.type, params)
+          }
+          promise = middleware.didChange ? middleware.didChange(event, didChange) : didChange(event)
+        }
+        if (promise) promises.push(promise)
+      }
+    }
+    return Promise.all(promises).then(undefined, error => {
+      this._client.error(`Sending document notification ${DidChangeTextDocumentNotification.type.method} failed`, error)
+      throw error
+    })
+  }
+
+  public get onNotificationSent(): Event<NotificationSendEvent<TextDocumentChangeEvent, DidChangeTextDocumentParams>> {
+    return this._onNotificationSent.event
+  }
+
+  private notificationSent(changeEvent: TextDocumentChangeEvent, type: ProtocolNotificationType<DidChangeTextDocumentParams, TextDocumentRegistrationOptions>, params: DidChangeTextDocumentParams): void {
+    this._onNotificationSent.fire({ original: changeEvent, type, params })
+  }
+
+  public unregister(id: string): void {
+    this._changeData.delete(id)
+    if (this._changeData.size === 0 && this._listener) {
+      this._listener.dispose()
+      this._listener = undefined
+    }
+  }
+
+  public dispose(): void {
+    this._changeData.clear()
+    if (this._listener) {
+      this._listener.dispose()
+      this._listener = undefined
+    }
+  }
+
+  public getProvider(document: TextDocument): { send: (event: TextDocumentChangeEvent) => Promise<void> } | undefined {
+    for (const changeData of this._changeData.values()) {
+      if (workspace.match(changeData.documentSelector, document) > 0) {
+        return {
+          send: (event: TextDocumentChangeEvent): Promise<void> => {
+            return this.callback(event)
+          }
+        }
+      }
+    }
+    return undefined
+  }
+}
+
+export class WillSaveFeature extends TextDocumentEventFeature<WillSaveTextDocumentParams, TextDocumentWillSaveEvent, TextDocumentSynchronizationMiddleware> {
+  constructor(client: FeatureClient<TextDocumentSynchronizationMiddleware>) {
+    super(
+      client,
+      workspace.onWillSaveTextDocument,
+      WillSaveTextDocumentNotification.type,
+      () => client.middleware.willSave,
+      willSaveEvent => cv.asWillSaveTextDocumentParams(willSaveEvent),
+      event => event.document,
+      (selectors, willSaveEvent) => TextDocumentEventFeature.textDocumentFilter(selectors, willSaveEvent.document)
+    )
+  }
+
+  public get registrationType(): RegistrationType<TextDocumentRegistrationOptions> {
+    return WillSaveTextDocumentNotification.type
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    let value = ensure(ensure(capabilities, 'textDocument')!, 'synchronization')!
+    value.willSave = true
+  }
+
+  public initialize(
+    capabilities: ServerCapabilities,
+    documentSelector: DocumentSelector
+  ): void {
+    let textDocumentSyncOptions = (capabilities as ResolvedTextDocumentSyncCapabilities).resolvedTextDocumentSync
+    if (
+      documentSelector &&
+      textDocumentSyncOptions &&
+      textDocumentSyncOptions.willSave
+    ) {
+      this.register({
+        id: UUID.generateUuid(),
+        registerOptions: { documentSelector }
+      })
+    }
+  }
+}
+
+export class WillSaveWaitUntilFeature extends DynamicDocumentFeature<TextDocumentRegistrationOptions, TextDocumentSynchronizationMiddleware> {
+  private _listener: Disposable | undefined
+  private _selectors: Map<string, DocumentSelector>
+
+  constructor(client: FeatureClient<TextDocumentSynchronizationMiddleware>) {
+    super(client)
+    this._selectors = new Map<string, DocumentSelector>()
+  }
+
+  protected getDocumentSelectors(): IterableIterator<DocumentSelector> {
+    return this._selectors.values()
+  }
+
+  public get registrationType(): RegistrationType<TextDocumentRegistrationOptions> {
+    return WillSaveTextDocumentWaitUntilRequest.type
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    let value = ensure(ensure(capabilities, 'textDocument')!, 'synchronization')!
+    value.willSaveWaitUntil = true
+  }
+
+  public initialize(
+    capabilities: ServerCapabilities,
+    documentSelector: DocumentSelector
+  ): void {
+    let textDocumentSyncOptions = (capabilities as ResolvedTextDocumentSyncCapabilities).resolvedTextDocumentSync
+    if (
+      documentSelector &&
+      textDocumentSyncOptions &&
+      textDocumentSyncOptions.willSaveWaitUntil
+    ) {
+      this.register({
+        id: UUID.generateUuid(),
+        registerOptions: { documentSelector }
+      })
+    }
+  }
+
+  public register(
+    data: RegistrationData<TextDocumentRegistrationOptions>
+  ): void {
+    if (!data.registerOptions.documentSelector) {
+      return
+    }
+    if (!this._listener) {
+      this._listener = workspace.onWillSaveTextDocument(this.callback, this)
+    }
+    this._selectors.set(data.id, data.registerOptions.documentSelector)
+  }
+
+  private callback(event: TextDocumentWillSaveEvent): void {
+    if (TextDocumentEventFeature.textDocumentFilter(
+      this._selectors.values(),
+      event.document)) {
+      let middleware = this._client.middleware!
+      let willSaveWaitUntil = (event: TextDocumentWillSaveEvent): Thenable<TextEdit[]> => {
+        return this._client
+          .sendRequest(
+            WillSaveTextDocumentWaitUntilRequest.type,
+            cv.asWillSaveTextDocumentParams(event)
+          )
+          .then(edits => {
+            return Array.isArray(edits) ? edits : []
+          })
+      }
+      event.waitUntil(
+        middleware.willSaveWaitUntil
+          ? middleware.willSaveWaitUntil(event, willSaveWaitUntil)
+          : willSaveWaitUntil(event)
+      )
+    }
+  }
+
+  public unregister(id: string): void {
+    this._selectors.delete(id)
+    if (this._selectors.size === 0 && this._listener) {
+      this._listener.dispose()
+      this._listener = undefined
+    }
+  }
+
+  public dispose(): void {
+    this._selectors.clear()
+    if (this._listener) {
+      this._listener.dispose()
+      this._listener = undefined
+    }
+  }
+}
+
+export class DidSaveTextDocumentFeature extends TextDocumentEventFeature<DidSaveTextDocumentParams, TextDocument, TextDocumentSynchronizationMiddleware> implements DidSaveTextDocumentFeatureShape {
+  private _includeText: boolean
+
+  constructor(client: FeatureClient<TextDocumentSynchronizationMiddleware>) {
+    super(
+      client, workspace.onDidSaveTextDocument, DidSaveTextDocumentNotification.type,
+      () => client.middleware.didSave,
+      textDocument => cv.asSaveTextDocumentParams(textDocument, this._includeText),
+      data => data,
+      TextDocumentEventFeature.textDocumentFilter
+    )
+    this._includeText = false
+  }
+
+  public get registrationType(): RegistrationType<TextDocumentSaveRegistrationOptions> {
+    return DidSaveTextDocumentNotification.type
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    ensure(ensure(capabilities, 'textDocument')!, 'synchronization')!.didSave = true
+  }
+
+  public initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {
+    const textDocumentSyncOptions = (capabilities as ResolvedTextDocumentSyncCapabilities).resolvedTextDocumentSync
+    if (documentSelector && textDocumentSyncOptions && textDocumentSyncOptions.save) {
+      const saveOptions: SaveOptions = typeof textDocumentSyncOptions.save === 'boolean'
+        ? { includeText: false }
+        : { includeText: !!textDocumentSyncOptions.save.includeText }
+      this.register({
+        id: UUID.generateUuid(),
+        registerOptions: Object.assign({}, { documentSelector }, saveOptions)
+      })
+    }
+  }
+
+  public register(data: RegistrationData<TextDocumentSaveRegistrationOptions>): void {
+    this._includeText = !!data.registerOptions.includeText
+    super.register(data)
+  }
+}

--- a/src/language-client/typeDefinition.ts
+++ b/src/language-client/typeDefinition.ts
@@ -1,14 +1,10 @@
 'use strict'
-/* ---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 import { CancellationToken, ClientCapabilities, Definition, DefinitionLink, Disposable, DocumentSelector, Position, ServerCapabilities, TypeDefinitionOptions, TypeDefinitionRegistrationOptions, TypeDefinitionRequest } from 'vscode-languageserver-protocol'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import languages from '../languages'
 import { ProviderResult, TypeDefinitionProvider } from '../provider'
-import { BaseLanguageClient, ensure, TextDocumentFeature } from './client'
 import * as cv from './utils/converter'
+import { TextDocumentLanguageFeature, FeatureClient, ensure } from './features'
 
 export interface ProvideTypeDefinitionSignature {
   (
@@ -29,14 +25,15 @@ export interface TypeDefinitionMiddleware {
   ) => ProviderResult<Definition | DefinitionLink[]>
 }
 
-export class TypeDefinitionFeature extends TextDocumentFeature<boolean | TypeDefinitionOptions, TypeDefinitionRegistrationOptions, TypeDefinitionProvider> {
-  constructor(client: BaseLanguageClient) {
+export class TypeDefinitionFeature extends TextDocumentLanguageFeature<boolean | TypeDefinitionOptions, TypeDefinitionRegistrationOptions, TypeDefinitionProvider, TypeDefinitionMiddleware> {
+  constructor(client: FeatureClient<TypeDefinitionMiddleware>) {
     super(client, TypeDefinitionRequest.type)
   }
 
   public fillClientCapabilities(capabilities: ClientCapabilities): void {
     const typeDefinitionSupport = ensure(ensure(capabilities, 'textDocument')!, 'typeDefinition')!
     typeDefinitionSupport.dynamicRegistration = true
+    // TODO link support
     // typeDefinitionSupport.linkSupport = true
   }
 
@@ -57,7 +54,7 @@ export class TypeDefinitionFeature extends TextDocumentFeature<boolean | TypeDef
             return client.handleFailedRequest(TypeDefinitionRequest.type, token, error, null)
           }
         )
-        const middleware = client.clientOptions.middleware
+        const middleware = client.middleware
         return middleware.provideTypeDefinition
           ? middleware.provideTypeDefinition(document, position, token, provideTypeDefinition)
           : provideTypeDefinition(document, position, token)

--- a/src/language-client/utils/errorHandler.ts
+++ b/src/language-client/utils/errorHandler.ts
@@ -1,0 +1,86 @@
+'use strict'
+import { InitializeError, Message, ResponseError } from 'vscode-languageserver-protocol'
+import window from '../../window'
+
+/**
+ * An action to be performed when the connection to a server got closed.
+ */
+export enum CloseAction {
+  /**
+   * Don't restart the server. The connection stays closed.
+   */
+  DoNotRestart = 1,
+  /**
+   * Restart the server.
+   */
+  Restart = 2
+}
+
+/**
+ * An action to be performed when the connection is producing errors.
+ */
+export enum ErrorAction {
+  /**
+   * Continue running the server.
+   */
+  Continue = 1,
+  /**
+   * Shutdown the server.
+   */
+  Shutdown = 2
+}
+
+/**
+ * A pluggable error handler that is invoked when the connection is either
+ * producing errors or got closed.
+ */
+export interface ErrorHandler {
+  /**
+   * An error has occurred while writing or reading from the connection.
+   *
+   * @param error - the error received
+   * @param message - the message to be delivered to the server if know.
+   * @param count - a count indicating how often an error is received. Will
+   * be reset if a message got successfully send or received.
+   */
+  error(error: Error, message: Message | undefined, count: number | undefined): ErrorAction
+
+  /**
+   * The connection to the server got closed.
+   */
+  closed(): CloseAction
+}
+
+export interface InitializationFailedHandler {
+  (error: ResponseError<InitializeError> | Error | any): boolean
+}
+
+export class DefaultErrorHandler implements ErrorHandler {
+  private readonly restarts: number[]
+
+  constructor(private name: string, private maxRestartCount: number) {
+    this.restarts = []
+  }
+
+  public error(_error: Error, _message: Message, count: number): ErrorAction {
+    if (count && count <= 3) {
+      return ErrorAction.Continue
+    }
+    return ErrorAction.Shutdown
+  }
+  public closed(): CloseAction {
+    this.restarts.push(Date.now())
+    if (this.restarts.length < this.maxRestartCount) {
+      return CloseAction.Restart
+    } else {
+      let diff = this.restarts[this.restarts.length - 1] - this.restarts[0]
+      if (diff <= 3 * 60 * 1000) {
+        window.showMessage(`The "${this.name}" server crashed ${this.maxRestartCount} times in the last 3 minutes. The server will not be restarted.`, 'error')
+        return CloseAction.DoNotRestart
+      } else {
+        this.restarts.shift()
+        return CloseAction.Restart
+      }
+    }
+  }
+}

--- a/src/language-client/utils/logger.ts
+++ b/src/language-client/utils/logger.ts
@@ -1,0 +1,29 @@
+'use strict'
+import { Logger } from 'vscode-languageserver-protocol'
+const logger = require('../../util/logger')('language-client')
+
+export class ConsoleLogger implements Logger {
+  public error(message: string): void {
+    logger.error(message)
+  }
+  public warn(message: string): void {
+    logger.warn(message)
+  }
+  public info(message: string): void {
+    logger.info(message)
+  }
+  public log(message: string): void {
+    logger.log(message)
+  }
+}
+
+export class NullLogger implements Logger {
+  public error(_message: string): void {
+  }
+  public warn(_message: string): void {
+  }
+  public info(_message: string): void {
+  }
+  public log(_message: string): void {
+  }
+}

--- a/src/provider/semanticTokensRangeManager.ts
+++ b/src/provider/semanticTokensRangeManager.ts
@@ -2,6 +2,7 @@
 import { v4 as uuid } from 'uuid'
 import { CancellationToken, Disposable, DocumentSelector, Range, SemanticTokens, SemanticTokensLegend } from 'vscode-languageserver-protocol'
 import { TextDocument } from 'vscode-languageserver-textdocument'
+import { CancellationError } from '../util/errors'
 import { DocumentRangeSemanticTokensProvider } from './index'
 import Manager, { ProviderItem } from './manager'
 const logger = require('../util/logger')('semanticTokensRangeManager')
@@ -31,6 +32,11 @@ export default class SemanticTokensRangeManager extends Manager<DocumentRangeSem
     if (!item) return null
     let { provider } = item
     if (provider.provideDocumentRangeSemanticTokens === null) return null
-    return await Promise.resolve(provider.provideDocumentRangeSemanticTokens(document, range, token))
+    try {
+      return await Promise.resolve(provider.provideDocumentRangeSemanticTokens(document, range, token))
+    } catch (err) {
+      if (err instanceof CancellationError) return null
+      throw err
+    }
   }
 }

--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -1,5 +1,35 @@
 'use strict'
 
+const canceledName = 'Canceled'
+
+// !!!IMPORTANT!!!
+// Do NOT change this class because it is also used as an API-type.
+export class CancellationError extends Error {
+  constructor() {
+    super(canceledName)
+    this.name = this.message
+  }
+}
+
+/**
+ * Checks if the given error is a promise in canceled state
+ */
+export function isCancellationError(error: any): boolean {
+  if (error instanceof CancellationError) {
+    return true
+  }
+  return error instanceof Error && error.name === canceledName && error.message === canceledName
+}
+
+export function onUnexpectedError(e: any): void {
+  // ignore errors from cancelled promises
+  if (isCancellationError(e)) return
+  if (e.stack) {
+    throw new Error(e.message + '\n\n' + e.stack)
+  }
+  throw e
+}
+
 export function illegalArgument(name?: string): Error {
   if (name) {
     return new Error(`Illegal argument: ${name}`)

--- a/src/window.ts
+++ b/src/window.ts
@@ -10,7 +10,6 @@ import Terminals from './core/terminals'
 import * as ui from './core/ui'
 import Cursors from './cursors/index'
 import events from './events'
-import languages from './languages'
 import Dialog, { DialogConfig, DialogPreferences } from './model/dialog'
 import Highligher from './model/highligher'
 import InputBox, { InputOptions, InputPreference } from './model/input'
@@ -803,6 +802,7 @@ export class Window {
     let hi = new Highligher()
     hi.addLine('Provider state', 'Title')
     hi.addLine('')
+    let languages = require('./languages').default
     for (let name of PROVIDER_NAMES) {
       let exists = languages.hasProvider(name, doc.textDocument)
       hi.addTexts([

--- a/yarn.lock
+++ b/yarn.lock
@@ -3574,7 +3574,12 @@ vscode-jsonrpc@8.0.1:
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz#f30b0625ebafa0fb3bc53e934ca47b706445e57e"
   integrity sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ==
 
-vscode-languageserver-protocol@3.17.1, vscode-languageserver-protocol@^3.17.1:
+vscode-jsonrpc@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz#f239ed2cd6004021b6550af9fd9d3e47eee3cac9"
+  integrity sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==
+
+vscode-languageserver-protocol@3.17.1:
   version "3.17.1"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz#e801762c304f740208b6c804a0cf21f2c87509ed"
   integrity sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==
@@ -3582,15 +3587,28 @@ vscode-languageserver-protocol@3.17.1, vscode-languageserver-protocol@^3.17.1:
     vscode-jsonrpc "8.0.1"
     vscode-languageserver-types "3.17.1"
 
-vscode-languageserver-textdocument@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.4.tgz#3cd56dd14cec1d09e86c4bb04b09a246cb3df157"
-  integrity sha512-/xhqXP/2A2RSs+J8JNXpiiNVvvNM0oTosNVmQnunlKvq9o4mupHOBAnnzH0lwIPKazXKvAKsVp1kr+H/K4lgoQ==
+vscode-languageserver-protocol@^3.17.2:
+  version "3.17.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz#beaa46aea06ed061576586c5e11368a9afc1d378"
+  integrity sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==
+  dependencies:
+    vscode-jsonrpc "8.0.2"
+    vscode-languageserver-types "3.17.2"
 
-vscode-languageserver-types@3.17.1, vscode-languageserver-types@^3.17.1:
+vscode-languageserver-textdocument@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.5.tgz#838769940ece626176ec5d5a2aa2d0aa69f5095c"
+  integrity sha512-1ah7zyQjKBudnMiHbZmxz5bYNM9KKZYz+5VQLj+yr8l+9w3g+WAhCkUkWbhMEdC5u0ub4Ndiye/fDyS8ghIKQg==
+
+vscode-languageserver-types@3.17.1:
   version "3.17.1"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz#c2d87fa7784f8cac389deb3ff1e2d9a7bef07e16"
   integrity sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ==
+
+vscode-languageserver-types@3.17.2, vscode-languageserver-types@^3.17.2:
+  version "3.17.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz#b2c2e7de405ad3d73a883e91989b850170ffc4f2"
+  integrity sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==
 
 vscode-languageserver@^8.0.1:
   version "8.0.1"


### PR DESCRIPTION
Synchronize changes from vscode-langaugeclient

- Separate feature classes from client.ts, add features.ts.
- Add `preInitialize()` and `getState` to `DynamicFeature` and `StaticFeature`.
- Promise support of methods from `TextDocumentSynchronizationMiddleware`.
- `sendProgress()` and `sendNotification()` of language-client return `Promise<void>`
- Allow methods `sendRequest()` `onRequest()` `sendNotification()` `onNotification()` called before server start