### PR TITLE
fix(workspace): add missing interface to renamed method

### DIFF
--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -589,6 +589,10 @@ export class Workspace {
     return this.workspaceFolderControl.getRelativePath(pathOrUri, includeWorkspace)
   }
 
+  public asRelativePath(pathOrUri: string | URI, includeWorkspace?: boolean): string {
+    return this.getRelativePath(pathOrUri, includeWorkspace)
+  }
+
   public async findFiles(include: GlobPattern, exclude?: GlobPattern | null, maxResults?: number, token?: CancellationToken): Promise<URI[]> {
     return this.files.findFiles(include, exclude, maxResults, token)
   }


### PR DESCRIPTION
The method asRelativePath was probably renamed in the past, however there are extensions such as coc-java which are using the method named asRelativePath expose the method in the workspace api, as it is already exposed in the typings api.