### PR TITLE
fix: block Vim until completion resolve finishes

### DIFF
--- a/autoload/coc/pum.vim
+++ b/autoload/coc/pum.vim
@@ -65,7 +65,7 @@ function! coc#pum#close(...) abort
     endif
     call s:close_pum()
     if !get(a:, 2, 0)
-      call coc#rpc#notify('CompleteStop', [kind])
+      call coc#rpc#request('CompleteStop', [kind])
     endif
   endif
   return ''
@@ -115,7 +115,7 @@ function! coc#pum#_insert() abort
     endif
     doautocmd <nomodeline> TextChangedI
     call s:close_pum()
-    call coc#rpc#notify('CompleteStop', [''])
+    call coc#rpc#request('CompleteStop', [''])
   endif
   return ''
 endfunction

--- a/src/attach.ts
+++ b/src/attach.ts
@@ -99,7 +99,11 @@ export default (opts: Attach, requestApi = false): Plugin => {
     timing.start(method)
     try {
       events.requesting = true
-      if (method == 'CocAutocmd') {
+      if (method == 'CompleteStop') {
+        logger.trace('Event: ', method, ...args)
+        await events.fire(method, args)
+        resp.send(undefined)
+      } else if (method == 'CocAutocmd') {
         logger.trace('Request autocmd:', ...args)
         await events.fire(args[0], args.slice(1))
         resp.send(undefined)


### PR DESCRIPTION
Fixes #4823.

## What changes in this PR

- Allow `CompleteStop` as a `request` call
- Do not ignore promise in stop() and await all