### PR TITLE
feat(core): don't resolve root for readonly file

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -489,6 +489,7 @@ function! coc#util#get_bufoptions(bufnr, max) abort
         \ 'variables': coc#util#variables(a:bufnr),
         \ 'filetype': getbufvar(a:bufnr, '&filetype'),
         \ 'lisp': getbufvar(a:bufnr, '&lisp'),
+        \ 'readonly': getbufvar(a:bufnr, '&readonly'),
         \ 'iskeyword': getbufvar(a:bufnr, '&iskeyword'),
         \ 'changedtick': getbufvar(a:bufnr, 'changedtick'),
         \ 'fullpath': empty(bufname) ? '' : fnamemodify(bufname, ':p'),

--- a/src/core/workspaceFolder.ts
+++ b/src/core/workspaceFolder.ts
@@ -153,7 +153,7 @@ export default class WorkspaceFolderController {
   }
 
   public resolveRoot(document: Document, cwd: string, fireEvent: boolean, expand: ((input: string) => string)): string | null {
-    if (document.buftype !== '' || document.schema !== 'file') return null
+    if (document.buftype !== '' || document.schema !== 'file' || document.readonly === 1) return null
     let u = URI.parse(document.uri)
     let curr = this.getWorkspaceFolder(u)
     if (curr) return URI.parse(curr.uri).fsPath

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -47,6 +47,7 @@ export default class Document {
   private _winid = -1
   private _filetype: string
   private _bufname: string
+  private _readonly: number
   private _uri: string
   private _changedtick: number
   private variables: { [key: string]: VimValue }
@@ -107,6 +108,10 @@ export default class Document {
 
   public get bufname(): string {
     return this._bufname
+  }
+
+  public get readonly(): number {
+    return this._readonly
   }
 
   public get filetype(): string {
@@ -195,6 +200,7 @@ export default class Document {
     this._bufname = opts.bufname
     this._previewwindow = !!opts.previewwindow
     this._winid = opts.winid
+    this._readonly = opts.readonly
     this.variables = toObject(opts.variables)
     this._changedtick = opts.changedtick
     this.eol = opts.eol == 1

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,7 @@ export interface BufferOption {
   readonly filetype: string
   readonly iskeyword: string
   readonly lisp: number
+  readonly readonly: number
   readonly changedtick: number
   readonly previewwindow: number
 }


### PR DESCRIPTION
For example you're editing a rust file, `jumpDefinition` to std lib like `/opt/homebrew/Cellar/rust/1.68.0/lib/rustlib/src/rust/library/std/src/alloc.rs`, coc opens this document, will resolve root for it, then `didChangeWorkspaceFolders` notification to language server, this made the language server try to index and analyze the std libs. The std libs should be added to workspace in `didChangeWorkspaceFolders`.

This patch may not be a complete solution, for example rust std file is readonly, but go's not

`&readonly` of  `/opt/homebrew/Cellar/rust/1.68.0/lib/rustlib/src/rust/library/std/src/alloc.rs` is 1

`&readonly` of `/opt/homebrew/Cellar/go/1.20.2/libexec/src/context/context.go` is 0

Maybe a better way to detect std files and prevent coc to resolve root.