### PR TITLE
chore(CI): use Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup python3
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.x"
       - run: pip install pynvim
 
       - name: Setup vim


### PR DESCRIPTION
Python 3.12 can cause issues because `distutils` was removed from the Standard Library.