### PR TITLE
fix(util): detect fieltype if none

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -90,7 +90,7 @@ endfunction
 function! coc#util#path_replace_patterns() abort
   if has('win32unix') && exists('g:coc_cygqwin_path_prefixes')
     echohl WarningMsg
-    echon 'g:coc_cygqwin_path_prefixes is deprecated, use g:coc_uri_prefix_replace_patterns instead' 
+    echon 'g:coc_cygqwin_path_prefixes is deprecated, use g:coc_uri_prefix_replace_patterns instead'
     echohl None
     return g:coc_cygqwin_path_prefixes
   endif
@@ -482,6 +482,7 @@ endfunction
 
 function! coc#util#get_bufoptions(bufnr, max) abort
   if !bufloaded(a:bufnr) | return v:null | endif
+  if &filetype ==# '' | filetype detect | endif
   let bufname = bufname(a:bufnr)
   let buftype = getbufvar(a:bufnr, '&buftype')
   let size = coc#util#bufsize(a:bufnr)


### PR DESCRIPTION
`deno lsp` returns definitions like `deno:/asset/lib.es5.d.ts`, coc-deno will register `provideTextDocumentContent` to fetch and return content, coc will set buf with content and fire `BufCreate` to `createDocument`.

In this case, `coc#util#get_bufoptions` buffer filetype is none, we should detect it.