### PR TITLE
chore(doc): Backspace same as README

### DIFF
--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -552,7 +552,7 @@ key-mappings when your key-mappings not work.
 
 Use <tab> and <S-tab> to navigate completion list: >
 
-  function! CheckBackSpace() abort
+  function! CheckBackspace() abort
     let col = col('.') - 1
     return !col || getline('.')[col - 1]  =~ '\s'
   endfunction
@@ -560,7 +560,7 @@ Use <tab> and <S-tab> to navigate completion list: >
   " Insert <tab> when previous text is space, refresh completion if not.
   inoremap <silent><expr> <TAB>
 	\ coc#pum#visible() ? coc#pum#next(1):
-	\ CheckBackSpace() ? "\<Tab>" :
+	\ CheckBackspace() ? "\<Tab>" :
 	\ coc#refresh()
   inoremap <expr><S-TAB> coc#pum#visible() ? coc#pum#prev(1) : "\<C-h>"
 
@@ -589,10 +589,10 @@ like VSCode: >
     \ coc#pum#visible() ? coc#_select_confirm() :
     \ coc#expandableOrJumpable() ?
     \ "\<C-r>=coc#rpc#request('doKeymap', ['snippets-expand-jump',''])\<CR>" :
-    \ CheckBackSpace() ? "\<TAB>" :
+    \ CheckBackspace() ? "\<TAB>" :
     \ coc#refresh()
 
-  function! CheckBackSpace() abort
+  function! CheckBackspace() abort
     let col = col('.') - 1
     return !col || getline('.')[col - 1]  =~# '\s'
   endfunction


### PR DESCRIPTION
prefer to Backspace cause it's a proper noun