### PR TITLE
chore: fix typo

### DIFF
--- a/autoload/coc.vim
+++ b/autoload/coc.vim
@@ -135,7 +135,7 @@ endfunction
 function! coc#on_notify(id, method, Cb)
   let key = a:id. '-'.a:method
   let s:callbacks[key] = a:Cb
-  call coc#rpc#notify('registNotification', [a:id, a:method])
+  call coc#rpc#notify('registerNotification', [a:id, a:method])
 endfunction
 
 function! coc#do_notify(id, method, result)
@@ -158,7 +158,7 @@ endfunction
 
 function! coc#_select_confirm() abort
   call timer_start(10, { -> coc#pum#select_confirm()})
-  return s:is_vim || has('nvim-0.5.0') ? "\<Ignore>" : "\<space>\<bs>" 
+  return s:is_vim || has('nvim-0.5.0') ? "\<Ignore>" : "\<space>\<bs>"
 endfunction
 
 function! coc#complete_indent() abort

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -2191,14 +2191,14 @@ CocNotify({id}, {method}, [{params}])			*CocNotify()*
 >
 	call CocNotify('ccls', '$ccls/reload')
 <
-							*CocRegistNotification()*
+							*CocRegisterNotification()*
 
-CocRegistNotification({id}, {method}, {callback})
+CocRegisterNotification({id}, {method}, {callback})
 
 	Register notification callback for specified client {id} and {method},
 	example: >
 
-	autocmd User CocNvimInit call CocRegistNotification('ccls',
+	autocmd User CocNvimInit call CocRegisterNotification('ccls',
 		\ '$ccls/publishSemanticHighlight', function('s:Handler'))
 <
 	{callback} is called with single param as notification result.

--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -117,6 +117,11 @@ function! CocNotify(...) abort
   return coc#rpc#request('sendNotification', a:000)
 endfunction
 
+function! CocRegisterNotification(id, method, cb) abort
+  call coc#on_notify(a:id, a:method, a:cb)
+endfunction
+
+" Deprecated, use CocRegisterNotification instead
 function! CocRegistNotification(id, method, cb) abort
   call coc#on_notify(a:id, a:method, a:cb)
 endfunction

--- a/src/__tests__/configuration/configurationModel.test.ts
+++ b/src/__tests__/configuration/configurationModel.test.ts
@@ -518,7 +518,7 @@ describe('Configuration', () => {
     assert.strictEqual(testObject.getValue('a', {}), 2)
   })
 
-  test('Test update by resouce', async () => {
+  test('Test update by resource', async () => {
     const parser = new ConfigurationModelParser('test')
     parser.parse(JSON.stringify({ a: 1 }))
     const testObject: Configuration = new Configuration(parser.configurationModel, new ConfigurationModel(), new ConfigurationModel())
@@ -1015,7 +1015,7 @@ describe('ConfigurationChangeEvent', () => {
     const configuration = new Configuration(new ConfigurationModel(), new ConfigurationModel(), new ConfigurationModel())
     const change = configuration.compareAndUpdateUserConfiguration(toConfigurationModel({
       launch: {
-        configuraiton: {}
+        configuration: {}
       },
       'launch.version': 1,
       tasks: {

--- a/src/__tests__/configuration/configurations.test.ts
+++ b/src/__tests__/configuration/configurations.test.ts
@@ -367,7 +367,7 @@ describe('Configurations', () => {
       expect(val).toBe(3)
     })
 
-    it('should show error when workspace folder not resovled', async () => {
+    it('should show error when workspace folder not resolved', async () => {
       let called = false
       let s = jest.spyOn(console, 'error').mockImplementation(() => {
         called = true

--- a/src/__tests__/core/editors.test.ts
+++ b/src/__tests__/core/editors.test.ts
@@ -148,7 +148,7 @@ describe('editors', () => {
     expect(editors.visibleTextEditors.length).toBe(2)
   })
 
-  it('should have corrent tabnr after tab changed', async () => {
+  it('should have current tabnr after tab changed', async () => {
     await nvim.command('tabe')
     await helper.waitValue(() => {
       return editors.visibleTextEditors.length

--- a/src/__tests__/handler/highlights.test.ts
+++ b/src/__tests__/handler/highlights.test.ts
@@ -26,7 +26,7 @@ afterEach(async () => {
   disposables = []
 })
 
-function registProvider(): void {
+function registerProvider(): void {
   disposables.push(languages.registerDocumentHighlightProvider([{ language: '*' }], {
     provideDocumentHighlights: async document => {
       let word = await nvim.eval('expand("<cword>")')
@@ -119,7 +119,7 @@ describe('document highlights', () => {
   })
 
   it('should add highlights to symbols', async () => {
-    registProvider()
+    registerProvider()
     await helper.createDocument()
     await nvim.setLine('foo bar foo')
     await helper.doAction('highlight')
@@ -128,7 +128,7 @@ describe('document highlights', () => {
   })
 
   it('should return highlight ranges', async () => {
-    registProvider()
+    registerProvider()
     await helper.createDocument()
     await nvim.setLine('foo bar foo')
     let res = await helper.doAction('symbolRanges')

--- a/src/__tests__/handler/search.test.ts
+++ b/src/__tests__/handler/search.test.ts
@@ -89,7 +89,7 @@ describe('search', () => {
     expect(lines[1]).toMatch(/No match found/)
   })
 
-  it('should use corrent search folder for rg', async () => {
+  it('should use current search folder for rg', async () => {
     let search = new Search(nvim, 'rg')
     await helper.createDocument()
     let buf = await refactor.createRefactorBuffer()

--- a/src/__tests__/list/sources.test.ts
+++ b/src/__tests__/list/sources.test.ts
@@ -580,8 +580,8 @@ describe('list sources', () => {
 
   describe('services', () => {
     function createService(name: string): IServiceProvider {
-      let _onServcieReady = new Emitter<void>()
-      // public readonly onServcieReady: Event<void> = this.
+      let _onServiceReady = new Emitter<void>()
+      // public readonly onServiceReady: Event<void> = this.
       let service: IServiceProvider = {
         id: name,
         name,
@@ -589,7 +589,7 @@ describe('list sources', () => {
         state: ServiceStat.Initial,
         start(): Promise<void> {
           service.state = ServiceStat.Running
-          _onServcieReady.fire()
+          _onServiceReady.fire()
           return Promise.resolve()
         },
         dispose(): void {
@@ -600,11 +600,11 @@ describe('list sources', () => {
         },
         restart(): void {
           service.state = ServiceStat.Running
-          _onServcieReady.fire()
+          _onServiceReady.fire()
         },
-        onServiceReady: _onServcieReady.event
+        onServiceReady: _onServiceReady.event
       }
-      disposables.push(services.regist(service))
+      disposables.push(services.register(service))
       return service
     }
 

--- a/src/__tests__/modules/workspace.test.ts
+++ b/src/__tests__/modules/workspace.test.ts
@@ -400,7 +400,7 @@ describe('workspace utility', () => {
     disposables.forEach(d => d.dispose())
   })
 
-  it('should regist keymap', async () => {
+  it('should register keymap', async () => {
     let fn = jest.fn()
     await nvim.command('nmap go <Plug>(coc-echo)')
     let disposable = workspace.registerKeymap(['n', 'v'], 'echo', fn, { sync: true })
@@ -416,7 +416,7 @@ describe('workspace utility', () => {
     expect(fn).toBeCalledTimes(1)
   })
 
-  it('should regist expr keymap', async () => {
+  it('should register expr keymap', async () => {
     let called = false
     let fn = () => {
       called = true
@@ -435,7 +435,7 @@ describe('workspace utility', () => {
     disposable.dispose()
   })
 
-  it('should regist buffer expr keymap', async () => {
+  it('should register buffer expr keymap', async () => {
     let fn = () => '""'
     await nvim.input('i')
     let disposable = workspace.registerExprKeymap('i', '"', fn, true)
@@ -630,7 +630,7 @@ describe('workspace events', () => {
 
 describe('workspace textDocument content provider', () => {
 
-  it('should regist document content provider', async () => {
+  it('should register document content provider', async () => {
     let provider: TextDocumentContentProvider = {
       provideTextDocumentContent: (_uri, _token): string => 'sample text'
     }
@@ -660,7 +660,7 @@ describe('workspace textDocument content provider', () => {
 })
 
 describe('workspace registerBufferSync', () => {
-  it('should regist', async () => {
+  it('should register', async () => {
     await helper.createDocument()
     let created = 0
     let deleted = 0

--- a/src/__tests__/snippets/parser.test.ts
+++ b/src/__tests__/snippets/parser.test.ts
@@ -331,10 +331,10 @@ describe('SnippetParser', () => {
     let filtered = arr.filter(o => o.primary === true)
     assert.equal(filtered.length, 1)
     assert.equal(filtered[0], arr[2])
-    let childs = arr.map(o => o.children[0])
-    assert.ok(childs[0] instanceof Text)
-    assert.ok(childs[1] instanceof Text)
-    assert.ok(childs[2] instanceof CodeBlock)
+    let children = arr.map(o => o.children[0])
+    assert.ok(children[0] instanceof Text)
+    assert.ok(children[1] instanceof Text)
+    assert.ok(children[2] instanceof CodeBlock)
   })
 
   test('Parser, placeholder with CodeBlock not primary', () => {

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -296,7 +296,7 @@ export class Configuration {
     this._defaultConfiguration.freeze().keys.forEach(key => keys.add(key))
     this._userConfiguration.freeze().keys.forEach(key => keys.add(key))
     this._workspaceConfiguration.freeze().keys.forEach(key => keys.add(key))
-    this._folderConfigurations.forEach(folderConfiguraiton => folderConfiguraiton.freeze().keys.forEach(key => keys.add(key)))
+    this._folderConfigurations.forEach(folderConfiguration => folderConfiguration.freeze().keys.forEach(key => keys.add(key)))
     return [...keys.values()]
   }
 

--- a/src/configuration/event.ts
+++ b/src/configuration/event.ts
@@ -14,7 +14,7 @@ export class ConfigurationChangeEvent implements IConfigurationChangeEvent {
 
   constructor(public readonly change: IConfigurationChange,
     private readonly previous: IConfigurationData | undefined,
-    private readonly currentConfiguraiton: Configuration) {
+    private readonly currentConfiguration: Configuration) {
     const keysSet = new Set<string>()
     change.keys.forEach(key => keysSet.add(key))
     change.overrides.forEach(([, keys]) => keys.forEach(key => keysSet.add(key)))
@@ -38,7 +38,7 @@ export class ConfigurationChangeEvent implements IConfigurationChangeEvent {
     if (this.doesAffectedKeysTreeContains(this.affectedKeysTree, section)) {
       if (overrides) {
         const value1 = this.previousConfiguration ? this.previousConfiguration.getValue(section, overrides) : undefined
-        const value2 = this.currentConfiguraiton.getValue(section, overrides)
+        const value2 = this.currentConfiguration.getValue(section, overrides)
         return !equals(value1, value2)
       }
       return true

--- a/src/configuration/model.ts
+++ b/src/configuration/model.ts
@@ -66,7 +66,7 @@ export class ConfigurationModel implements IConfigurationModel {
   }
 
   public getOverrideValue<V>(section: string | undefined, overrideIdentifier: string): V | undefined {
-    const overrideContents = this.getContentsForOverrideIdentifer(overrideIdentifier)
+    const overrideContents = this.getContentsForOverrideIdentifier(overrideIdentifier)
     return overrideContents
       ? section ? getConfigurationValue<any>(overrideContents, section) : overrideContents
       : undefined
@@ -179,7 +179,7 @@ export class ConfigurationModel implements IConfigurationModel {
   }
 
   private createOverrideConfigurationModel(identifier: string): ConfigurationModel {
-    const overrideContents = this.getContentsForOverrideIdentifer(identifier)
+    const overrideContents = this.getContentsForOverrideIdentifier(identifier)
 
     if (!overrideContents || typeof overrideContents !== 'object' || !Object.keys(overrideContents).length) {
       // If there are no valid overrides, return self
@@ -209,7 +209,7 @@ export class ConfigurationModel implements IConfigurationModel {
     return new ConfigurationModel(contents, this._keys, this.overrides)
   }
 
-  private getContentsForOverrideIdentifer(identifier: string): any {
+  private getContentsForOverrideIdentifier(identifier: string): any {
     let contentsForIdentifierOnly: IStringDictionary<any> | null = null
     let contents: IStringDictionary<any> | null = null
     const mergeContents = (contentsToMerge: any) => {

--- a/src/cursors/index.ts
+++ b/src/cursors/index.ts
@@ -9,7 +9,7 @@ import CursorSession, { CursorsConfig } from './session'
 import { getVisualRanges, splitRange } from './util'
 const logger = require('../util/logger')('cursors')
 
-export type CursorPostion = [number, number, number, number]
+export type CursorPosition = [number, number, number, number]
 
 export default class Cursors {
   private sessionsMap: Map<number, CursorSession> = new Map()
@@ -60,7 +60,7 @@ export default class Cursors {
     let session = this.createSession(doc)
     let range: Range
     if (kind == 'operator') {
-      let res = await nvim.eval(`[getpos("'["),getpos("']")]`) as [CursorPostion, CursorPostion]
+      let res = await nvim.eval(`[getpos("'["),getpos("']")]`) as [CursorPosition, CursorPosition]
       if (mode == 'char') {
         let start = doc.getPosition(res[0][1], res[0][2])
         let end = doc.getPosition(res[1][1], res[1][2] + 1)

--- a/src/language-client/codeAction.ts
+++ b/src/language-client/codeAction.ts
@@ -89,7 +89,7 @@ export class CodeActionFeature extends TextDocumentLanguageFeature<boolean | Cod
   protected registerLanguageProvider(
     options: CodeActionRegistrationOptions
   ): [Disposable, CodeActionProvider] {
-    const registCommand = (id: string) => {
+    const registerCommand = (id: string) => {
       const client = this._client
       const executeCommand: ExecuteCommandSignature = (command: string, args: any[]): any => {
         const params: ExecuteCommandParams = {
@@ -122,7 +122,7 @@ export class CodeActionFeature extends TextDocumentLanguageFeature<boolean | Cod
               // some server may not registered commands to client.
               values.forEach(val => {
                 let cmd = Command.is(val) ? val.command : val.command?.command
-                if (cmd && !commands.has(cmd)) registCommand(cmd)
+                if (cmd && !commands.has(cmd)) registerCommand(cmd)
               })
               return values
             }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -58,6 +58,8 @@ export default class Plugin extends EventEmitter {
     this.addAction('attach', () => workspace.attach())
     this.addAction('detach', () => workspace.detach())
     this.addAction('doKeymap', async (key, defaultReturn, pressed) => this.handler.workspace.doKeymap(key, defaultReturn, pressed))
+    this.addAction('registerExtensions', (...folders: string[]) => extensions.loadExtension(folders))
+    // Deprecated, use registerExtensions instead.
     this.addAction('registExtensions', (...folders: string[]) => extensions.loadExtension(folders))
     this.addAction('snippetCheck', async (checkExpand: boolean, checkJump: boolean) => this.handler.workspace.snippetCheck(checkExpand, checkJump))
     this.addAction('snippetNext', () => snippetManager.nextPlaceholder())
@@ -85,7 +87,9 @@ export default class Plugin extends EventEmitter {
     this.addAction('listLast', (name?: string) => listManager.last(name))
     this.addAction('sendRequest', (id: string, method: string, params?: any) => services.sendRequest(id, method, params))
     this.addAction('sendNotification', (id: string, method: string, params?: any) => services.sendNotification(id, method, params))
-    this.addAction('registNotification', (id: string, method: string) => services.registNotification(id, method))
+    this.addAction('registerNotification', (id: string, method: string) => services.registerNotification(id, method))
+    // Deprecated, use registerNotification instead.
+    this.addAction('registNotification', (id: string, method: string) => services.registerNotification(id, method))
     this.addAction('updateConfig', (section: string, val: any) => workspace.configurations.updateMemoryConfig({ [section]: val }))
     this.addAction('links', () => this.handler.links.getLinks())
     this.addAction('openLink', () => this.handler.links.openCurrentLink())

--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -56,9 +56,9 @@ export class Sources {
   }
 
   private createNativeSources(): void {
-    this.disposables.push((require('./native/around')).regist(this.sourceMap, this.keywords))
-    this.disposables.push((require('./native/buffer')).regist(this.sourceMap, this.keywords))
-    this.disposables.push((require('./native/file')).regist(this.sourceMap))
+    this.disposables.push((require('./native/around')).register(this.sourceMap, this.keywords))
+    this.disposables.push((require('./native/buffer')).register(this.sourceMap, this.keywords))
+    this.disposables.push((require('./native/file')).register(this.sourceMap))
   }
 
   public createLanguageSource(

--- a/src/sources/native/around.ts
+++ b/src/sources/native/around.ts
@@ -91,7 +91,7 @@ export default class Around extends Source {
   }
 }
 
-export function regist(sourceMap: Map<string, ISource>, keywords: BufferSync<KeywordsBuffer>): Disposable {
+export function register(sourceMap: Map<string, ISource>, keywords: BufferSync<KeywordsBuffer>): Disposable {
   sourceMap.set('around', new Around(keywords))
   return Disposable.create(() => {
     sourceMap.delete('around')

--- a/src/sources/native/buffer.ts
+++ b/src/sources/native/buffer.ts
@@ -80,7 +80,7 @@ export default class Buffer extends Source {
   }
 }
 
-export function regist(sourceMap: Map<string, ISource>, keywords: BufferSync<KeywordsBuffer>): Disposable {
+export function register(sourceMap: Map<string, ISource>, keywords: BufferSync<KeywordsBuffer>): Disposable {
   sourceMap.set('buffer', new Buffer(keywords))
   return Disposable.create(() => {
     sourceMap.delete('buffer')

--- a/src/sources/native/file.ts
+++ b/src/sources/native/file.ts
@@ -152,7 +152,7 @@ export default class File extends Source {
   }
 }
 
-export function regist(sourceMap: Map<string, ISource>): Disposable {
+export function register(sourceMap: Map<string, ISource>): Disposable {
   sourceMap.set('file', new File())
   return Disposable.create(() => {
     sourceMap.delete('file')

--- a/src/tree/TreeView.ts
+++ b/src/tree/TreeView.ts
@@ -966,7 +966,7 @@ export default class BasicTreeView<T> implements TreeView<T> {
   private registerKeymaps(): void {
     let { toggleSelection, actions, close, invoke, toggle, collapseAll, activeFilter } = this.keys
     let { nvim, _keymapDefs } = this
-    const regist = (mode: LocalMode, key: string | undefined, fn: (element: T | undefined) => Promise<void> | void, notify = true) => {
+    const register = (mode: LocalMode, key: string | undefined, fn: (element: T | undefined) => Promise<void> | void, notify = true) => {
       if (!key) return
       workspace.registerLocalKeymap(mode, key, async () => {
         let lnum = await this.nvim.call('line', ['.'])
@@ -977,24 +977,24 @@ export default class BasicTreeView<T> implements TreeView<T> {
     this.disposables.push(workspace.registerLocalKeymap('n', '<C-o>', () => {
       nvim.call('win_gotoid', [this._targetWinId], true)
     }, true))
-    regist('n', '<LeftRelease>', async element => {
+    register('n', '<LeftRelease>', async element => {
       if (element) await this.onClick(element)
     })
-    this.filter && regist('n', activeFilter, async () => {
+    this.filter && register('n', activeFilter, async () => {
       this.nvim.command(`exe ${this.startLnum}`, true)
       this.filter.active()
       this.filterText = ''
       this._onDidFilterStateChange.fire(true)
     })
-    regist('n', toggleSelection, element => this.toggleSelection(element))
-    regist('n', invoke, element => this.invokeCommand(element))
-    regist('n', actions, element => this.invokeActions(element))
-    regist('n', toggle, element => this.toggleExpand(element))
-    regist('n', collapseAll, () => this.collapseAll())
-    regist('n', close, () => this.hide())
+    register('n', toggleSelection, element => this.toggleSelection(element))
+    register('n', invoke, element => this.invokeCommand(element))
+    register('n', actions, element => this.invokeActions(element))
+    register('n', toggle, element => this.toggleExpand(element))
+    register('n', collapseAll, () => this.collapseAll())
+    register('n', close, () => this.hide())
     while (_keymapDefs.length) {
       const def = _keymapDefs.pop()
-      regist(def.mode, def.key, def.fn, def.notify)
+      register(def.mode, def.key, def.fn, def.notify)
     }
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -6121,9 +6121,17 @@ declare module 'coc.nvim' {
     /**
      * Register languageClient as service provider.
      */
+    export function registerLanguageClient(client: LanguageClient): Disposable
+    /**
+     * @deprecated use registerLanguageClient instead.
+     */
     export function registLanguageClient(client: LanguageClient): Disposable
     /**
      * Register service, nothing happens when `service.id` already exists.
+     */
+    export function register(service: IServiceProvider): Disposable
+    /**
+     * @deprecated use register instead.
      */
     export function regist(service: IServiceProvider): Disposable
     /**
@@ -6318,7 +6326,7 @@ declare module 'coc.nvim' {
     /**
      * Add source to sources list.
      *
-     * Note: Use `sources.createSource()` for regist new source is recommended for
+     * Note: Use `sources.createSource()` to register new source is recommended for
      * user configuration support.
      */
     export function addSource(source: ISource): Disposable
@@ -10378,7 +10386,7 @@ declare module 'coc.nvim' {
 
   /**
    * A language server for manage a language server.
-   * It's recommended to use `services.registLanguageClient` for regist language client to serviers,
+   * It's recommended to use `services.registerLanguageClient` to register language client to serviers,
    * you can have language client listed in `CocList services` and services could start the language client
    * by `documentselector` of `clientOptions`.
    */
@@ -10387,8 +10395,8 @@ declare module 'coc.nvim' {
     readonly name: string
     constructor(id: string, name: string, serverOptions: ServerOptions, clientOptions: LanguageClientOptions, forceDebug?: boolean)
     /**
-     * Create language client by name and options, don't forget regist language client
-     * to services by `services.registLanguageClient`
+     * Create language client by name and options, don't forget to register language client
+     * to services by `services.registerLanguageClient`
      */
     constructor(name: string, serverOptions: ServerOptions, clientOptions: LanguageClientOptions, forceDebug?: boolean)
     /**
@@ -10461,7 +10469,7 @@ declare module 'coc.nvim' {
     stop(): Promise<void>
 
     /**
-     * Start language server, not needed when registered to services by `services.registLanguageClient`
+     * Start language server, not needed when registered to services by `services.registerLanguageClient`
      */
     start(): Promise<void>
     /**


### PR DESCRIPTION
Non-trivial change: Correct `regist` to `register`. Add a new API for `register` and claim `regist` is deprecated.