### PR TITLE
Add workspace folder filter argument for diagnostics

### DIFF
--- a/autoload/coc/list.vim
+++ b/autoload/coc/list.vim
@@ -40,9 +40,9 @@ function! coc#list#setlines(bufnr, lines, append)
 endfunction
 
 function! coc#list#options(...)
-  let list = ['--top', '--tab', '--buffer', '--normal', '--no-sort', '--input=', '--strict',
-        \ '--regex', '--interactive', '--number-select', '--auto-preview',
-        \ '--ignore-case', '--no-quit', '--first', '--reverse', '--height=']
+  let list = ['--top', '--tab', '--buffer', '--workspace-folder', '--normal', '--no-sort',
+   \ '--input=', '--strict', '--regex', '--interactive', '--number-select',
+   \ '--auto-preview', '--ignore-case', '--no-quit', '--first', '--reverse', '--height=']
   if get(g:, 'coc_enabled', 0)
     let names = coc#rpc#request('listNames', [])
     call extend(list, names)

--- a/history.md
+++ b/history.md
@@ -1,3 +1,8 @@
+# 2024-03-26
+
+- Added new `--workspace-folder` argument for diagnostics lists
+- Added new `--buffer` argument for diagnostics lists
+
 # 2024-02-28
 
 - Increase `g:coc_highlight_maximum_count` default to 200

--- a/src/__tests__/list/sources.test.ts
+++ b/src/__tests__/list/sources.test.ts
@@ -684,6 +684,56 @@ describe('list sources', () => {
       expect(lines.length).toEqual(5)
     })
 
+    it('should load diagnostics for workspace folder only', async () => {
+      await createDocument('list/workspace-folder1/a')
+      await createDocument('list/workspace-folder1/b')
+
+      await createDocument('list/workspace-folder2/c')
+      await createDocument('list/workspace-folder2/d')
+
+      await createDocument('e')
+      await createDocument('f')
+
+      const workspaceFolder = path.join(__dirname, 'workspace-folder1')
+      jest.spyOn(workspace, 'getWorkspaceFolder').mockReturnValue({
+        name : 'workspace-folder1',
+        uri: URI.file(workspaceFolder).toString()
+      })
+      await manager.start(['diagnostics', '--workspace-folder'])
+      await manager.session?.ui.ready
+      expect(manager.isActivated).toBe(true)
+
+      let buf = await nvim.buffer
+      let lines = await buf.lines
+      // A Total of 10 for buf a & b
+      expect(lines.length).toEqual(10)
+    })
+
+    it('should load no diagnostics for buffers outside workspace folder', async () => {
+      await createDocument('list/workspace-folder1/a')
+      await createDocument('list/workspace-folder1/b')
+
+      await createDocument('list/workspace-folder2/c')
+      await createDocument('list/workspace-folder2/d')
+
+      await createDocument('e')
+      await createDocument('f')
+
+      const workspaceFolder = path.join(__dirname, 'workspace-folder4')
+      jest.spyOn(workspace, 'getWorkspaceFolder').mockReturnValue({
+        name : 'workspace-folder4',
+        uri: URI.file(workspaceFolder).toString()
+      })
+      await manager.start(['diagnostics', '--workspace-folder'])
+      await manager.session?.ui.ready
+      expect(manager.isActivated).toBe(true)
+
+      let buf = await nvim.buffer
+      let lines = await buf.lines
+      // No results line just visible
+      expect(lines.length).toEqual(1)
+    })
+
     it('should refresh on diagnostics refresh', async () => {
       let doc = await createDocument('bar')
       await manager.start(['diagnostics'])


### PR DESCRIPTION
In addition to the recently added `--buffer` option, i have also added a `--workspace-folder` which will show only the ones active for the current workspace folder.