### PR TITLE
fix(native): checkComplete for file/buffer/around

### DIFF
--- a/src/completion/native/around.ts
+++ b/src/completion/native/around.ts
@@ -12,6 +12,8 @@ export class Around extends Source {
   }
 
   public async doComplete(opt: CompleteOption, token: CancellationToken): Promise<CompleteResult<ExtendedCompleteItem>> {
+    const shouldRun = await this.checkComplete(opt)
+    if (!shouldRun) return null
     let { bufnr, input, word, linenr, triggerForInComplete } = opt
     if (input.length === 0) return null
     let buf = this.keywords.getItem(bufnr)

--- a/src/completion/native/buffer.ts
+++ b/src/completion/native/buffer.ts
@@ -16,6 +16,8 @@ export class Buffer extends Source {
   }
 
   public async doComplete(opt: CompleteOption, token: CancellationToken): Promise<CompleteResult<ExtendedCompleteItem>> {
+    const shouldRun = await this.checkComplete(opt)
+    if (!shouldRun) return null
     let { bufnr, input, word, triggerForInComplete } = opt
     if (input.length === 0) return null
     await waitImmediate()

--- a/src/completion/native/file.ts
+++ b/src/completion/native/file.ts
@@ -146,6 +146,8 @@ export class File extends Source {
   }
 
   public async doComplete(opt: CompleteOption, token: CancellationToken): Promise<CompleteResult<ExtendedCompleteItem>> {
+    const shouldRun = await this.checkComplete(opt)
+    if (!shouldRun) return null
     let { filepath } = opt
     let option = this.getPathOption(opt)
     if (!option || option.startcol < opt.col) return null


### PR DESCRIPTION
otherwise, `coc.source.around.disableSyntaxes` won't work.