### PR TITLE
fix(util): properly escape breakat

### DIFF
--- a/autoload/coc/string.vim
+++ b/autoload/coc/string.vim
@@ -96,7 +96,7 @@ endfunction
 " Used when 'wrap' and 'linebreak' is enabled
 function! coc#string#content_height(lines, width) abort
   let len = 0
-  let pattern = empty(&breakat) ? '.\zs' : '['.substitute(&breakat, '\([\[\]]\)', '\\\1', 'g').']\zs'
+  let pattern = empty(&breakat) ? '.\zs' : '['.substitute(&breakat, '\([\[\]\-]\)', '\\\1', 'g').']\zs'
   for line in a:lines
     if strwidth(line) <= a:width
       let len += 1


### PR DESCRIPTION
In `coc#string#content_height`, coc uses the `breakat` option to determine where to break a line when it's too long. However, the option value is not properly escaped.

For example, `set breakat=\ !@-+;:,./?` can lead to `request error on "nvim_call_function" - Vim(for):E944: Reverse range in character class` when lines need to be broken. In this case, the generated `pattern` is `[ !@-+;:,./?]\zs` where `@-+` is a "reverse range." The fix is to escape `-` as well.