### PR TITLE
feat(diagnostic): Support "diagnostic.virtualTextFormat" to define virtual text format

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -782,6 +782,11 @@
       "description": "The prefix added virtual text diagnostics",
       "default": " "
     },
+    "diagnostic.virtualTextFormat": {
+      "type": "string",
+      "description": "Define the virtual text diagnostic format, available parts: source, code, severity, message",
+      "default": "%message"
+    },
     "diagnostic.virtualTextLines": {
       "type": "number",
       "description": "The number of non empty lines from a diagnostic to display",

--- a/doc/coc-config.txt
+++ b/doc/coc-config.txt
@@ -489,6 +489,13 @@ Diagnostics~
 
 	The prefix added for virtual text diagnostics, default: `" "`
 
+"diagnostic.virtualTextFormat"				*coc-config-diagnostic-virtualTextFormat*
+
+	Define the virtual text diagnostic message format.
+	Available parts: source, code, severity, message
+
+	Default: `%message`
+
 "diagnostic.virtualTextLines"				*coc-config-diagnostic-virtualTextLines*
 
 	The number of non-empty lines from a diagnostic to display, default: `3`

--- a/src/__tests__/modules/diagnosticBuffer.test.ts
+++ b/src/__tests__/modules/diagnosticBuffer.test.ts
@@ -19,6 +19,7 @@ const config: any = {
   virtualText: false,
   virtualTextCurrentLineOnly: true,
   virtualTextPrefix: " ",
+  virtualTextFormat: "%message",
   virtualTextLines: 3,
   virtualTextLineSeparator: " \\ ",
   displayByAle: false,

--- a/src/diagnostic/buffer.ts
+++ b/src/diagnostic/buffer.ts
@@ -8,7 +8,7 @@ import Document from '../model/document'
 import { DidChangeTextDocumentParams, VirtualTextOption, HighlightItem, LocationListItem } from '../types'
 import { lineInRange, positionInRange } from '../util/position'
 import workspace from '../workspace'
-import { adjustDiagnostics, DiagnosticConfig, getHighlightGroup, getLocationListItem, getNameFromSeverity, getSeverityType, sortDiagnostics } from './util'
+import { adjustDiagnostics, DiagnosticConfig, formatDiagnostic, getHighlightGroup, getLocationListItem, getNameFromSeverity, getSeverityType, sortDiagnostics } from './util'
 const logger = require('../util/logger')('diagnostic-buffer')
 const signGroup = 'CocDiagnostic'
 const NAMESPACE = 'diagnostic'
@@ -334,7 +334,10 @@ export class DiagnosticBuffer implements SyncItem {
         .slice(0, this.config.virtualTextLines)
         .join(this.config.virtualTextLineSeparator)
       let arr = map.get(line) ?? []
-      arr.push([virtualTextPrefix + msg, highlight])
+      arr.unshift([virtualTextPrefix + formatDiagnostic(this.config.virtualTextFormat, {
+        ...diagnostic,
+        message: msg
+      }), highlight])
       map.set(line, arr)
     }
     for (let [line, blocks] of map.entries()) {

--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -575,6 +575,7 @@ export class DiagnosticManager implements Disposable {
       virtualTextWinCol: workspace.has('nvim-0.5.1') ? config.get<number | null>('virtualTextWinCol', null) : null,
       virtualTextCurrentLineOnly: config.get<boolean>('virtualTextCurrentLineOnly', true),
       virtualTextPrefix: config.get<string>('virtualTextPrefix', " "),
+      virtualTextFormat: config.get<string>('virtualTextFormat', "%message"),
       virtualTextLineSeparator: config.get<string>('virtualTextLineSeparator', " \\ "),
       virtualTextLines: config.get<number>('virtualTextLines', 3),
       displayByAle: config.get<boolean>('displayByAle', false),

--- a/src/diagnostic/util.ts
+++ b/src/diagnostic/util.ts
@@ -43,6 +43,7 @@ export interface DiagnosticConfig {
   virtualTextCurrentLineOnly: boolean
   virtualTextSrcId?: number
   virtualTextPrefix: string
+  virtualTextFormat: string
   virtualTextLines: number
   virtualTextLineSeparator: string
   filetypeMap: object


### PR DESCRIPTION
### Two changes

1. Add `diagnostic.virtualTextFormat` (maybe `virtualTextPrefix` can be deprecated?)
2. Fix virtual text diagnostics shown order `arr.push(...)` --> `arr.unshift(...)`. This is because the diagnostics have been sorted by `severity`, but the `for ... in` loop is reverved. This change ensures that high-severity diagnostic message shown first
    