### PR TITLE
Add parameter to command 'workspace.showOutput'

### DIFF
--- a/src/handler/workspace.ts
+++ b/src/handler/workspace.ts
@@ -103,9 +103,9 @@ export default class WorkspaceHandler {
     }, false, 'Generates a snapshot of the current V8 heap and writes it to a JSON file.')
     commands.register({
       id: 'workspace.showOutput',
-      execute: async (name?: string) => {
+      execute: async (name?: string, cmd?: string) => {
         if (!name) name = await window.showQuickPick(workspace.channelNames, { title: 'Choose output name' }) as string
-        window.showOutputChannel(toText(name))
+        window.showOutputChannel(toText(name), cmd)
       }
     }, false, 'open output buffer to show output from languageservers or extensions.')
     commands.register({

--- a/src/window.ts
+++ b/src/window.ts
@@ -144,10 +144,11 @@ export class Window {
    * Reveal buffer of output channel.
    *
    * @param name Name of output channel.
+   * @param cmd command for open output channel.
    * @param preserveFocus Preserve window focus when true.
    */
-  public showOutputChannel(name: string, preserveFocus?: boolean): void {
-    let command = this.configuration.get<string>('workspace.openOutputCommand', 'vs')
+  public showOutputChannel(name: string, cmd?: string, preserveFocus?: boolean): void {
+    let command = cmd ? cmd : this.configuration.get<string>('workspace.openOutputCommand', 'vs')
     channels.show(name, command, preserveFocus)
   }
 


### PR DESCRIPTION
Add parameter to command `workspace.showOutput`, let user could control  how to open the `OutputChannel` window in  command mode like this:
`:CocCommand workspace.showOutput channelName sp`