### PR TITLE
fix(language-client): register DiagnosticRefreshRequest

### DIFF
--- a/src/language-client/diagnostic.ts
+++ b/src/language-client/diagnostic.ts
@@ -674,13 +674,13 @@ export class DiagnosticFeature extends TextDocumentLanguageFeature<DiagnosticOpt
 
   public initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {
     const client = this._client
-    let [id, options] = this.getRegistration(documentSelector, capabilities.diagnosticProvider)
-    if (!id || !options) return
     client.onRequest(DiagnosticRefreshRequest.type, async () => {
       for (const provider of this.getAllProviders()) {
         provider.onDidChangeDiagnosticsEmitter.fire()
       }
     })
+    let [id, options] = this.getRegistration(documentSelector, capabilities.diagnosticProvider)
+    if (!id || !options) return
     this.register({ id, registerOptions: options })
   }
 


### PR DESCRIPTION
https://github.com/yaegassy/coc-volar/pull/327

1. LSP 3.16 and before, only push mode, server `publishDiagnostics`
2. LSP 3.17 added `refreshSupport`, server will ask client to refresh from `workspace/diagnostic/refresh`
3. LSP 3.17 also added pull mode, server provides `diagnosticProvider`, client pull diagnostics onSave/onChange etc

coc.nvim enabled `refreshSupport` but didn't onRequest DiagnosticRefreshRequest, could't handle `workspace/diagnostic/refresh`. Because no `diagnosticProvider`, coc.nvim cancelled registration.