### PR TITLE
fix(inlayHints): break on empty hints

### DIFF
--- a/src/handler/inlayHint/buffer.ts
+++ b/src/handler/inlayHint/buffer.ts
@@ -147,7 +147,7 @@ export default class InlayHintBuffer implements SyncItem {
     if (this.regions.has(res[0], res[1])) return
     let range = Range.create(res[0] - 1, 0, res[1], 0)
     let inlayHints = await languages.provideInlayHints(this.doc.textDocument, range, token)
-    if (inlayHints == null || token.isCancellationRequested) return
+    if (inlayHints == null || inlayHints.length === 0 || token.isCancellationRequested) return
     if (!this.config.enableParameter) {
       inlayHints = inlayHints.filter(o => o.kind !== InlayHintKind.Parameter)
     }


### PR DESCRIPTION
came this issue with rust-analyzer. RA takes a time to do indexing work, the first time inlayHints request will failed and inlayHintManager returns empty hints, coc saved the region. coc will send request again on refresh, but `regions` contains the old region and won't request to LS again.