### PR TITLE
feat(list): avoid highlight colorcolumn in list window

### DIFF
--- a/autoload/coc/list.vim
+++ b/autoload/coc/list.vim
@@ -78,6 +78,7 @@ function! coc#list#create(position, height, name, numberSelect)
     setl nonumber
     setl norelativenumber
   endif
+  setl colorcolumn=""
   return [bufnr('%'), win_getid(), tabpagenr()]
 endfunction
 


### PR DESCRIPTION
We don't need to show colorcolumn in list window.