### PR TITLE
FIx `opts.close` for `window.showDialog`

### DIFF
--- a/src/model/dialog.ts
+++ b/src/model/dialog.ts
@@ -94,7 +94,7 @@ export class Dialog {
     let highlight = this.config.highlight || preferences.floatHighlight
     let opts: any = { maxwidth: preferences.maxWidth || 80, }
     if (title) opts.title = title
-    if (close || typeof close === 'undefined') opts.close = 1
+    opts.close = +(close ?? 1)
     if (preferences.maxHeight) opts.maxHeight = preferences.maxHeight
     if (preferences.maxWidth) opts.maxWidth = preferences.maxWidth
     if (highlight) opts.highlight = highlight


### PR DESCRIPTION
Currently if `close: false` is passed, it won't be set to `opts`.

https://github.com/neoclide/coc.nvim/blob/e10877749538a9875e359abe69974b0d0ca697ca/src/model/dialog.ts#L97

As a result, `coc#dialog#create_dialog` will consider `opts.close` not set and use `1` as a fallback.

https://github.com/neoclide/coc.nvim/blob/e10877749538a9875e359abe69974b0d0ca697ca/autoload/coc/dialog.vim#L300

This PR makes sure `opts.close = 0` is properly set.