### PR TITLE
fix bug: patchLine, byte aligned

### DIFF
--- a/src/util/diff.ts
+++ b/src/util/diff.ts
@@ -56,7 +56,7 @@ export function diffLines(oldLines: ReadonlyArray<string>, newLines: ReadonlyArr
 export function patchLine(from: string, to: string, fill = ' '): string {
   if (from == to) return to
   let idx = to.indexOf(from)
-  if (idx !== -1) return fill.repeat(idx) + from
+  if (idx !== -1) return fill.repeat(byteLength(to.substring(0, idx))) + from
   let result = fastDiff(from, to)
   let str = ''
   for (let item of result) {


### PR DESCRIPTION
modify function `patchLine`, let it filled character align by byte, avoid it causing bug at fuzzy match highlights like this:

<img width="587" alt="image" src="https://user-images.githubusercontent.com/907942/220004464-2b7665a1-4177-421d-ab2b-b63f7c9f8927.png">