### PR TITLE
Do not auto-insert Class snippets on completion item scroll

### DIFF
--- a/src/completion/util.ts
+++ b/src/completion/util.ts
@@ -288,7 +288,7 @@ function toValidWord(snippet: string, excludes: number[]): string {
 }
 
 function snippetToWord(text: string, kind: CompletionItemKind | undefined): string {
-  if (kind === CompletionItemKind.Function || kind === CompletionItemKind.Method) {
+  if (kind === CompletionItemKind.Function || kind === CompletionItemKind.Method || kind === CompletionItemKind.Class) {
     text = text.replace(/\(.+/, '')
   }
   if (!text.includes(DollarSign)) return text


### PR DESCRIPTION
Currently, class names have their snippets automatically inserted when scrolling through the popup menu. In many languages (Python in particular), class names can be directly called (their constructor / `__init__` method is called under the hood). For this reason, I suggest that we treat class CompletionItemKind names similarly to functions and methods.

This PR resolves the issue.

## GIF of weird completion behavior

![gif-for-coc](https://user-images.githubusercontent.com/3723671/206556006-6ed171d5-e1db-4cd0-9975-734988d49f98.gif)