### PR TITLE
feat(configuration): Add display config to inlayHints

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -1141,6 +1141,12 @@
       "default": true,
       "description": "Enable inlay hints for parameters."
     },
+    "inlayHint.display": {
+      "type": "boolean",
+      "scope": "language-overridable",
+      "default": true,
+      "description": "Display inlay hints."
+    },
     "inlayHint.filetypes": {
       "type": ["array", "null"],
       "scope": "application",

--- a/doc/coc-config.txt
+++ b/doc/coc-config.txt
@@ -532,6 +532,12 @@ InlayHint~
 
 	Scope: `language-overridable`, default: `true`
 
+"inlayHint.display"					coc-config-inlayHint-display
+
+	Display inlay hints. Toggle with :CocCommand document.toggleInlayHint
+
+	Scope: `language-overridable`, default: true
+
 "inlayHint.parameterSeparator"				*coc-config-inlayHint-parameterSeparator*
 
 	Separator for parameter inlay hint, neovim only.


### PR DESCRIPTION
This controls if inlayHints should be displayed enabled by default.
Allowing you to have inlay hints enabled but not displayed by default.
