### PR TITLE
fix(hover): move quotation mark to correct scope

### DIFF
--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -385,14 +385,18 @@ function! s:funcs.buf_set_lines(bufnr, start, end, strict, ...) abort
       if delCount
         let start = startLnum + len(replacement)
         let saved_reg = @"
-        let system_reg = @*
+        if has('clipboard')
+          let system_reg = @*
+        endif
         if exists('*deletebufline')
           silent call deletebufline(curr, start, start + delCount - 1)
         else
           silent execute start . ','.(start + delCount - 1).'d'
         endif
         let @" = saved_reg
-        let @* = system_reg
+        if has('clipboard')
+          let @* = system_reg
+        endif
       endif
     endif
     call winrestview(storeView)
@@ -412,11 +416,15 @@ function! s:funcs.buf_set_lines(bufnr, start, end, strict, ...) abort
       if delCount
         let start = startLnum + len(replacement)
         let saved_reg = @"
-        let system_reg = @*
+        if has('clipboard')
+          let system_reg = @*
+        endif
         "8.1.0039
         silent call deletebufline(bufnr, start, start + delCount - 1)
         let @" = saved_reg
-        let @* = system_reg
+        if has('clipboard')
+          let @* = system_reg
+        endif
       endif
     endif
   endif

--- a/src/handler/hover.ts
+++ b/src/handler/hover.ts
@@ -53,7 +53,7 @@ export default class HoverHandler {
         nvim.command('setlocal conceallevel=2 nospell nofoldenable wrap', true)
         nvim.command('setlocal bufhidden=wipe nobuflisted', true)
         nvim.command('setfiletype markdown', true)
-        nvim.command(`if winnr('j') != winnr('k') | exe "normal! z${Math.min(this.documentLines.length, this.config.previewMaxHeight)}\\<cr> | endif"`, true)
+        nvim.command(`if winnr('j') != winnr('k') | exe "normal! z${Math.min(this.documentLines.length, this.config.previewMaxHeight)}\\<cr>" | endif`, true)
         await nvim.resumeNotification()
         return this.documentLines.join('\n')
       }


### PR DESCRIPTION
I was having an issue with the hover preview functionality in vim. Every time I tried to force coc to use a preview window I got the following error:
```
2022-09-14T15:34:19.377 INFO (pid:3578083) [attach] - receive notification: doHover [ 'preview' ]
2022-09-14T15:34:19.436 ERROR (pid:3578083) [node-client] - call_atomic request error VimException(String) on "nvim_command" [ `if winnr('j') != winnr('k') | exe "normal! z12\\<cr> | endif"` ] Vim(endfunction):E171: Missing :endif on function co
c#api#call[4]..304[5]..BufReadCmd Autocommands for "coc:/*"..function coc#rpc#request[4]..<SNR>79_request[5]..coc#api#call[4]..298[6]..304, line 12 Error
     at BH.resumeNotification (/home/user/.vim/bundle/coc.nvim/build/index.js:23:1302)
     at $H.resumeNotification (/home/user/.vim/bundle/coc.nvim/build/index.js:26:5485)
     at Object.provideTextDocumentContent (/home/user/.vim/bundle/coc.nvim/build/index.js:274:4360)
     at Qb.onBufReadCmd (/home/user/.vim/bundle/coc.nvim/build/index.js:163:1080)
     at /home/user/.vim/bundle/coc.nvim/build/index.js:63:3130
     at new Promise (<anonymous>)
     at s (/home/user/.vim/bundle/coc.nvim/build/index.js:63:3088)
     at /home/user/.vim/bundle/coc.nvim/build/index.js:63:2750
     at Array.map (<anonymous>)
     at A2.fire (/home/user/.vim/bundle/coc.nvim/build/index.js:63:2743)
2022-09-14T15:34:19.436 ERROR (pid:3578083) [events] - Error on event: BufReadCmd Error
     at BH.resumeNotification (/home/user/.vim/bundle/coc.nvim/build/index.js:23:1302)
     at $H.resumeNotification (/home/user/.vim/bundle/coc.nvim/build/index.js:26:5485)
     at Object.provideTextDocumentContent (/home/user/.vim/bundle/coc.nvim/build/index.js:274:4360)
     at Qb.onBufReadCmd (/home/user/.vim/bundle/coc.nvim/build/index.js:163:1080)
     at /home/user/.vim/bundle/coc.nvim/build/index.js:63:3130
     at new Promise (<anonymous>)
     at s (/home/user/.vim/bundle/coc.nvim/build/index.js:63:3088)
     at /home/user/.vim/bundle/coc.nvim/build/index.js:63:2750
     at Array.map (<anonymous>)
     at A2.fire (/home/user/.vim/bundle/coc.nvim/build/index.js:63:2743)
2022-09-14T15:34:23.498 INFO (pid:3578083) [attach] - receive notification: showInfo []
```

You'll have to excuse me as I've never worked on a Vim plugin as complex as coc, but from what I can see this quotation mark is closed at the wrong scope. When I changed this, preview functionality seemed to begin working correctly.

Feel free to close this out if I'm wrong and the current code is correct.

Version Info:
```
## versions

vim version: VIM - Vi IMproved 8.2 8023995
node version: v18.7.0
coc.nvim version: 0.0.82-dbd0976c 2022-09-14 18:27:21 +0800
coc.nvim directory: /home/user/.vim/bundle/coc.nvim
term: tmux
platform: linux
```