### PR TITLE
fix(list): update lastSession when resume list by name

### DIFF
--- a/src/list/manager.ts
+++ b/src/list/manager.ts
@@ -154,6 +154,7 @@ export class ListManager implements Disposable {
         void window.showWarningMessage(`Can't find exists ${name} list`)
         return
       }
+      this.lastSession = session
       await session.resume()
     }
   }


### PR DESCRIPTION
List action works on lastSession. When resuming a named list which is not the lastSession, it should update the lastSession.

This fix #4971 case2.
