### PR TITLE
feat(diagnostic): add `DiagnosticWithFileType`

### DIFF
--- a/src/diagnostic/buffer.ts
+++ b/src/diagnostic/buffer.ts
@@ -4,7 +4,7 @@ import { Diagnostic, DiagnosticSeverity, Position, TextEdit } from 'vscode-langu
 import events from '../events'
 import { SyncItem } from '../model/bufferSync'
 import Document from '../model/document'
-import { DidChangeTextDocumentParams, Documentation, FloatFactory, HighlightItem } from '../types'
+import { DiagnosticWithFileType, DidChangeTextDocumentParams, Documentation, FloatFactory, HighlightItem } from '../types'
 import { getConditionValue } from '../util'
 import { isFalsyOrEmpty } from '../util/array'
 import { lineInRange, positionInRange } from '../util/position'
@@ -317,7 +317,7 @@ export class DiagnosticBuffer implements SyncItem {
     return true
   }
 
-  public async showFloat(diagnostics: Diagnostic[], target = 'float'): Promise<boolean> {
+  public async showFloat(diagnostics: DiagnosticWithFileType[], target = 'float'): Promise<boolean> {
     if (target !== 'float') return false
     if (!floatFactory) floatFactory = window.createFloatFactory({ modes: ['n'], autoHide: true })
     if (diagnostics.length == 0) {
@@ -335,7 +335,9 @@ export class DiagnosticBuffer implements SyncItem {
     }
     diagnostics.forEach(diagnostic => {
       let filetype = 'Error'
-      if (ft === '') {
+      if (diagnostic.filetype) {
+        filetype = diagnostic.filetype
+      } else if (ft === '') {
         switch (diagnostic.severity) {
           case DiagnosticSeverity.Hint:
             filetype = 'Hint'

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ import type { Disposable, Event } from 'vscode-languageserver-protocol'
 import type { CreateFile, DeleteFile, Location, Range, RenameFile, TextDocumentEdit } from 'vscode-languageserver-types'
 import type { URI } from 'vscode-uri'
 import type RelativePattern from './model/relativePattern'
+import type { Diagnostic } from 'vscode-languageserver-types'
 
 export type { IConfigurationChangeEvent } from './configuration/types'
 
@@ -348,3 +349,12 @@ export interface DidChangeTextDocumentParams {
   readonly originalLines: ReadonlyArray<string>
 }
 // }}
+
+export interface DiagnosticWithFileType extends Diagnostic {
+  /**
+   * The `filetype` property provides the type of file associated with the diagnostic information.
+   * This information is utilized by the diagnostic buffer panel for highlighting and formatting
+   * the diagnostic messages according to the specific filetype.
+   */
+  filetype?: string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,9 @@
 'use strict'
 import type { Window } from '@chemzqm/neovim'
 import type { Disposable, Event } from 'vscode-languageserver-protocol'
-import type { CreateFile, DeleteFile, Location, Range, RenameFile, TextDocumentEdit } from 'vscode-languageserver-types'
+import type { CreateFile, DeleteFile, Diagnostic, Location, Range, RenameFile, TextDocumentEdit } from 'vscode-languageserver-types'
 import type { URI } from 'vscode-uri'
 import type RelativePattern from './model/relativePattern'
-import type { Diagnostic } from 'vscode-languageserver-types'
 
 export type { IConfigurationChangeEvent } from './configuration/types'
 


### PR DESCRIPTION
add `DiagnosticWithFileType` to support highlight diagnostic buffer

I am currently working on porting https://github.com/yoavbls/pretty-ts-errors to coc (https://github.com/hexh250786313/coc-pretty-ts-errors). It requires that the diagnostic's floating buffer supports a custom filetype to highlight and format the diagnostic information. And the PR is for this purpose.