### PR TITLE
Add coc.preferences.formatOnSaveTimeout

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -566,6 +566,14 @@
       "scope": "language-overridable",
       "default": false
     },
+    "coc.preferences.formatOnSaveTimeout": {
+      "type": "integer",
+      "scope": "language-overridable",
+      "description": "How long before the format command run on save times out.",
+      "default": 500,
+      "minimum": 200,
+      "maximum": 5000
+    },
     "coc.preferences.formatOnSaveFiletypes": {
       "type": ["null", "array"],
       "scope": "resource",

--- a/doc/coc-config.txt
+++ b/doc/coc-config.txt
@@ -1566,6 +1566,12 @@ Preferences~
 
 	Scope: `language-overridable`, default: `false`
 
+"coc.preferences.formatOnSaveTimeout"			*coc-preferences-formatOnSaveTimeout*
+
+	How long before the format command run on save will time out.
+
+	Scope: `language-overridable`, default: `200`
+
 "coc.preferences.formatOnType"				*coc-preferences-formatOnType*
 
 	Set to true to enable formatting on typing

--- a/src/handler/format.ts
+++ b/src/handler/format.ts
@@ -45,13 +45,18 @@ export default class FormatHandler {
           }
           let options = await workspace.getFormatOptions(event.document.uri)
           let tokenSource = new CancellationTokenSource()
+          let config = workspace.getConfiguration('coc.preferences', {
+            uri: event.document.uri, languageId:
+              event.document.languageId
+          })
+          let formatOnSaveTimeout = config.get<number>('formatOnSaveTimeout', 500)
           let timer: NodeJS.Timer
           const tp = new Promise<undefined>(c => {
             timer = setTimeout(() => {
-              logger.warn(`Format on save ${event.document.uri} timeout after 0.5s`)
+              logger.warn(`Attempt to format ${event.document.uri} on save timed out after ${formatOnSaveTimeout}ms`)
               tokenSource.cancel()
               c(undefined)
-            }, 500)
+            }, formatOnSaveTimeout)
           })
           const provideEdits = languages.provideDocumentFormattingEdits(event.document, options, tokenSource.token)
           let textEdits = await Promise.race([tp, provideEdits])


### PR DESCRIPTION
If `formatOnSave` is enabled, and the format command takes longer than 500ms to run, it will time out and the file will not be formatted. Add a way to configure the timeout to address slow linters. (This is a companion change to `coc.preferences.willSaveHandlerTimeout`.)