### PR TITLE
fix(model): fire onTextChange on TextChangedI

### DIFF
--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -640,7 +640,7 @@ export default class Document {
    */
   public onTextChange(event: string, change: InsertChange): void {
     if (event === 'TextChanged'
-      || (event === 'TextChangedI' && !change.insertChar)
+      || event === 'TextChangedI'
       || !this._noFetch) {
       fireLinesChanged(this.bufnr)
       this._noFetch = false


### PR DESCRIPTION
This fixes issue like https://github.com/neoclide/coc.nvim/issues/4873 on Vim, but https://github.com/neoclide/coc.nvim/blob/392264f475aea82419b493cec368b0bcf5ca40ee/src/model/document.ts#L648-L655 won't called anymore.

I've checked https://github.com/neoclide/coc.nvim/commit/930c6dc09c2c9db5d648d07033025d808283ec90, but still can't get the original logic, needs more tests.

Before this change, vim couldn't get correct lines of buffer as nvim.