### PR TITLE
feat(extension): prompt to install recommend extensions

### DIFF
--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -80,6 +80,7 @@ export class Extensions {
     await this.manager.activateExtensions()
     let names = this.states.filterGlobalExtensions(workspace.env.globalExtensions)
     void this.installExtensions(names)
+    await this.promptRecommendedExtensions()
     // check extensions need watch & install
     let config = workspace.initialConfiguration.get('coc.preferences') as any
     let interval = config.extensionUpdateCheck
@@ -89,6 +90,17 @@ export class Extensions {
       this.updateExtensions(silent).catch(e => {
         this.outputChannel.appendLine(`Error on updateExtensions ${e}`)
       })
+    }
+  }
+
+  public async promptRecommendedExtensions(): Promise<void> {
+    const recommendations = workspace.getConfiguration('extensions', workspace.workspaceFolders[0]).get<string[]>('recommendations', [])
+    const unInstalled = this.states.filterGlobalExtensions(recommendations)
+    if (unInstalled.length) {
+      const toInstalls = await window.showPickerDialog(unInstalled, 'Install recommend extensions?')
+      if (toInstalls?.length) {
+        await this.installExtensions(toInstalls)
+      }
     }
   }
 


### PR DESCRIPTION
A very minimal implementation.

`extensions.recommendations` can be set with a list of extensions' name, coc will prompt user to install or not.

How VSCode does this: https://code.visualstudio.com/docs/editor/extension-marketplace#_workspace-recommended-extensions

1. workspace only, not global
2. uses `.vscode/extensions.json` file to locate the settings, in workspace folder
3. `recommendations` for should be recommended, `unwantedRecommendations` for should not be recommended for users of this workspace

@chemzqm any suggestions? Do we need to use a separate file to save the settings? 