### PR TITLE
fix(list): set foldcolumn to 0 since it isn't applicable

### DIFF
--- a/autoload/coc/list.vim
+++ b/autoload/coc/list.vim
@@ -98,6 +98,7 @@ function! coc#list#setup(source)
   setl norelativenumber bufhidden=wipe nocursorline winfixheight
   setl tabstop=1 nolist nocursorcolumn undolevels=-1
   setl signcolumn=auto
+  setl foldcolumn=0
   if exists('&cursorlineopt')
     setl cursorlineopt=both
   endif


### PR DESCRIPTION
If the user uses `foldcolumn` then the list buffers have an extra column that is not useful especially for a buffer that is bound to only be in insert mode. This locally sets `foldcolumn=0`