### PR TITLE
fix(api): Fix Buffer.getVar() for non-current buffer

### DIFF
--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -602,7 +602,7 @@ endfunction
 
 function! s:funcs.buf_get_var(bufnr, name)
   call s:check_bufnr(a:bufnr)
-  if !has_key(b:, a:name)
+  if !has_key(getbufvar(a:bufnr, ''), a:name)
     throw 'Key not found: '.a:name
   endif
   return getbufvar(a:bufnr, a:name)

--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -616,11 +616,8 @@ endfunction
 
 function! s:funcs.buf_del_var(bufnr, name)
   call s:check_bufnr(a:bufnr)
-  if a:bufnr == bufnr('%')
-    execute 'unlet! b:'.a:name
-  else
-    call s:buf_execute(a:bufnr, ['unlet! b:'.a:name])
-  endif
+  let bufvars = getbufvar(a:bufnr, '')
+  call remove(bufvars, a:name)
   return v:null
 endfunction
 

--- a/src/__tests__/vim.test.ts
+++ b/src/__tests__/vim.test.ts
@@ -462,6 +462,15 @@ describe('Buffer API', () => {
     buffer.deleteVar('foo')
     curr = await buffer.getVar('foo')
     expect(curr).toBeNull()
+
+    // another non-current buffer
+    const buf2 = await nvim.createNewBuffer()
+    await buf2.setVar('foo', 'qux', false)
+    let curr2 = await buf2.getVar('foo')
+    expect(curr2).toBe('qux')
+    buf2.deleteVar('foo')
+    curr = await buf2.getVar('foo')
+    expect(curr).toBeNull()
   })
 })
 


### PR DESCRIPTION
Fix Buffer.getVar() on vim.

Related issue: https://github.com/weirongxu/coc-explorer/issues/563