### PR TITLE
fix: ls provider's score is equal to the default one

### DIFF
--- a/src/__tests__/modules/workspace.test.ts
+++ b/src/__tests__/modules/workspace.test.ts
@@ -292,6 +292,7 @@ describe('workspace methods', () => {
     expect(workspace.match([{ scheme: 'file' }], doc.textDocument)).toBe(5)
     expect(workspace.match([{ scheme: 'term' }], doc.textDocument)).toBe(0)
     expect(workspace.match([{ language: 'xml' }, { scheme: 'file' }], doc.textDocument)).toBe(10)
+    expect(workspace.match([{ language: 'xml', scheme: 'file', pattern: '**/*.xml' }], doc.textDocument)).toBe(10)
   })
 
   it('should handle will save event', async () => {

--- a/src/core/funcs.ts
+++ b/src/core/funcs.ts
@@ -140,7 +140,7 @@ export function score(selector: DocumentSelector | DocumentFilter | string, uri:
       let p = caseInsensitive ? pattern.toLowerCase() : pattern
       let f = caseInsensitive ? u.fsPath.toLowerCase() : u.fsPath
       if (p === f || minimatch(f, p, { dot: true })) {
-        ret = 5
+        ret = Math.max(ret, 5)
       } else {
         return 0
       }


### PR DESCRIPTION
For now, ls provider's score will be equal to the default one if ls provider's documentSelector has pattern. For example, a ls registers capability `textDocument/documentHighlight` with documentSelector `{'language': 'cs', 'scheme': 'file', 'pattern': '**/*.cs'}`, it will get score 5, which is equal to the default one with documentSelector '*', even if the language id has matched. Since the capability is registered later than the default one, DocumentHighlightManager will only use the default one to provide highlight, which is not expected.

If all of language, scheme, and pattern match, we should return the highest score of them, instead of the last score.