### PR TITLE
fix(README): reverts #4270 and applies the correct fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ local keyset = vim.keymap.set
 -- Auto complete
 function _G.check_back_space()
     local col = vim.fn.col('.') - 1
-    return col ~= 0 or vim.fn.getline('.'):sub(col, col):match('%s')
+    return col == 0 or vim.fn.getline('.'):sub(col, col):match('%s') ~= nil
 end
 
 -- Use tab for trigger completion with characters ahead and navigate.


### PR DESCRIPTION
The change I introduced in #4270 was not correct. It made it so that `<TAB>` worked anywhere on a line but not at the beginning of the line. This reverts that change and applies the correct fix.

The difference between the vimscript solution and the Lua one is that vimscript `=~#` returns a `bool` while Lua's `match` returns [the captures from the pattern](http://www.lua.org/manual/5.4/manual.html#6.4) or `fail` which seems to get converted into `nil` somewhere.