### PR TITLE
make tagfunc cmds silent

### DIFF
--- a/src/handler/locations.ts
+++ b/src/handler/locations.ts
@@ -124,7 +124,7 @@ export default class LocationsHandler {
       const filename = parsedURI.scheme == 'file' ? parsedURI.fsPath : parsedURI.toString()
       return {
         name: word,
-        cmd: `keepjumps ${location.range.start.line + 1} | normal ${location.range.start.character + 1}|`,
+        cmd: `silent keepjumps ${location.range.start.line + 1} | normal ${location.range.start.character + 1}|`,
         filename,
       }
     })


### PR DESCRIPTION
previously, the commands generated by the CoC tagfunc produced output that caused the press-enter dialog to appear when selecting from multiple options with g<C-]>. make the commands silent so that this doesn't happen.

the commands themselves are still displayed in the g<C-]> dialog when there are multiple options, which may potentially confuse a user. a better choice might be to replace cmd with the exact string that matches the tag, like the native tagfunc does.