### PR TITLE
fix(select_and_confirm): return ''

### DIFF
--- a/autoload/coc/pum.vim
+++ b/autoload/coc/pum.vim
@@ -77,6 +77,7 @@ function! coc#pum#select_confirm() abort
     endif
     call coc#pum#close('confirm')
   endif
+  return ''
 endfunction
 
 function! coc#pum#_close() abort


### PR DESCRIPTION
```vim
inoremap <silent><expr> <CR> coc#pum#visible()
      \? coc#_select_confirm()
      \: "\<C-g>u\<CR>\<c-r>=coc#on_enter()\<CR>"

```

fix add `0` to the end of completion item.

<img width="330" alt="image" src="https://user-images.githubusercontent.com/5492542/207272640-7b0cbe67-2be1-41bf-9618-e1e9084b3f11.png">
