### PR TITLE
fix(coc#has_item_selected)

### DIFF
--- a/autoload/coc/pum.vim
+++ b/autoload/coc/pum.vim
@@ -23,10 +23,7 @@ if s:is_vim
 endif
 
 function! coc#pum#has_item_selected() abort
-    if s:pum_winid == -1
-        return 0
-    endif
-    return s:pum_index != -1
+    return coc#pum#visible() && s:pum_index != -1
 endfunction
 
 function! coc#pum#visible() abort


### PR DESCRIPTION
I find that `coc#pum#visible` use `getwinvar(s:pum_winid, 'float', 0) == 1` to check the window. So using `s:pum_winid == -1` may cause problems, now use `coc#pum#visible()` to check if the `pum` is visible.