### PR TITLE
fix(dialog): set nonumber for floating doc

### DIFF
--- a/autoload/coc/dialog.vim
+++ b/autoload/coc/dialog.vim
@@ -104,6 +104,7 @@ function! coc#dialog#create_cursor_float(winid, bufnr, lines, config) abort
   let alignTop = dimension['row'] < 0
   let winid = res[0]
   let bufnr = res[1]
+  call coc#compat#execute(winid, 'setl nonumber')
   redraw
   if has('nvim')
     call coc#float#nvim_scrollbar(winid)


### PR DESCRIPTION
Closes https://github.com/fannheyward/coc-rust-analyzer/issues/1221

Problem: coc will `syntax include @RUST syntax/rust.vim` to highlight doc floating window. If `set number` in `syntax/rust.vim`, display the number line will decrease floating width by `numberwidth`.

Better way: check floating window `&number == 1` to increase max line width by `nuw`, set to window's `width`. But we need to exec `&number` in the floating window, in this case, we didn't have floating winid created/reused, couldn't `win_execute` with floating win.

The fix: after floating win created/reused, `setl nonumber` to disable number line.