### PR TITLE
docs(coc.txt): Correct spelling resutl to result

### DIFF
--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -2376,7 +2376,7 @@ CocActionAsync({action}, [...{args}, [{callback}]])
 
 	When callback function exists as the last argument, the callback
 	function is called with `error` string as the first argument and
-	`resutl` as the second argument.  When no callback exists, error
+	`result` as the second argument.  When no callback exists, error
 	message would be echoed.
 
 	Checkout |coc-actions| for available actions.


### PR DESCRIPTION
docs(coc.txt): Correct spelling resutl to result

Correct spelling error in doc/coc.txt, Line: 2379<br>
resutl was corrected to result

```text
When callback function exists as the last argument, the callback
function is called with `error` string as the first argument and
  -	`resutl` as the second argument.  When no callback exists, error
  +	`result` as the second argument.  When no callback exists, error
message would be echoed.

Chceckout |coc-actions| for available actions.
```
Using grep I found no other reference to the word resutl in the projects structure. I'm not knowledgeable enough to know what is going on with the CocActionAsync function so please let me know if their are any problems with this PR. I've only made one other PR to an actuall project, Vim, the others being repositories for first time users. Thanks for the completion plugin and opportunity to contribute.

cheers;
itsf4llofstars