### PR TITLE
feat(inlayHint): inline display for nvim

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -1304,29 +1304,11 @@
         "type": "string"
       }
     },
-    "inlayHint.parameterSeparator": {
-      "type": "string",
-      "scope": "language-overridable",
-      "default": "",
-      "description": "Separator for parameter inlay hint, neovim only."
-    },
     "inlayHint.refreshOnInsertMode": {
       "type": "boolean",
       "default": false,
       "scope": "language-overridable",
       "description": "Refresh inlayHints on insert mode."
-    },
-    "inlayHint.subSeparator": {
-      "type": "string",
-      "scope": "language-overridable",
-      "default": " ",
-      "description": "Separator for chained inlay hints, neovim only."
-    },
-    "inlayHint.typeSeparator": {
-      "type": "string",
-      "scope": "language-overridable",
-      "default": "",
-      "description": "Separator for type inlay hint, neovim only."
     },
     "links.enable": {
       "type": "boolean",

--- a/doc/coc-config.txt
+++ b/doc/coc-config.txt
@@ -539,29 +539,11 @@ InlayHint~
 
 	Scope: `language-overridable`, default: `true`
 
-"inlayHint.parameterSeparator"				*coc-config-inlayHint-parameterSeparator*
-
-	Separator for parameter inlay hint, neovim only.
-
-	Scope: `language-overridable`, default: `""`
-
 "inlayHint.refreshOnInsertMode"				*coc-config-inlayHint-refreshOnInsertMode*
 
 	Refresh inlayHints on insert mode.
 
 	Scope: `language-overridable`, default: `false`
-
-"inlayHint.subSeparator"				*coc-config-inlayHint-subSeparator*
-
-	Separator for chained inlay hints, neovim only.
-
-	Scope: `language-overridable`, default: `" "`
-
-"inlayHint.typeSeparator"				*coc-config-inlayHint-typeSeparator*
-
-	Separator for type inlay hint, neovim only.
-
-	Scope: `language-overridable`, default: `""`
 
 ------------------------------------------------------------------------------
 Links~

--- a/src/__tests__/handler/inlayHint.test.ts
+++ b/src/__tests__/handler/inlayHint.test.ts
@@ -226,17 +226,6 @@ describe('InlayHint', () => {
       let markers = await doc.buffer.getExtMarks(ns, 0, -1, { details: true })
       expect(markers.length).toBe(1)
     })
-
-    it('should use custom subseparator', async () => {
-      helper.updateConfiguration('inlayHint.subSeparator', '|')
-      let doc = await helper.createDocument()
-      let disposable = await registerProvider('foo bar')
-      disposables.push(disposable)
-      await waitRefresh(doc.bufnr)
-      let markers = await doc.buffer.getExtMarks(ns, 0, -1, { details: true })
-      let virt_text = markers[0][3].virt_text
-      expect(virt_text[1]).toEqual(['|', 'CocInlayHintType'])
-    })
   })
 
   describe('toggle inlayHint', () => {


### PR DESCRIPTION
needs https://github.com/neovim/neovim/pull/20130

Next:

- [x] remove the separator, this is a breaking change, but we don't needs separator for inline inlayHint, same as vim
    - inlayHint.subSeparator
    - inlayHint.typeSeparator
    - inlayHint.parameterSeparator
- [x] clean docs of separator
- [x] tests // The CI runs with nvim 0.9.0, which didn't support inline virt, works on my local

Do we need to support both `inline` for nvim 0.10.0+ and `eol` for nvim 0.9.0-? I do like only `inline`, for nvim 0.9.0 and before, no inlayHint