### PR TITLE
feat(diagnostic): Add 'diagnostic.virtualTextAlign' to set the position of virtual text

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -730,6 +730,12 @@
       "description": "Use NeoVim virtual text to display diagnostics",
       "default": false
     },
+    "diagnostic.virtualTextAlign": {
+      "type": "string",
+      "description": "Position of virtual text, default 'after'. Vim9 only",
+      "default": "after",
+      "enum": ["after", "right", "below"]
+    },
     "diagnostic.virtualTextLevel": {
       "type": ["string", "null"],
       "description": "Filter diagnostic message in virtual text by level",

--- a/doc/coc-config.txt
+++ b/doc/coc-config.txt
@@ -439,6 +439,10 @@ Diagnostics~
 
 	Filter diagnostic message in virtual text by level, default: `null`
 
+"diagnostic.virtualTextAlign"				*coc-config-diagnostic-virtualTextAlign*
+
+	Position of virtual text, requires vim >= 9.0.0121, default: `"after"`
+
 "diagnostic.virtualTextWinCol"				*coc-config-diagnostic-virtualTextWinCol*
 
 	Window column number to align virtual text neovim only, default: `null`

--- a/src/diagnostic/buffer.ts
+++ b/src/diagnostic/buffer.ts
@@ -315,6 +315,9 @@ export class DiagnosticBuffer implements SyncItem {
     buffer.clearNamespace(virtualTextSrcId)
     let map: Map<number, [string, string][]> = new Map()
     let opts: VirtualTextOption = {}
+    if (typeof config.virtualTextAlign === 'string') {
+      opts.text_align = config.virtualTextAlign
+    }
     if (typeof config.virtualTextWinCol === 'number') {
       opts.virt_text_win_col = config.virtualTextWinCol
     }

--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -6,7 +6,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument'
 import { URI } from 'vscode-uri'
 import events from '../events'
 import BufferSync from '../model/bufferSync'
-import { ConfigurationChangeEvent, FloatFactory, Documentation, ErrorItem } from '../types'
+import { ConfigurationChangeEvent, FloatFactory, Documentation, ErrorItem, VirtualTextOption } from '../types'
 import { disposeAll } from '../util'
 import { readFileLines } from '../util/fs'
 import { comparePosition, rangeIntersect } from '../util/position'
@@ -570,6 +570,7 @@ export class DiagnosticManager implements Disposable {
       enableMessage: config.get<string>('enableMessage', 'always'),
       messageDelay: config.get<number>('messageDelay', 200),
       virtualText: config.get<boolean>('virtualText', false),
+      virtualTextAlign: config.get<VirtualTextOption['text_align']>('virtualTextAlign', 'after'),
       virtualTextWinCol: workspace.has('nvim-0.5.1') ? config.get<number | null>('virtualTextWinCol', null) : null,
       virtualTextCurrentLineOnly: config.get<boolean>('virtualTextCurrentLineOnly', true),
       virtualTextPrefix: config.get<string>('virtualTextPrefix', " "),

--- a/src/diagnostic/util.ts
+++ b/src/diagnostic/util.ts
@@ -1,6 +1,6 @@
 'use strict'
 import { DiagnosticSeverity, Diagnostic, Range, DiagnosticTag, TextEdit } from 'vscode-languageserver-protocol'
-import { FloatConfig, LocationListItem } from '../types'
+import { FloatConfig, LocationListItem, VirtualTextOption } from '../types'
 import { comparePosition, rangeOverlap } from '../util/position'
 import { byteIndex } from '../util/string'
 import { getPosition } from '../util/textedit'
@@ -37,6 +37,7 @@ export interface DiagnosticConfig {
   messageDelay: number
   refreshOnInsertMode: boolean
   virtualText: boolean
+  virtualTextAlign: VirtualTextOption['text_align']
   virtualTextLevel: number | undefined
   virtualTextWinCol: number | null
   virtualTextCurrentLineOnly: boolean


### PR DESCRIPTION
Add a option `diagnostic.virtualTextAlign` to set the diagnostic virtual text position. 

### `"diagnostic.virtualTextAlign": "right"`
![截屏2022-08-26 17 28 54](https://user-images.githubusercontent.com/3774036/186873879-827f0fb5-b42f-4245-8a7c-1b5432810eb7.png)

### `"diagnostic.virtualTextAlign": "below"`
![截屏2022-08-26 17 30 11](https://user-images.githubusercontent.com/3774036/186874176-2fbb652c-306a-4de1-9301-1d7d7194e112.png)


