### PR TITLE
Keep empty lines in markdown

### DIFF
--- a/src/__tests__/markdown/index.test.ts
+++ b/src/__tests__/markdown/index.test.ts
@@ -89,14 +89,14 @@ example:
 \`\`\`
     `
     let res = parseMarkdown(content, {})
-    expect(res.lines).toEqual(['example:', '<div>code</div>'])
-    expect(res.codes).toEqual([{ filetype: 'html', startLine: 1, endLine: 2 }])
+    expect(res.lines).toEqual(['example:', '', '<div>code</div>'])
+    expect(res.codes).toEqual([{ filetype: 'html', startLine: 2, endLine: 3 }])
   })
 
   it('should compose empty lines', async () => {
     let content = 'foo\n\n\nbar\n\n\n'
     let res = parseMarkdown(content, {})
-    expect(res.lines).toEqual(['foo', 'bar'])
+    expect(res.lines).toEqual(['foo', '', 'bar'])
   })
 
   it('should merge lines', async () => {
@@ -127,7 +127,7 @@ example:
   it('should render hr', async () => {
     let content = 'foo\n***\nbar'
     let res = parseMarkdown(content, {})
-    expect(res.lines).toEqual(['foo', '───', 'bar'])
+    expect(res.lines).toEqual(['foo', '', '───', 'bar'])
   })
 
   it('should render deleted text', async () => {

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -140,7 +140,7 @@ export function parseMarkdown(content: string, opts: MarkdownParseOptions): Docu
   let startLnum = 0
   let parsed = marked(content)
   let links = Renderer.getLinks()
-  parsed = parsed.replace(/\n\n/g, '\n').replace(/\s*$/, '')
+  parsed = parsed.replace(/\s*$/, '')
   if (links.length) {
     parsed = parsed + '\n\n' + links.join('\n')
   }


### PR DESCRIPTION
How users choose to format their documentation should be of no concern to this plugin.

You can probably agree on how hard it is to read the following
![bad-hover](https://user-images.githubusercontent.com/87620379/190873863-2efba4c1-ad32-4e0f-9380-1cda58547ec6.png)

The original markdown is
```
Creates a binding of type `Interface` to type `Implementation` inside of the
associated [`DIContainer`](https://docs.rs/syrette/0.3.0/syrette/di_container/struct.DIContainer.html).

The scope of the binding is transient. But that can be changed by using the
returned [`BindingScopeConfigurator`](https://docs.rs/syrette/0.3.0/syrette/di_container/struct.BindingScopeConfigurator.html)

# Errors

Will return Err if the associated [`DIContainer`](https://docs.rs/syrette/0.3.0/syrette/di_container/struct.DIContainer.html) already have a binding for
the interface.']
```

The below is with the commit in this pull request
![good-hover](https://user-images.githubusercontent.com/87620379/190874405-461653f3-2cab-4fb2-b8ec-c0d31442ec2e.png)
