### PR TITLE
Fix formatting usage in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ nmap <leader>rn <Plug>(coc-rename)
 
 " Formatting selected code.
 xmap <leader>f  <Plug>(coc-format-selected)
-nmap <leader>f  <Plug>(coc-format-selected)
+vmap <leader>f  <Plug>(coc-format-selected)
+nmap <leader>f  <Plug>(coc-format)
 
 augroup mygroup
   autocmd!


### PR DESCRIPTION
In the example given in the README, formatting in normal mode works only with a movement. This PR changes to formatting selected text (which was probably the intention), and formatting in normal mode formats the entire file.