### PR TITLE
Fix the issue of opening an empty buffer in the help action of the :CocList extensions

### DIFF
--- a/src/list/source/extensions.ts
+++ b/src/list/source/extensions.ts
@@ -69,7 +69,7 @@ export default class ExtensionList extends BasicList {
       let { root } = item.data
       let files = fs.readdirSync(root, { encoding: 'utf8' })
       let file = files.find(f => /^readme/i.test(f))
-      if (file) await workspace.jumpTo(URI.file(file))
+      if (file) await workspace.jumpTo(URI.file(path.join(root, file)))
     })
 
     this.addAction('reload', async item => {


### PR DESCRIPTION
## Before

The buffer is empty due to the file not existing.  `file:///Readme.md`

**Log**:

```
2023-05-24T17:35:46.639 DEBUG (pid:44710) [core-documents] - buffer created 6 true file:///Readme.md
```

## After

**Log**:

```
2023-05-24T17:36:41.713 DEBUG (pid:44813) [core-documents] - buffer created 7 true file:///Users/yaegassy/.config/coc/extensions/node_modules/coc-tsserver/Readme.md
```