### PR TITLE
fix(symbol): don't decrease end.line for Python

### DIFF
--- a/src/handler/symbols/index.ts
+++ b/src/handler/symbols/index.ts
@@ -158,8 +158,12 @@ export default class Symbols {
     if (inner && selectRange) {
       let { start, end } = selectRange
       let line = doc.getline(start.line + 1)
-      let endLine = doc.getline(end.line - 1)
-      selectRange = Range.create(start.line + 1, line.match(/^\s*/)[0].length, end.line - 1, endLine.length)
+      // https://github.com/neoclide/coc.nvim/issues/1847
+      // https://github.com/neoclide/coc.nvim/pull/4488#issuecomment-1409717682
+      // don't decrease end.line for python
+      let endDelta = doc.filetype === 'python' ? 0 : 1
+      let endLine = doc.getline(end.line - endDelta)
+      selectRange = Range.create(start.line + 1, line.match(/^\s*/)[0].length, end.line - endDelta, endLine.length)
     }
     if (selectRange) {
       await window.selectRange(selectRange)


### PR DESCRIPTION
Closes #1847, temporarily workaround fix, don't decrease end.line for Python

To make `coc-funcobj-a/i` to work as expected, the code should be formatted first.