### PR TITLE
feat(inlayHint): add `inlayHint.position` configuration

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -1303,6 +1303,13 @@
       "scope": "language-overridable",
       "description": "Enable inlay hint support"
     },
+    "inlayHint.position": {
+      "type": "string",
+      "default": "inline",
+      "scope": "language-overridable",
+      "description": "Controls where to show inlay hints: inline in the text, or at the end of the line",
+      "enum": ["inline", "eol"]
+    },
     "inlayHint.enableParameter": {
       "type": "boolean",
       "scope": "language-overridable",

--- a/src/handler/inlayHint/buffer.ts
+++ b/src/handler/inlayHint/buffer.ts
@@ -16,10 +16,16 @@ import workspace from '../../workspace'
 
 export interface InlayHintConfig {
   enable: boolean
+  position: InlayHintPosition,
   display: boolean
   filetypes: string[]
   refreshOnInsertMode: boolean
   enableParameter: boolean
+}
+
+export enum InlayHintPosition {
+  Inline = "inline",
+  Eol = "eol",
 }
 
 let srcId: number | undefined
@@ -70,6 +76,7 @@ export default class InlayHintBuffer implements SyncItem {
     let changed = this._config && this._config.enable != config.enable
     this._config = {
       enable: config.get<boolean>('enable'),
+      position: config.get<InlayHintPosition>('position'),
       display: config.get<boolean>('display', true),
       filetypes: config.get<string[]>('filetypes'),
       refreshOnInsertMode: config.get<boolean>('refreshOnInsertMode'),
@@ -204,6 +211,9 @@ export default class InlayHintBuffer implements SyncItem {
       chunks.push([getLabel(item), getHighlightGroup(item.kind)])
       if (item.paddingRight) {
         chunks.push(nvim.isVim ? [' ', 'Normal'] : [' '])
+      }
+      if (this.config.position == InlayHintPosition.Eol) {
+        col = 0
       }
       buffer.setVirtualText(srcId, position.line, chunks, { col, hl_mode: 'replace' })
     }


### PR DESCRIPTION
This PR adds an option to move all inlay hints to *after* the original text.

Personally, I find hints inside the source code very distracting. And they make the code look much wider than it really is, which I personally do not like.

This option allows to restore the old behavior where all hints were displayed at the end of a line.