### PR TITLE
CocStart function added to readme before CocInstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Checkout [Install
 coc.nvim](https://github.com/neoclide/coc.nvim/wiki/Install-coc.nvim) for
 more info.
 
+Start the plugin before you can install extension:
+
+    :CocStart
+
+
 You **have to** install coc extensions or configure language servers for
 LSP support.
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,9 @@ Checkout [Install
 coc.nvim](https://github.com/neoclide/coc.nvim/wiki/Install-coc.nvim) for
 more info.
 
-Start the plugin before you can install extension:
+Start the plugin before you can install extensions:
 
     :CocStart
-
 
 You **have to** install coc extensions or configure language servers for
 LSP support.


### PR DESCRIPTION
I felt the need to specify that we need to do CocStart before being able to use any functions so I added it to the readme