### PR TITLE
Merge &winhl rather than just replace it

### DIFF
--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -154,9 +154,8 @@ function! coc#float#create_float_win(winid, bufnr, config) abort
       let config = s:convert_config_nvim(a:config, 0)
       let hlgroup = get(a:config, 'highlight', 'CocFloating')
       let winhl = 'Normal:'.hlgroup.',NormalNC:'.hlgroup.',FoldColumn:'.hlgroup
-      if winhl !=# getwinvar(a:winid, '&winhl', '')
-        call setwinvar(a:winid, '&winhl', winhl)
-      endif
+      let merged_winhl = coc#util#merge_winhl(getwinvar(a:winid, '&winhl', ''), winhl)
+      call setwinvar(a:winid, '&winhl', merged_winhl)
       call nvim_win_set_buf(a:winid, bufnr)
       call nvim_win_set_config(a:winid, config)
       call nvim_win_set_cursor(a:winid, [lnum, 0])

--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -623,3 +623,31 @@ function! s:visible_ranges(winid) abort
   endwhile
   return res
 endfunction
+
+function! s:parse_winhl(var) abort
+  let map = {}
+  for segment in split(a:var, ',')
+    let m = matchlist(segment, '\v^([^:]+):([^:]*)$')
+    if !empty(m)
+      let map[m[1]] = m[2]
+    endif
+  endfor
+  return map
+endfunction
+
+function! coc#util#merge_winhl(one, other) abort
+  let map = s:parse_winhl(a:one)
+  let other_map = s:parse_winhl(a:other)
+  for key in keys(other_map)
+    if !has_key(map, key)
+      let map[key] = other_map[key]
+    endif
+  endfor
+
+  let list = []
+  for key in keys(map)
+    call add(list, key . ':' . map[key])
+  endfor
+
+  return join(list, ',')
+endfunction


### PR DESCRIPTION
## Why

When a float window is reused, it forcibly resets `&winhl` and never fires a CocOpenFloat event.

https://github.com/neoclide/coc.nvim/discussions/4016#discussioncomment-3345247

## What

Add the default value by merging it into the current `&winhl`.
