### PR TITLE
chore(list): support <C-space> and <C-_> mappings

### DIFF
--- a/autoload/coc/prompt.vim
+++ b/autoload/coc/prompt.vim
@@ -29,6 +29,8 @@ let s:char_map = {
       \ "\<LeftDrag>": '<LeftDrag>',
       \ "\<LeftRelease>": '<LeftRelease>',
       \ "\<2-LeftMouse>": '<2-LeftMouse>',
+      \ "\<C-space>": '<C-space>',
+      \ "\<C-_>": '<C-_>',
       \ "\<C-a>": '<C-a>',
       \ "\<C-b>": '<C-b>',
       \ "\<C-c>": '<C-c>',

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -3711,6 +3711,8 @@ Configurations `"list.normalMappings"` and `"list.insertMappings"` are used
 for customizing the list key-mappings, example: >
 
 	"list.insertMappings": {
+		"<C-space>": "do:previewtoggle",
+		"<C-_>": "do:help"
 		"<C-r>": "do:refresh",
 		"<C-f>": "feedkeys:\\<C-f>",
 		"<C-b>": "feedkeys:\\<C-b>",

--- a/src/list/configuration.ts
+++ b/src/list/configuration.ts
@@ -23,6 +23,8 @@ export const validKeys = [
   '<LeftDrag>',
   '<LeftRelease>',
   '<2-LeftMouse>',
+  '<C-space>',
+  '<C-_>',
   '<C-a>',
   '<C-b>',
   '<C-c>',


### PR DESCRIPTION
### Changes
As described in title, this PR allows user to map two additional keys: `<C-space>` and `<C-_>` (this is equivalent to pressing `Ctrl` and `/`).

Personally, I bind `<C-space>` to toggle preview, and `<C-_>` to show help (since `/` and `?` are the same key).

### Testing
If we run `:echo nr2char(getchar())` and press `Ctrl+Space` or `Ctrl+/`, we get the relevant string output as expected.

**Question**: Is there a way to automate the above test? Or are we comfortable relying on Vim's testing:
 - `<C-space>` is also tested in Vim: [keycode_check.vim](https://github.com/vim/vim/blob/7062be13129985fe297b9a8e59c57b8f0db61b8f/src/testdir/keycode_check.vim#L75).

_Thanks again for this wonderful plugin; coc.nvim has been always been a joy to use!_