### PR TITLE
fix: CocTagFunc jumps to wrong position if using tabs for indentation

### DIFF
--- a/src/__tests__/handler/locations.test.ts
+++ b/src/__tests__/handler/locations.test.ts
@@ -278,10 +278,10 @@ describe('locations', () => {
       expect(res).toEqual([
         {
           name: 'foo',
-          cmd: 'silent keepjumps 3 | normal 1|',
+          cmd: 'silent keepjumps call cursor(3, 1)',
           filename: 'test://bar'
         },
-        { name: 'foo', cmd: 'silent keepjumps 2 | normal 1|', filename: '/foo' }
+        { name: 'foo', cmd: 'silent keepjumps call cursor(2, 1)', filename: '/foo' }
       ])
     })
   })

--- a/src/handler/locations.ts
+++ b/src/handler/locations.ts
@@ -136,7 +136,7 @@ export default class LocationsHandler {
       const filename = parsedURI.scheme == 'file' ? parsedURI.fsPath : parsedURI.toString()
       return {
         name: word,
-        cmd: `silent keepjumps ${location.range.start.line + 1} | normal ${location.range.start.character + 1}|`,
+        cmd: `silent keepjumps call cursor(${location.range.start.line + 1}, ${location.range.start.character + 1})`,
         filename,
       }
     })


### PR DESCRIPTION
From LSP specification, Position.character indicates the character offset on a line in a document (zero-based) [1]. However, `|` in vim will jump to screen column [2]. If the file (e.g., linux kernel source code) uses tabs for indentation, then CocTagFunc will jump to a wrong position. We can fix it by changing to use `cursor()`, whose col argument means the byte-count column.

1. https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#position
2. https://vimdoc.sourceforge.net/htmldoc/motion.html#bar