### PR TITLE
fix(inlayHint): hl_mode = 'replace' for neovim

### DIFF
--- a/src/handler/inlayHint/buffer.ts
+++ b/src/handler/inlayHint/buffer.ts
@@ -205,7 +205,7 @@ export default class InlayHintBuffer implements SyncItem {
       if (item.paddingRight) {
         chunks.push([' ', 'Normal'])
       }
-      buffer.setVirtualText(srcId, position.line, chunks, { col })
+      buffer.setVirtualText(srcId, position.line, chunks, { col, hl_mode: 'replace' })
     }
     nvim.resumeNotification(true, true)
     this._onDidRefresh.fire()


### PR DESCRIPTION
Problem: https://github.com/neovim/neovim/issues/24152 The inlays are affected by the other highlight groups.
Solution: use `replace` value for `hl_mode` instead of  `combine`.