### PR TITLE
Remove <c-j> in example lua config

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,8 +293,6 @@ keyset("i", "<S-TAB>", [[coc#pum#visible() ? coc#pum#prev(1) : "\<C-h>"]], opts)
 -- <C-g>u breaks current undo, please make your own choice
 keyset("i", "<cr>", [[coc#pum#visible() ? coc#pum#confirm() : "\<C-g>u\<CR>\<c-r>=coc#on_enter()\<CR>"]], opts)
 
--- Use <c-j> to trigger snippets
-keyset("i", "<c-j>", "<Plug>(coc-snippets-expand-jump)")
 -- Use <c-space> to trigger completion
 keyset("i", "<c-space>", "coc#refresh()", {silent = true, expr = true})
 


### PR DESCRIPTION
Not sure why this config is in there. It's not in the vim script version and it literally just types `<Plug>(coc-snippets-expand-jump)`  on my machine. Remove it restore the snippet jump function since `c-j` is already the default.