### PR TITLE
fix(diagnostic): "xyz" suffix after each virtual text line

### DIFF
--- a/src/diagnostic/buffer.ts
+++ b/src/diagnostic/buffer.ts
@@ -335,7 +335,6 @@ export class DiagnosticBuffer implements SyncItem {
       map.set(line, arr)
     }
     for (let [line, blocks] of map.entries()) {
-      blocks.push(['xyz', 'MoreMsg'])
       buffer.setVirtualText(virtualTextSrcId, line, blocks, opts)
     }
   }


### PR DESCRIPTION
There is a suffix given on each line with diagnostic virtual text that says `xyz` and is highlighted with `MoreMsg`.
![2022-08-25_11-58](https://user-images.githubusercontent.com/44355502/186725729-bda70a76-2730-4481-8a6d-dede12dd49bf.png)

