### PR TITLE
fix(hover): rm hover validation

### DIFF
--- a/src/provider/hoverManager.ts
+++ b/src/provider/hoverManager.ts
@@ -26,7 +26,7 @@ export default class HoverManager extends Manager<HoverProvider> {
     let hovers: Hover[] = []
     let results = await Promise.allSettled(items.map(item => {
       return Promise.resolve(item.provider.provideHover(document, position, token)).then(hover => {
-        if (!Hover.is(hover)) return
+        if (!hover) return
         if (hovers.findIndex(o => equals(o.contents, hover.contents)) == -1) {
           hovers.push(hover)
         }


### PR DESCRIPTION
https://github.com/neoclide/coc.nvim/issues/4755, some LS responses with invalid `hover.range`, remove this validation doesn't break hover actions:

1. hover.range is only used to highlight the hover object, this will be checked later
2. previewHover will check hover.contents