### PR TITLE
fix(bufferSync): null thisArg

### DIFF
--- a/src/model/bufferSync.ts
+++ b/src/model/bufferSync.ts
@@ -3,7 +3,6 @@ import type Documents from '../core/documents'
 import events from '../events'
 import { DidChangeTextDocumentParams } from '../types'
 import { disposeAll } from '../util'
-import { isVim } from '../util/constants'
 import { Disposable } from '../util/protocol'
 import type Document from './document'
 
@@ -32,7 +31,7 @@ export default class BufferSync<T extends SyncItem> {
     documents.onDidCloseDocument(e => {
       this.delete(e.bufnr)
     }, null, disposables)
-    events.on('LinesChanged', this.onTextChange, this, disposables)
+    events.on('LinesChanged', this.onTextChange, null, disposables)
   }
 
   private onTextChange(bufnr: number): void {


### PR DESCRIPTION
closes #4778

@chemzqm typo? I didn't get the use of `thisArg`, when this must set? Why this effect vim only