### PR TITLE
fix(list): scrolling float preview for vim

### DIFF
--- a/autoload/coc/list.vim
+++ b/autoload/coc/list.vim
@@ -185,11 +185,22 @@ function! coc#list#get_preview(...) abort
   return -1
 endfunction
 
-function! coc#list#scroll_preview(dir) abort
+function! coc#list#scroll_preview(dir, floatPreview) abort
   let winid = coc#list#get_preview()
   if winid == -1
     return
   endif
+  if a:floatPreview
+    let forward = a:dir ==# 'up' ? 0 : 1
+    let amount = 1
+    if s:is_vim
+      call coc#float#scroll_win(winid, forward, amount)
+    else
+      call timer_start(0, { -> coc#float#scroll_win(winid, forward, amount)})
+    endif
+    return
+  endif
+
   if exists('*win_execute')
     call win_execute(winid, "normal! ".(a:dir ==# 'up' ? "\<C-u>" : "\<C-d>"))
   else

--- a/src/list/mappings.ts
+++ b/src/list/mappings.ts
@@ -301,9 +301,10 @@ export default class Mappings {
   }
 
   private scrollPreview(dir: 'up' | 'down'): void {
+    const floatPreview = listConfiguration.get<boolean>('floatPreview', false)
     let { nvim } = this
     nvim.pauseNotification()
-    nvim.call('coc#list#scroll_preview', [dir], true)
+    nvim.call('coc#list#scroll_preview', [dir, floatPreview], true)
     nvim.command('redraw', true)
     nvim.resumeNotification(false, true)
   }


### PR DESCRIPTION
Closes #4643

use `coc#float#scroll_win` to scroll float/popup window, same as hover