### PR TITLE
fix(util): check $XDG_CONFIG_HOME before use as data home

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -536,7 +536,7 @@ function! coc#util#get_data_home()
   if !empty(get(g:, 'coc_data_home', ''))
     let dir = resolve(expand(g:coc_data_home))
   else
-    if exists('$XDG_CONFIG_HOME')
+    if exists('$XDG_CONFIG_HOME') && isdirectory(resolve($XDG_CONFIG_HOME))
       let dir = resolve($XDG_CONFIG_HOME."/coc")
     else
       if s:is_win


### PR DESCRIPTION
https://github.com/neoclide/coc.nvim/issues/4491

`$XDG_CONFIG_HOME` exists but invalid, don't use it as data home.