### PR TITLE
Remove floatFactory `zindex: 1`

### DIFF
--- a/src/model/floatFactory.ts
+++ b/src/model/floatFactory.ts
@@ -138,7 +138,6 @@ export default class FloatFactoryImpl implements Disposable {
       close: opts.close ? 1 : 0,
       rounded: opts.rounded ? 1 : 0,
       modes: opts.modes || ['n', 'i', 'ic', 's'],
-      zindex: 1
     }
     if (!isVim) {
       if (typeof opts.winblend === 'number') config.winblend = opts.winblend


### PR DESCRIPTION
## Problem

`FloatFactoryImpl.createPopup` [hardcodes zindex: 1](https://github.com/neoclide/coc.nvim/blob/9c3723a011e68a4e4e7a37298bd0f6c64ab59dca/src/model/floatFactory.ts#L141) which then gets passed to [coc#dialog#create_cursor_float](https://github.com/neoclide/coc.nvim/blob/9c3723a011e68a4e4e7a37298bd0f6c64ab59dca/autoload/coc/dialog.vim#L69) and afterwards to [coc#float#create_float_win](https://github.com/neoclide/coc.nvim/blob/9c3723a011e68a4e4e7a37298bd0f6c64ab59dca/autoload/coc/float.vim#L121) where it overwrites the default value of 50.

A value of 1 will not allow any other floating window to be displayed underneath as `zindex > 0`. This will for example make it impossible for documentation to be shown above the [zen-mode plugin](https://github.com/folke/zen-mode.nvim) which works with `zindex` but sets it to 40 expecting other floating windows to use the default of 50 or above.

## Solution

By removing the line which hardcodes `zindex: 1` the floating window will have a default `zindex` value of 50 according to the [neovim docs](https://neovim.io/doc/user/api.html#api-win_config) which seems more fitting.

## Open Questions

I do not understand why @chemzqm [added](https://github.com/neoclide/coc.nvim/commit/a30437e4d77bc57cc7285442ca00a9ed7d6c840f#diff-ddf466f68b3bf368ca8575ab8941285ec421b9bfa34fb7898579d2dcd5a6f3bcR143) this line. It would be interesting to know the background on this.

I am a first time contributor and honestly I am very unfamiliar with this project's source code or vim plugin development in general. I have looked for tests relevant to this setting but couldn't find any. Also I could not think of what to test regarding this change. If you have any suggestions I am happy to add some tests.