### PR TITLE
fix(extension): quote cmd on windows

### DIFF
--- a/src/extension/installer.ts
+++ b/src/extension/installer.ts
@@ -236,7 +236,8 @@ export class Installer extends EventEmitter implements IInstaller {
     return new Promise<void>((resolve, reject) => {
       let args = this.getInstallArguments(this.npm, this.url)
       this.log(`Installing dependencies by: ${this.npm} ${args.join(' ')}.`)
-      const child = child_process.spawn(this.npm, args, {
+      const cmd = process.platform === 'win32' && this.npm.includes(' ') ? `"${this.npm}"` : this.npm
+      const child = child_process.spawn(cmd, args, {
         cwd: folder,
         shell: process.platform === 'win32',
         env: Object.assign(process.env, { NODE_ENV: 'production' })


### PR DESCRIPTION
Closes #4987

on windows, command should be quoted if containing spaces. https://github.com/nodejs/node/issues/7367