### PR TITLE
fix(inlayHint): more compact padding highlight group

### DIFF
--- a/src/handler/inlayHint/buffer.ts
+++ b/src/handler/inlayHint/buffer.ts
@@ -194,16 +194,16 @@ export default class InlayHintBuffer implements SyncItem {
     nvim.pauseNotification()
     buffer.clearNamespace(srcId, range.start.line, range.end.line + 1)
     for (const item of inlayHints) {
-      const chunks: [string, string][] = []
+      const chunks = []
       let { position } = item
       let line = this.doc.getline(position.line)
       let col = byteIndex(line, position.character) + 1
       if (item.paddingLeft) {
-        chunks.push([' ', 'Normal'])
+        chunks.push([' '])
       }
       chunks.push([getLabel(item), getHighlightGroup(item.kind)])
       if (item.paddingRight) {
-        chunks.push([' ', 'Normal'])
+        chunks.push([' '])
       }
       buffer.setVirtualText(srcId, position.line, chunks, { col, hl_mode: 'replace' })
     }


### PR DESCRIPTION
If the chunk is an array with a single string, the highlight group only uses the foreground of `Normal`, which makes `cursorline` look better.

Reference: https://github.com/neovim/neovim/blob/0f85aeb478a68c18a8195e69724e1cb618fec058/runtime/lua/vim/lsp/inlay_hint.lua#L333-L337