### PR TITLE
fix(defaultAction) fallback to default action on emtpy expression

### DIFF
--- a/src/list/mappings.ts
+++ b/src/list/mappings.ts
@@ -141,7 +141,7 @@ export default class Mappings {
     })
     this.addAction('expr', async expr => {
       let name = await manager.call(expr)
-      if (name) await manager.doAction(name)
+      await manager.doAction(name)
     })
 
     this.addKeyMapping('insert', '<C-s>', 'do:switch')


### PR DESCRIPTION
This should allow the expression function to return nil, to by default execute the default action of the list, as there are no easy ways to extract the name of the default action for the current list. doAction by default if no 'name' is provided would fallback to the defaultAction.