### PR TITLE
fix(plugin): fix CocMenuSel in dark background

### DIFF
--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -426,11 +426,7 @@ function! s:Highlight() abort
   else
     exe 'hi default link CocFloating '.(has('nvim') ? 'NormalFloat' : 'Pmenu')
     if coc#highlight#get_contrast('CocFloating', 'PmenuSel') > 2.0
-      if &background ==# 'dark'
-        hi default CocMenuSel ctermbg=237 guibg=#13354A
-      else
-        exe 'hi default CocMenuSel '.coc#highlight#create_bg_command('CocFloating', &background ==# 'dark' ? -0.2 : 0.05)
-      endif
+      exe 'hi default CocMenuSel '.coc#highlight#create_bg_command('CocFloating', &background ==# 'dark' ? -0.2 : 0.05)
     else
       exe 'hi default CocMenuSel '.coc#highlight#get_hl_command(synIDtrans(hlID('PmenuSel')), 'bg', '237', '#13354A')
     endif


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16915589/190355171-929edddd-25df-4f9b-b01d-7316a8208523.png)
* `CocMenuSel ctermbg=237 guibg=#13354A` is not distinguishable in https://github.com/lifepillar/vim-solarized8
* [line 432](https://github.com/neoclide/coc.nvim/blob/01ddea57674bf36512923e37e45510577f36dc18/plugin/coc.vim#L432) already checked `background == darak`, so no need to check in [line 429](https://github.com/neoclide/coc.nvim/blob/01ddea57674bf36512923e37e45510577f36dc18/plugin/coc.vim#L429)?