### PR TITLE
feat(InlayHints): Highlights by InlayHint kind

### DIFF
--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -794,6 +794,8 @@ To temporarily toggle inlay hint of current buffer, use command
 Change highlight group:~
 
 |CocInlayHint|
+|CocInlayHintType|
+|CocInlayHintParameter|
 
 Configure inlay hint support:~
 

--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -517,6 +517,10 @@ function! s:Highlight() abort
   endfor
 
   call s:CreateHighlight('CocInlayHint', 'CocHintSign', 'SignColumn')
+  for name in ['Parameter', 'Type']
+    exe 'hi default link CocInlayHint'.name.' CocInlayHint'
+  endfor
+
   call s:AddAnsiGroups()
 
   if get(g:, 'coc_default_semantic_highlight_groups', 1)

--- a/src/__tests__/handler/inlayHint.test.ts
+++ b/src/__tests__/handler/inlayHint.test.ts
@@ -206,7 +206,7 @@ describe('InlayHint', () => {
       await waitRefresh(doc.bufnr)
       let markers = await doc.buffer.getExtMarks(ns, 0, -1, { details: true })
       let obj = markers[0][3].virt_text
-      expect(obj).toEqual([['baz', 'CocInlayHint']])
+      expect(obj).toEqual([['baz', 'CocInlayHintType']])
     })
 
     it('should disable parameter inlayHint', async () => {
@@ -227,7 +227,7 @@ describe('InlayHint', () => {
       await waitRefresh(doc.bufnr)
       let markers = await doc.buffer.getExtMarks(ns, 0, -1, { details: true })
       let virt_text = markers[0][3].virt_text
-      expect(virt_text[1]).toEqual(['|', 'CocInlayHint'])
+      expect(virt_text[1]).toEqual(['|', 'CocInlayHintType'])
     })
   })
 

--- a/src/handler/inlayHint/buffer.ts
+++ b/src/handler/inlayHint/buffer.ts
@@ -26,7 +26,16 @@ export interface InlayHintConfig {
 
 let srcId: number | undefined
 const debounceInterval = global.__TEST__ ? 10 : 100
-const highlightGroup = 'CocInlayHint'
+const getHighlightGroup = (kind: InlayHintKind): string => {
+  switch (kind) {
+    case InlayHintKind.Parameter:
+      return 'CocInlayHintParameter'
+    case InlayHintKind.Type:
+      return 'CocInlayHintType'
+    default:
+      return 'CocInlayHint'
+  }
+}
 
 export default class InlayHintBuffer implements SyncItem {
   private _enabled = true
@@ -177,10 +186,10 @@ export default class InlayHintBuffer implements SyncItem {
         let { line } = item.position
         const chunks: [string, string][] = chunksMap.get(line) ?? []
         if (chunks.length > 0) {
-          chunks.push([subSeparator, subSeparator === ' ' ? 'Normal' : highlightGroup])
+          chunks.push([subSeparator, subSeparator === ' ' ? 'Normal' : getHighlightGroup(item.kind)])
         }
         let sep = item.kind === InlayHintKind.Parameter ? parameterSeparator : typeSeparator
-        chunks.push([sep + getLabel(item), highlightGroup])
+        chunks.push([sep + getLabel(item), getHighlightGroup(item.kind)])
         chunksMap.set(line, chunks)
       }
     }
@@ -195,7 +204,7 @@ export default class InlayHintBuffer implements SyncItem {
         if (item.paddingLeft) {
           chunks.push([' ', 'Normal'])
         }
-        chunks.push([getLabel(item), highlightGroup])
+        chunks.push([getLabel(item), getHighlightGroup(item.kind)])
         if (item.paddingRight) {
           chunks.push([' ', 'Normal'])
         }


### PR DESCRIPTION
According to the InlayHint kind, apply different highlight group. This behavior is similar to the display in JetBrains/WebStorm.

This PR add the new highlight groups `CocInlayHintParameter` `CocInlayHintType`, they default link to `CocInlayHint`. 

Vim
![截屏2022-09-16 17 53 52](https://user-images.githubusercontent.com/3774036/190612532-56ce0a53-ab51-4eb5-addd-9871b42c0803.png)

#### WebStorm
![截屏2022-09-16 17 55 27](https://user-images.githubusercontent.com/3774036/190612878-e35c2575-662b-49f5-b8eb-9da6beb3bbcb.png)
