### PR TITLE
chore(list): support moving by word in prompt

### DIFF
--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -3760,6 +3760,8 @@ The mapping expression should be `command:arguments`, available commands:
 	'end'            - move cursor to end.
 	'left'           - move cursor left.
 	'right'          - move cursor right.
+	'leftword'       - move cursor left by a word.
+	'rightword'      - move cursor right by a word.
 	'deleteforward'  - remove previous character.
 	'deletebackward' - remove next character.
 	'removetail'     - remove characters afterwards.

--- a/src/__tests__/list/mappings.test.ts
+++ b/src/__tests__/list/mappings.test.ts
@@ -625,6 +625,26 @@ describe('list insert mappings', () => {
     expect(input).toBe('afc')
   })
 
+  it('should move cursor by leftword and rightword', async () => {
+    let revert = helper.updateConfiguration('list.insertMappings', {
+      '<A-b>': 'prompt:leftword',
+      '<A-f>': 'prompt:rightword',
+    })
+    await manager.start(['location'])
+    await manager.session.ui.ready
+    await helper.listInput('aaa bbb ccc') // -> aaa bbb ccc|
+    await helper.listInput('<A-b>')       // -> aaa bbb |ccc
+    await helper.listInput('<A-b>')       // -> aaa |bbb ccc
+    await helper.listInput('ddd ')        // -> aaa ddd |bbb ccc
+    await helper.listInput('<A-f>')       // -> aaa ddd bbb |ccc
+    await helper.listInput('eee ')        // -> aaa ddd bbb eee |ccc
+    expect(manager.mappings.hasUserMapping('insert', '<A-b>')).toBe(true)
+    expect(manager.mappings.hasUserMapping('insert', '<A-f>')).toBe(true)
+    let input = manager.prompt.input
+    revert()
+    expect(input).toBe('aaa ddd bbb eee ccc')
+  })
+
   it('should move cursor by <end> and <home>', async () => {
     await manager.start(['location'])
     await manager.session.ui.ready

--- a/src/list/mappings.ts
+++ b/src/list/mappings.ts
@@ -88,6 +88,12 @@ export default class Mappings {
     this.addAction('prompt:right', () => {
       prompt.moveRight()
     })
+    this.addAction('prompt:leftword', () => {
+      prompt.moveLeftWord()
+    })
+    this.addAction('prompt:rightword', () => {
+      prompt.moveRightWord()
+    })
     this.addAction('prompt:deleteforward', () => {
       prompt.onBackspace()
     })

--- a/src/list/prompt.ts
+++ b/src/list/prompt.ts
@@ -107,6 +107,28 @@ export default class Prompt {
     this.drawPrompt()
   }
 
+  public moveLeftWord(): void {
+    // Reuses logic from removeWord(), except that we only update the
+    // cursorIndex and don't actually remove the word.
+    let { cusorIndex, input } = this
+    if (cusorIndex == 0) return
+    let pre = input.slice(0, cusorIndex)
+    let remain = pre.replace(/[\w$]+([^\w$]+)?$/, '')
+    this.cusorIndex = cusorIndex - (pre.length - remain.length)
+    this.drawPrompt()
+    this._onDidChangeInput.fire(this._input)
+  }
+
+  public moveRightWord(): void {
+    let { cusorIndex, input } = this
+    if (cusorIndex == input.length) return
+    let post = input.slice(cusorIndex)
+    let nextWord = post.match(/[\w$]+ */).at(0) ?? post
+    this.cusorIndex = cusorIndex + nextWord.length
+    this.drawPrompt()
+    this._onDidChangeInput.fire(this._input)
+  }
+
   public moveToEnd(): void {
     if (this.cusorIndex == this._input.length) return
     this.cusorIndex = this._input.length


### PR DESCRIPTION
### Changes

Support moving left and right in list prompt (similar to `forward-word` and `backward-word` in [GNU Readline][gnu-readline]).

[gnu-readline]:http://git.savannah.gnu.org/cgit/readline.git/tree/doc/readline.info?id=5d4d92f221d6aac4be445bdd8cd9b48d9ac33f04#n1064

### Testing

Added unit test in `list/mappings.test.ts`.