### PR TITLE
fix(semanticTokens): make indexing of highlight groups more consistent

### DIFF
--- a/src/handler/semanticTokens/index.ts
+++ b/src/handler/semanticTokens/index.ts
@@ -12,7 +12,7 @@ import type { Disposable } from '../../util/protocol'
 import { toErrorText, toText, upperFirst } from '../../util/string'
 import window from '../../window'
 import workspace from '../../workspace'
-import SemanticTokensBuffer, { HLGROUP_PREFIX, NAMESPACE, StaticConfig } from './buffer'
+import SemanticTokensBuffer, { HLGROUP_PREFIX, NAMESPACE, StaticConfig, toHighlightPart } from './buffer'
 const headGroup = 'Statement'
 
 function getFiletypes(): string[] {
@@ -215,7 +215,7 @@ export default class SemanticTokens {
       let legend = languages.getLegend(doc.textDocument) ?? languages.getLegend(doc.textDocument, true)
       if (legend.tokenTypes.length) {
         for (const t of [...new Set(legend.tokenTypes)]) {
-          let text = HLGROUP_PREFIX + upperFirst(t)
+          let text = HLGROUP_PREFIX + toHighlightPart(t)
           hl.addTexts([{ text: '-', hlGroup: 'Comment' }, { text: ' ' }, { text, hlGroup: text }])
         }
         hl.addLine('')
@@ -227,7 +227,7 @@ export default class SemanticTokens {
       hl.addLine('')
       if (legend.tokenModifiers.length) {
         for (const t of [...new Set(legend.tokenModifiers)]) {
-          let text = HLGROUP_PREFIX + upperFirst(t)
+          let text = HLGROUP_PREFIX + toHighlightPart(t)
           hl.addTexts([{ text: '-', hlGroup: 'Comment' }, { text: ' ' }, { text, hlGroup: text }])
         }
         hl.addLine('')


### PR DESCRIPTION
Yeah, remember #4392? Turns out you forgot to change `index.ts` so when you call `semanticTokens.checkCurrent` the issue persists.
