### PR TITLE
fix(installer): fix pnpm unmet peer deps error

### DIFF
--- a/src/__tests__/modules/installer.test.ts
+++ b/src/__tests__/modules/installer.test.ts
@@ -22,7 +22,7 @@ describe('Installer', () => {
   })
 
   it('should get install arguments', async () => {
-    expect(getInstallArguments('pnpm', 'https://github.com/')).toEqual(['install'])
+    expect(getInstallArguments('pnpm', 'https://github.com/')).toEqual(['install', '--config.strict-peer-dependencies=false'])
     expect(getInstallArguments('npm', '')).toEqual(['install', '--ignore-scripts', '--no-lockfile', '--production', '--legacy-peer-deps', '--no-global'])
     expect(getInstallArguments('yarn', '')).toEqual(['install', '--ignore-scripts', '--no-lockfile', '--production', '--ignore-engines'])
   })

--- a/src/model/installer.ts
+++ b/src/model/installer.ts
@@ -76,7 +76,7 @@ export function getInstallArguments(exePath: string, url: string): string[] {
   if (isYarn(exePath)) {
     args.push('--ignore-engines')
   }
-  if (isPnPm(exePath)) {
+  if (isPnpm(exePath)) {
     args.push('--config.strict-peer-dependencies=false')
   }
   return args

--- a/src/model/installer.ts
+++ b/src/model/installer.ts
@@ -59,6 +59,11 @@ export function isYarn(exePath: string) {
   return ['yarn', 'yarn.CMD', 'yarnpkg', 'yarnpkg.CMD'].includes(name)
 }
 
+function isPnpm(exePath: string) {
+  let name = path.basename(exePath)
+  return name === 'pnpm'
+}
+
 export function getInstallArguments(exePath: string, url: string): string[] {
   let args = ['install', '--ignore-scripts', '--no-lockfile', '--production']
   if (url.startsWith('https://github.com')) {
@@ -70,6 +75,9 @@ export function getInstallArguments(exePath: string, url: string): string[] {
   }
   if (isYarn(exePath)) {
     args.push('--ignore-engines')
+  }
+  if (isPnPm(exePath)) {
+    args.push('--config.strict-peer-dependencies=false')
   }
   return args
 }

--- a/src/model/installer.ts
+++ b/src/model/installer.ts
@@ -61,7 +61,7 @@ export function isYarn(exePath: string) {
 
 function isPnpm(exePath: string) {
   let name = path.basename(exePath)
-  return name === 'pnpm'
+  return name === 'pnpm' || name === 'pnpm.CMD'
 }
 
 export function getInstallArguments(exePath: string, url: string): string[] {


### PR DESCRIPTION
In #2671 I removed `--legacy-peer-deps` option when installing extensions with pnpm, but the correct fix is to use a equivalent option to match this behavior.

This pull request will prevent unmet peer dependencies error when installing some extensions with pnpm, such as [coc-explorer](https://github.com/weirongxu/coc-explorer).