### PR TITLE
Remove outdated keybinding from lua conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,8 +293,6 @@ keyset("i", "<S-TAB>", [[coc#pum#visible() ? coc#pum#prev(1) : "\<C-h>"]], opts)
 -- <C-g>u breaks current undo, please make your own choice
 keyset("i", "<cr>", [[coc#pum#visible() ? coc#pum#confirm() : "\<C-g>u\<CR>\<c-r>=coc#on_enter()\<CR>"]], opts)
 
--- Use <c-j> to trigger snippets
-keyset("i", "<c-j>", "<Plug>(coc-snippets-expand-jump)")
 -- Use <c-space> to trigger completion
 keyset("i", "<c-space>", "coc#refresh()", {silent = true, expr = true})
 


### PR DESCRIPTION
The binding for "coc-snippets-expand-jump" don't need to be set manually anymore. These bindings are set up automatically when snippets are available now-a-days.