### PR TITLE
Add nextPlaceholderOnDelete option

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -1508,6 +1508,11 @@
       "description": "Use highlight group 'CocSnippetVisual' to highlight placeholders with same index of current one.",
       "default": false
     },
+    "coc.preferences.nextPlaceholderOnDelete": {
+      "type": "boolean",
+      "description": "Automatically jump to the next placeholder when the current one is completely deleted.",
+      "default": false
+    },
     "coc.preferences.currentFunctionSymbolAutoUpdate": {
       "type": "boolean",
       "description": "Automatically update the value of b:coc_current_function on CursorHold event",

--- a/doc/coc-config.txt
+++ b/doc/coc-config.txt
@@ -900,6 +900,13 @@ Preferences~
 
 	Default: `"SNIP"`
 
+"coc.preferences.nextPlaceholderOnDelete"		*coc-preferences-nextPlaceholderOnDelete*
+
+	Automatically jump to the next placeholder when the current one is
+	completely deleted.
+
+	default: `false`
+
 "coc.preferences.currentFunctionSymbolAutoUpdate"	*coc-preferences-currentFunctionSymbolAutoUpdate*
 
 	Automatically update the value of `b:coc_current_function` on `CursorHold`

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -773,6 +773,7 @@ Related configurations:~
 - |coc-config-suggest-preferCompleteThanJumpPlaceholder|
 - |coc-preferences-snippetStatusText|
 - |coc-preferences-snippetHighlight|
+- |coc-preferences-nextPlaceholderOnDelete|
 
 Related functions:~
 

--- a/src/__tests__/snippets/session.test.ts
+++ b/src/__tests__/snippets/session.test.ts
@@ -21,9 +21,9 @@ afterEach(async () => {
   await helper.reset()
 })
 
-async function createSession(enableHighlight = false, preferComplete = false): Promise<SnippetSession> {
+async function createSession(enableHighlight = false, preferComplete = false, nextOnDelete = false): Promise<SnippetSession> {
   let doc = await workspace.document
-  return new SnippetSession(nvim, doc, enableHighlight, preferComplete)
+  return new SnippetSession(nvim, doc, enableHighlight, preferComplete, nextOnDelete)
 }
 
 describe('SnippetSession', () => {
@@ -276,6 +276,20 @@ describe('SnippetSession', () => {
       await session.nextPlaceholder()
       let col = await nvim.call('col', ['.'])
       expect(col).toBe(7)
+    })
+
+    it('should automatically select next placeholder', async () => {
+      let session = await createSession(false, false, true)
+      await nvim.input('i')
+      await session.start('${1:foo} bar$0', defaultRange)
+      await nvim.input('<esc>')
+      await nvim.call('cursor', [1, 5])
+      await nvim.input('i')
+      await nvim.input('<backspace>')
+      await session.forceSynchronize()
+      expect(session.isActive).toBe(true)
+      let col = await nvim.call('col', ['.'])
+      expect(col).toBe(4)
     })
 
     it('should prefer range contains current cursor', async () => {

--- a/src/snippets/manager.ts
+++ b/src/snippets/manager.ts
@@ -19,6 +19,7 @@ export class SnippetManager {
   private disposables: Disposable[] = []
   private statusItem: StatusBarItem
   private highlight: boolean
+  private nextOnDelete: boolean
   private preferComplete: boolean
 
   constructor() {
@@ -60,6 +61,7 @@ export class SnippetManager {
     let config = workspace.getConfiguration('coc.preferences')
     this.statusItem.text = config.get<string>('snippetStatusText', 'SNIP')
     this.highlight = config.get<boolean>('snippetHighlight', false)
+    this.nextOnDelete = config.get<boolean>('nextPlaceholderOnDelete', false)
     let suggest = workspace.getConfiguration('suggest')
     this.preferComplete = suggest.get('preferCompleteThanJumpPlaceholder', false)
   }
@@ -101,7 +103,7 @@ export class SnippetManager {
       await doc.patchChange(true)
     }
     if (!session) {
-      session = new SnippetSession(this.nvim, doc, this.highlight, this.preferComplete)
+      session = new SnippetSession(this.nvim, doc, this.highlight, this.preferComplete, this.nextOnDelete)
       session.onCancel(() => {
         this.sessionMap.delete(bufnr)
         this.statusItem.hide()


### PR DESCRIPTION
My snippets often include _optional_ placeholders, e.g. the "name" of this snippet can be deleted to create an anonymous function:

```vim-snippet
snippet fn "function"
function ${1:name}(${2:params}) {
  ${0:${VISUAL}}
}
endsnippet
```

In such cases, after activating the snippet and I have `name` selected, I hit backspace to delete it. Even though I've fully removed it, the `name` placeholder is still the selected one. So I have to _manually_ jump to the next placeholder (`params`).

This new option, `coc.preferences.nextPlaceholderOnDelete`, makes it so that when a placeholder is completely removed from the document, coc _automatically_ jumps to the next placeholder.

Please note: this is my first contribution. :) So I'm a little unsure of whether I got everything right. In particular I have a feeling there's a better way to implement the core logic change in snippets/session.ts.