### PR TITLE
perf(highlight.lua): add lua highlight to reduce blocking

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,3 +20,15 @@ indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
 max_line_length = 120
+
+
+[*.lua]
+indent_size = 2
+max_line_length = 120
+align_call_args = only_not_exist_cross_row_expression
+align_table_field_to_first_field = true
+local_assign_continuation_align_to_first_expression = true
+keep_one_space_between_table_and_bracket = false
+quote_style = single
+remove_empty_header_and_footer_lines_in_function = true
+remove_expression_list_finish_comma= true

--- a/autoload/coc/highlight.vim
+++ b/autoload/coc/highlight.vim
@@ -193,7 +193,7 @@ function! coc#highlight#get_highlights(bufnr, key, ...) abort
       endfor
     endif
   else
-    throw 'Get highlights requires vim support prop_list'
+    throw 'Get highlights requires neovim 0.5.0 or vim support prop_list'
   endif
   return res
 endfunction

--- a/autoload/coc/highlight.vim
+++ b/autoload/coc/highlight.vim
@@ -152,6 +152,9 @@ function! coc#highlight#get_highlights(bufnr, key, ...) abort
   endif
   let start = get(a:, 1, 0)
   let end = get(a:, 2, -1)
+  if has('nvim-0.5.0')
+    return v:lua.require('coc.highlight').getHighlights(a:bufnr, a:key, start, end)
+  endif
   let res = []
   let ns = s:namespace_map[a:key]
   if exists('*prop_list')
@@ -189,34 +192,8 @@ function! coc#highlight#get_highlights(bufnr, key, ...) abort
         endfor
       endfor
     endif
-  elseif has('nvim-0.5.0')
-    let start = [start, 0]
-    let maximum = end == -1 ? nvim_buf_line_count(a:bufnr) : end + 1
-    let end = end == -1 ? -1 : [end + 1, 0]
-    let markers = nvim_buf_get_extmarks(a:bufnr, ns, start, -1, {'details': v:true})
-    for [marker_id, line, start_col, details] in markers
-      if line >= maximum
-        " Could be markers exceed end of line
-        continue
-      endif
-      let delta = details['end_row'] - line
-      if delta > 1 || (delta == 1 && details['end_col'] != 0)
-        " can't handle, single line only
-        continue
-      endif
-      let endCol = details['end_col']
-      if endCol == start_col
-        call nvim_buf_del_extmark(a:bufnr, ns, marker_id)
-        continue
-      endif
-      if delta == 1
-        let text = get(nvim_buf_get_lines(a:bufnr, line, line + 1, 0), 0, '')
-        let endCol = strlen(text)
-      endif
-      call add(res, [details['hl_group'], line, start_col, endCol, marker_id])
-    endfor
   else
-    throw 'Get highlights requires neovim 0.5.0 or vim support prop_list'
+    throw 'Get highlights requires vim support prop_list'
   endif
   return res
 endfunction
@@ -227,12 +204,16 @@ function! coc#highlight#set(bufnr, key, highlights, priority) abort
   if !bufloaded(a:bufnr)
     return
   endif
-    let ns = coc#highlight#create_namespace(a:key)
+  let ns = coc#highlight#create_namespace(a:key)
+  if has('nvim-0.5.0')
+    call v:lua.require('coc.highlight').set(a:bufnr, ns, a:highlights, a:priority)
+  else
     if len(a:highlights) > g:coc_highlight_maximum_count
       call s:add_highlights_timer(a:bufnr, ns, a:highlights, a:priority)
     else
       call s:add_highlights(a:bufnr, ns, a:highlights, a:priority)
     endif
+  endif
 endfunction
 
 " Clear highlights by 0 based line numbers.

--- a/lua/coc/highlight.lua
+++ b/lua/coc/highlight.lua
@@ -13,11 +13,11 @@ function M.getHighlights(bufnr, key, s, e)
   local ns = api.nvim_create_namespace('coc-' .. key)
   local markers = api.nvim_buf_get_extmarks(bufnr, ns, {s, 0}, {e, -1}, {details = true})
   local res = {}
-  for i = 1, #markers do
-    local id = markers[i][1]
-    local line = markers[i][2]
-    local startCol = markers[i][3]
-    local details = markers[i][4]
+  for _, mark in ipairs(markers) do
+    local id = mark[1]
+    local line = mark[2]
+    local startCol = mark[3]
+    local details = mark[4]
     local endCol = details.end_col
     if line < max then
       local delta = details.end_row - line

--- a/lua/coc/highlight.lua
+++ b/lua/coc/highlight.lua
@@ -1,0 +1,84 @@
+local api = vim.api
+
+local M = {}
+
+-- Get single line extmarks
+function M.getHighlights(bufnr, key, s, e)
+  if not api.nvim_buf_is_loaded(bufnr) then
+    return nil
+  end
+  s = s or 0
+  e = e or -1
+  local max = e == -1 and api.nvim_buf_line_count(bufnr) or e + 1
+  local ns = api.nvim_create_namespace('coc-' .. key)
+  local markers = api.nvim_buf_get_extmarks(bufnr, ns, {s, 0}, {e, -1}, {details = true})
+  local res = {}
+  for i = 1, #markers do
+    local id = markers[i][1]
+    local line = markers[i][2]
+    local startCol = markers[i][3]
+    local details = markers[i][4]
+    local endCol = details.end_col
+    if line < max then
+      local delta = details.end_row - line
+      if delta <= 1 and (delta == 0 or endCol == 0) then
+        if startCol == endCol then
+          api.nvim_buf_del_extmark(bufnr, ns, id)
+        else
+          if delta == 1 then
+            local text = api.nvim_buf_get_lines(bufnr, line, line + 1, false)[1] or ''
+            endCol = #text
+          end
+          table.insert(res, {details.hl_group, line, startCol, endCol, id})
+        end
+      end
+    end
+  end
+  return res
+end
+
+local function addHighlights(bufnr, ns, highlights, priority)
+  for _, items in ipairs(highlights) do
+    local hlGroup = items[1]
+    local line = items[2]
+    local startCol = items[3]
+    local endCol = items[4]
+    local hlMode = items[5] and 'combine' or 'replace'
+    api.nvim_buf_set_extmark(bufnr, ns, line, startCol, {
+      end_col = endCol,
+      hl_group = hlGroup,
+      hl_mode = hlMode,
+      right_gravity = true,
+      priority = type(priority) == 'numbers' and math.min(priority, 4096) or 4096
+    })
+  end
+end
+
+local function addHighlightTimer(bufnr, ns, highlights, priority, maxCount)
+  local hls = {}
+  local next = {}
+  for i, v in ipairs(highlights) do
+    if i < maxCount then
+      table.insert(hls, v)
+    else
+      table.insert(next, v)
+    end
+  end
+  addHighlights(bufnr, ns, hls, priority)
+  if #next > 0 then
+    vim.defer_fn(function()
+      addHighlightTimer(bufnr, ns, next, priority, maxCount)
+    end, 30)
+  end
+end
+
+function M.set(bufnr, ns, highlights, priority)
+  local maxCount = vim.g.coc_highlight_maximum_count
+  if #highlights > maxCount then
+    addHighlightTimer(bufnr, ns, highlights, priority, maxCount)
+  else
+    addHighlights(bufnr, ns, highlights, priority)
+  end
+end
+
+return M

--- a/lua/coc/highlight.lua
+++ b/lua/coc/highlight.lua
@@ -44,12 +44,13 @@ local function addHighlights(bufnr, ns, highlights, priority)
     local startCol = items[3]
     local endCol = items[4]
     local hlMode = items[5] and 'combine' or 'replace'
-    api.nvim_buf_set_extmark(bufnr, ns, line, startCol, {
-      end_col = endCol,
-      hl_group = hlGroup,
-      hl_mode = hlMode,
-      right_gravity = true,
-      priority = type(priority) == 'numbers' and math.min(priority, 4096) or 4096
+    -- Error: col value outside range
+    pcall(api.nvim_buf_set_extmark, bufnr, ns, line, startCol, {
+          end_col = endCol,
+          hl_group = hlGroup,
+          hl_mode = hlMode,
+          right_gravity = true,
+          priority = type(priority) == 'numbers' and math.min(priority, 4096) or 4096
     })
   end
 end


### PR DESCRIPTION
For now,  coc.nvim use Vimscript to drive highlighting, but Vimscript is slow enough. After opening https://github.com/tree-sitter/tree-sitter-javascript/blob/936d976a782e75395d9b1c8c7c7bf4ba6fe0d86b/src/parser.c#L70311, coc.nvim makes neovim lagging.

The bottleneck is in https://github.com/neoclide/coc.nvim/blob/488d6ae762f905f58a362294bab0af2150d0c399/autoload/coc/highlight.vim#L737-L743

TBH, I hope coc.nvim can hug the Lua.