### PR TITLE
fix(codeLens): clear whole buffer on resolving

### DIFF
--- a/src/handler/codelens/buffer.ts
+++ b/src/handler/codelens/buffer.ts
@@ -175,7 +175,7 @@ export default class CodeLensBuffer implements SyncItem {
     // nvim could have extmarks exceeded last line.
     if (end == total) end = -1
     this.nvim.pauseNotification()
-    this.clear(start - 1, end)
+    this.clear()
     this.setVirtualText(codeLenses)
     this.nvim.resumeNotification(true, true)
   }


### PR DESCRIPTION
coc will resolve codeLens onChange/onMove etc, with codeLens in current visible range, then display in virtualText.

If the codeLens.position = top, and outside the current visible, coc won't clear them, and add another line in virtualText.

Clear all on resolving before setting again.

Closes https://github.com/fannheyward/coc-rust-analyzer/issues/1112