### PR TITLE
feat(esbuild): disable minify for all

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -72,7 +72,6 @@ async function start() {
   await require('esbuild').build({
     entryPoints: ['index.js'],
     bundle: true,
-    minify: process.env.NODE_ENV === 'production',
     sourcemap: process.env.NODE_ENV === 'development',
     define: {
       REVISION: '"' + revision + '"',


### PR DESCRIPTION
Disabling minify will increase the `build/index.js` file size from 2.1M to 3.9M, but this provides clear trace line information for debugging when using the release branch