### PR TITLE
Improve readibility of readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,37 +262,30 @@ vim.opt.updatetime = 300
 -- diagnostics appear/become resolved.
 vim.opt.signcolumn = "yes"
 
-
+local keyset = vim.keymap.set
 -- Auto complete
 function _G.check_back_space()
     local col = vim.fn.col('.') - 1
     return col == 0 or vim.fn.getline('.'):sub(col, col):match('%s')
 end
 
-local opts = {silent = true, noremap = true, expr = true}
-
 -- Use tab for trigger completion with characters ahead and navigate.
 -- NOTE: There's always complete item selected by default, you may want to enable
 -- no select by `"suggest.noselect": true` in your configuration file.
 -- NOTE: Use command ':verbose imap <tab>' to make sure tab is not mapped by
 -- other plugin before putting this into your config.
-vim.api.nvim_set_keymap("i", "<TAB>",
-                        'coc#pum#visible() ? coc#pum#next(1) : v:lua.check_back_space() ? "<TAB>" : coc#refresh()', opts)
-vim.api.nvim_set_keymap("i", "<S-TAB>",
-                        [[coc#pum#visible() ? coc#pum#prev(1) : "\<C-h>"]], opts)
+local opts = {silent = true, noremap = true, expr = true}
+keyset("i", "<TAB>", 'coc#pum#visible() ? coc#pum#next(1) : v:lua.check_back_space() ? "<TAB>" : coc#refresh()', opts)
+keyset("i", "<S-TAB>", [[coc#pum#visible() ? coc#pum#prev(1) : "\<C-h>"]], opts)
 
 -- Make <CR> to accept selected completion item or notify coc.nvim to format
 -- <C-g>u breaks current undo, please make your own choice.
-vim.api.nvim_set_keymap("i", "<cr>",
-                        [[coc#pum#visible() ? coc#pum#confirm() : "\<C-g>u\<CR>\<c-r>=coc#on_enter()\<CR>"]], opts)
+keyset("i", "<cr>", [[coc#pum#visible() ? coc#pum#confirm() : "\<C-g>u\<CR>\<c-r>=coc#on_enter()\<CR>"]], opts)
 
-
-local keyset = vim.keymap.set
 -- Use <c-j> to trigger snippets
 keyset("i", "<c-j>", "<Plug>(coc-snippets-expand-jump)")
 -- Use <c-space> to trigger completion.
 keyset("i", "<c-space>", "coc#refresh()", {silent = true, expr = true})
-
 
 -- Use `[g` and `]g` to navigate diagnostics
 -- Use `:CocDiagnostics` to get all diagnostics of current buffer in location list.


### PR DESCRIPTION
- use `vim.keymap.set()` to replace `vim.api.nvim_set_keymap()`
	- thanks to [this commit](https://github.com/neovim/neovim/commit/6d41f65aa45f10a93ad476db01413abaac21f27d), `vim.keymap.set` is higher level than `vim.api.nvim_set_keymap`.
	- One obvious benefit is that we can direct call lua function in `vim.keymap.set`
- adjust some position of code