### PR TITLE
Add `coc.preferences.formatterExtension` configuration

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -630,6 +630,12 @@
         "type": "string"
       }
     },
+    "coc.preferences.formatterExtension": {
+      "type": ["null", "string"],
+      "default": null,
+      "scope": "language-overridable",
+      "description": "Extension used for formatting documents, defaulting to the formatter with highest priority."
+    },
     "coc.preferences.jumpCommand": {
       "anyOf": [
         {

--- a/data/schema.json
+++ b/data/schema.json
@@ -634,7 +634,7 @@
       "type": ["null", "string"],
       "default": null,
       "scope": "language-overridable",
-      "description": "Extension used for formatting documents, defaulting to the formatter with highest priority."
+      "description": "Extension used for formatting documents. When set to null, the formatter with highest priority is used."
     },
     "coc.preferences.jumpCommand": {
       "anyOf": [

--- a/doc/coc-config.txt
+++ b/doc/coc-config.txt
@@ -1624,6 +1624,12 @@ Preferences~
 
 	Scope: `language-overridable`, default: `false`
 
+"coc.preferences.formatterExtension"			*coc-preferences-formatterExtension*
+
+	Extension used for formatting documents. When set to null, the formatter with highest priority is used.
+
+	Scope: `language-overridable`, default: `null`
+
 "coc.preferences.jumpCommand"				*coc-preferences-jumpCommand*
 
 	Command used for location jump, like goto definition, goto references 

--- a/history.md
+++ b/history.md
@@ -1,3 +1,7 @@
+# 2024-08-12
+
+- Added `coc.preferences.formatterExtension` extension
+
 # 2024-07-04
 
 - Added `NVIM_APPNAME` support

--- a/history.md
+++ b/history.md
@@ -1,6 +1,6 @@
 # 2024-08-12
 
-- Added `coc.preferences.formatterExtension` extension
+- Added `coc.preferences.formatterExtension` configuration
 
 # 2024-07-04
 

--- a/src/language-client/client.ts
+++ b/src/language-client/client.ts
@@ -263,6 +263,8 @@ export namespace MessageTransports {
 }
 
 export abstract class BaseLanguageClient implements FeatureClient<Middleware, LanguageClientOptions> {
+  public registeredExtensionName: string
+
   private _id: string
   private _name: string
   private _clientOptions: ResolvedClientOptions

--- a/src/language-client/features.ts
+++ b/src/language-client/features.ts
@@ -599,6 +599,7 @@ import { DidChangeTextDocumentFeatureShape, DidCloseTextDocumentFeatureShape, Di
 import { WorkspaceProviderFeature } from './workspaceSymbol'
 
 export interface FeatureClient<M, CO = object> {
+  registeredExtensionName: string
   clientOptions: CO
   middleware: M
   readonly id: string

--- a/src/language-client/formatting.ts
+++ b/src/language-client/formatting.ts
@@ -6,7 +6,7 @@ import { DocumentFormattingEditProvider, DocumentRangeFormattingEditProvider, On
 import {
   DocumentFormattingRequest, DocumentOnTypeFormattingRequest, DocumentRangeFormattingRequest
 } from '../util/protocol'
-import { ensure, FeatureClient, TextDocumentLanguageFeature } from './features'
+import { FeatureClient, TextDocumentLanguageFeature, ensure } from './features'
 import * as cv from './utils/converter'
 import * as UUID from './utils/uuid'
 
@@ -121,7 +121,7 @@ export class DocumentFormattingFeature extends TextDocumentLanguageFeature<
     }
 
     return [
-      languages.registerDocumentFormatProvider(options.documentSelector!, provider, this._client.clientOptions.formatterPriority),
+      languages.registerDocumentFormatProvider(options.documentSelector!, provider, this._client.clientOptions.formatterPriority, this._client.registeredExtensionName),
       provider
     ]
   }
@@ -176,7 +176,7 @@ export class DocumentRangeFormattingFeature extends TextDocumentLanguageFeature<
       }
     }
 
-    return [languages.registerDocumentRangeFormatProvider(options.documentSelector, provider), provider]
+    return [languages.registerDocumentRangeFormatProvider(options.documentSelector, provider, undefined, this._client.registeredExtensionName), provider]
   }
 }
 

--- a/src/language-client/formatting.ts
+++ b/src/language-client/formatting.ts
@@ -177,7 +177,11 @@ export class DocumentRangeFormattingFeature extends TextDocumentLanguageFeature<
       }
     }
 
-    return [languages.registerDocumentRangeFormatProvider(options.documentSelector, provider, undefined, this._client.registeredExtensionName), provider]
+    return [
+      // We need to pass the originaly registered extension name to keep track of it.
+      languages.registerDocumentRangeFormatProvider(options.documentSelector, provider, undefined, this._client.registeredExtensionName),
+      provider
+    ]
   }
 }
 

--- a/src/language-client/formatting.ts
+++ b/src/language-client/formatting.ts
@@ -121,6 +121,7 @@ export class DocumentFormattingFeature extends TextDocumentLanguageFeature<
     }
 
     return [
+      // We need to pass the originaly registered extension name to keep track of it.
       languages.registerDocumentFormatProvider(options.documentSelector!, provider, this._client.clientOptions.formatterPriority, this._client.registeredExtensionName),
       provider
     ]

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -248,14 +248,18 @@ class Languages {
   // within coc.nvim. It does not meant to be explicitly specified by extension authors.
   public registerDocumentFormatProvider(selector: DocumentSelector, provider: DocumentFormattingEditProvider, priority = 0, extensionName?: string): Disposable {
     // To select formatter by extension name, we need to know who registered the formatting provider. This is possible
-    // by using parseExtensionName(). However, when the formatting provider is registered through the language client,
-    // parseExtensionName() returns "coc.nvim". But in this case the original extension name extension name shoould be
-    // passed as the `extensionName` parameter.
+    // by using parseExtensionName() when the extension explicitly called registerDocumentFormatProvider() within its
+    // activation code. However, when the formatting provider is registered through the language client,
+    // parseExtensionName() returns just "coc.nvim". But in this case the original extension name extension name should
+    // be passed as the `extensionName` parameter.
     extensionName = extensionName ?? parseExtensionName(Error().stack)
     return this.formatManager.register(extensionName, selector, provider, priority)
   }
 
+  // NOTE: The last `extensionName` parameter is not exposed in the index.d.ts since it is only for the internal use
+  // within coc.nvim. It does not meant to be explicitly specified by extension authors.
   public registerDocumentRangeFormatProvider(selector: DocumentSelector, provider: DocumentRangeFormattingEditProvider, priority = 0, extensionName?: string): Disposable {
+    // See registerDocumentFormatProvider() for the explanation of the `extensionName` parameter.
     extensionName = extensionName ?? parseExtensionName(Error().stack)
     return this.formatRangeManager.register(extensionName, selector, provider, priority)
   }

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -244,13 +244,13 @@ class Languages {
     return this.workspaceSymbolsManager.register(provider)
   }
 
-  public registerDocumentFormatProvider(selector: DocumentSelector, provider: DocumentFormattingEditProvider, priority = 0): Disposable {
-    const extensionName = parseExtensionName(Error().stack)
+  public registerDocumentFormatProvider(selector: DocumentSelector, provider: DocumentFormattingEditProvider, priority = 0, extensionName?: string): Disposable {
+    extensionName = extensionName ?? parseExtensionName(Error().stack)
     return this.formatManager.register(extensionName, selector, provider, priority)
   }
 
-  public registerDocumentRangeFormatProvider(selector: DocumentSelector, provider: DocumentRangeFormattingEditProvider, priority = 0): Disposable {
-    const extensionName = parseExtensionName(Error().stack)
+  public registerDocumentRangeFormatProvider(selector: DocumentSelector, provider: DocumentRangeFormattingEditProvider, priority = 0, extensionName?: string): Disposable {
+    extensionName = extensionName ?? parseExtensionName(Error().stack)
     return this.formatRangeManager.register(extensionName, selector, provider, priority)
   }
 

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -244,7 +244,13 @@ class Languages {
     return this.workspaceSymbolsManager.register(provider)
   }
 
+  // NOTE: The last `extensionName` parameter is not exposed in the index.d.ts since it is only for the internal use
+  // within coc.nvim. It does not meant to be explicitly specified by extension authors.
   public registerDocumentFormatProvider(selector: DocumentSelector, provider: DocumentFormattingEditProvider, priority = 0, extensionName?: string): Disposable {
+    // To select formatter by extension name, we need to know who registered the formatting provider. This is possible
+    // by using parseExtensionName(). However, when the formatting provider is registered through the language client,
+    // parseExtensionName() returns "coc.nvim". But in this case the original extension name extension name shoould be
+    // passed as the `extensionName` parameter.
     extensionName = extensionName ?? parseExtensionName(Error().stack)
     return this.formatManager.register(extensionName, selector, provider, priority)
   }

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -1,7 +1,7 @@
 'use strict'
 import type { LinkedEditingRanges, SignatureHelpContext } from 'vscode-languageserver-protocol'
 import { TextDocument } from 'vscode-languageserver-textdocument'
-import { CallHierarchyIncomingCall, CallHierarchyItem, CallHierarchyOutgoingCall, CodeAction, CodeActionContext, CodeActionKind, CodeLens, ColorInformation, ColorPresentation, DefinitionLink, DocumentHighlight, DocumentLink, DocumentSymbol, FoldingRange, FormattingOptions, Hover, InlineValue, InlineValueContext, Position, Range, SelectionRange, SemanticTokens, SemanticTokensDelta, SemanticTokensLegend, SignatureHelp, SymbolInformation, TextEdit, TypeHierarchyItem, WorkspaceEdit, WorkspaceSymbol } from 'vscode-languageserver-types'
+import { CallHierarchyIncomingCall, CallHierarchyItem, CallHierarchyOutgoingCall, CodeAction, CodeActionContext, CodeActionKind, CodeLens, ColorInformation, ColorPresentation, DefinitionLink, DocumentHighlight, DocumentLink, DocumentSymbol, FoldingRange, FormattingOptions, Hover, InlineValue, InlineValueContext, Position, Range, SelectionRange, SemanticTokens, SemanticTokensDelta, SemanticTokensLegend, SignatureHelp, TextEdit, TypeHierarchyItem, WorkspaceEdit, WorkspaceSymbol } from 'vscode-languageserver-types'
 import type { Sources } from './completion/sources'
 import DiagnosticCollection from './diagnostic/collection'
 import diagnosticManager from './diagnostic/manager'
@@ -35,6 +35,7 @@ import TypeHierarchyManager, { TypeHierarchyItemWithSource } from './provider/ty
 import WorkspaceSymbolManager from './provider/workspaceSymbolsManager'
 import { LocationWithTarget, TextDocumentMatch } from './types'
 import { disposeAll, getConditionValue } from './util'
+import { parseExtensionName } from './util/extensionRegistry'
 import * as Is from './util/is'
 import { CancellationToken, Disposable, Emitter, Event } from './util/protocol'
 import { toText } from './util/string'
@@ -244,11 +245,13 @@ class Languages {
   }
 
   public registerDocumentFormatProvider(selector: DocumentSelector, provider: DocumentFormattingEditProvider, priority = 0): Disposable {
-    return this.formatManager.register(selector, provider, priority)
+    const extensionName = parseExtensionName(Error().stack)
+    return this.formatManager.register(extensionName, selector, provider, priority)
   }
 
   public registerDocumentRangeFormatProvider(selector: DocumentSelector, provider: DocumentRangeFormattingEditProvider, priority = 0): Disposable {
-    return this.formatRangeManager.register(selector, provider, priority)
+    const extensionName = parseExtensionName(Error().stack)
+    return this.formatRangeManager.register(extensionName, selector, provider, priority)
   }
 
   public registerCallHierarchyProvider(selector: DocumentSelector, provider: CallHierarchyProvider): Disposable {

--- a/src/provider/formatManager.ts
+++ b/src/provider/formatManager.ts
@@ -2,18 +2,28 @@
 import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { FormattingOptions, TextEdit } from 'vscode-languageserver-types'
+import { createLogger } from '../logger'
+import { TextDocumentMatch } from '../types'
 import { CancellationToken, Disposable } from '../util/protocol'
+import workspace from '../workspace'
 import { DocumentFormattingEditProvider, DocumentSelector } from './index'
-import Manager from './manager'
+import Manager, { ProviderItem } from './manager'
 
-export default class FormatManager extends Manager<DocumentFormattingEditProvider> {
+const logger = createLogger('provider-formatManager')
 
-  public register(selector: DocumentSelector, provider: DocumentFormattingEditProvider, priority: number): Disposable {
+interface ProviderMeta {
+  extensionName: string,
+}
+
+export default class FormatManager extends Manager<DocumentFormattingEditProvider, ProviderMeta> {
+
+  public register(extensionName: string, selector: DocumentSelector, provider: DocumentFormattingEditProvider, priority: number): Disposable {
     return this.addProvider({
       id: uuid(),
       selector,
       priority,
-      provider
+      provider,
+      extensionName,
     })
   }
 
@@ -24,7 +34,26 @@ export default class FormatManager extends Manager<DocumentFormattingEditProvide
   ): Promise<TextEdit[]> {
     let item = this.getProvider(document)
     if (!item) return null
+    logger.info("Format by:", item.extensionName)
     let { provider } = item
     return await Promise.resolve(provider.provideDocumentFormattingEdits(document, options, token))
+  }
+
+  protected override getProvider(document: TextDocumentMatch): ProviderItem<DocumentFormattingEditProvider, ProviderMeta> {
+    // Prefer user choice
+    const userChoice = workspace.getConfiguration('coc.preferences', document).get<string>('formatterExtension')
+    if (userChoice) {
+      const items = this.getProviders(document)
+      const userChoiceProvider = items.find(item => item.extensionName === userChoice)
+      if (userChoiceProvider) {
+        logger.info("Using user-specified formatter:", userChoice)
+        return userChoiceProvider
+      }
+
+      logger.error("User-specified formatter not found:", userChoice)
+      return null
+    }
+
+    return super.getProvider(document)
   }
 }

--- a/src/provider/formatRangeManager.ts
+++ b/src/provider/formatRangeManager.ts
@@ -2,20 +2,30 @@
 import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { FormattingOptions, Range, TextEdit } from 'vscode-languageserver-types'
+import { createLogger } from '../logger'
+import { TextDocumentMatch } from '../types'
 import { CancellationToken, Disposable } from '../util/protocol'
+import workspace from '../workspace'
 import { DocumentRangeFormattingEditProvider, DocumentSelector } from './index'
-import Manager from './manager'
+import Manager, { ProviderItem } from './manager'
 
-export default class FormatRangeManager extends Manager<DocumentRangeFormattingEditProvider> {
+const logger = createLogger('provider-formatRangeManager')
 
-  public register(selector: DocumentSelector,
+interface ProviderMeta {
+  extensionName: string,
+}
+
+export default class FormatRangeManager extends Manager<DocumentRangeFormattingEditProvider, ProviderMeta> {
+
+  public register(extensionName: string, selector: DocumentSelector,
     provider: DocumentRangeFormattingEditProvider,
     priority: number): Disposable {
     return this.addProvider({
       id: uuid(),
       selector,
       provider,
-      priority
+      priority,
+      extensionName,
     })
   }
 
@@ -32,7 +42,26 @@ export default class FormatRangeManager extends Manager<DocumentRangeFormattingE
   ): Promise<TextEdit[]> {
     let item = this.getProvider(document)
     if (!item) return null
+    logger.info("Range format by:", item.extensionName)
     let { provider } = item
     return await Promise.resolve(provider.provideDocumentRangeFormattingEdits(document, range, options, token))
+  }
+
+  protected override getProvider(document: TextDocumentMatch): ProviderItem<DocumentRangeFormattingEditProvider, ProviderMeta> {
+    // Prefer user choice
+    const userChoice = workspace.getConfiguration('coc.preferences', document).get<string>('formatterExtension')
+    if (userChoice) {
+      const items = this.getProviders(document)
+      const userChoiceProvider = items.find(item => item.extensionName === userChoice)
+      if (userChoiceProvider) {
+        logger.info("Using user-specified range formatter:", userChoice)
+        return userChoiceProvider
+      }
+
+      logger.error("User-specified range formatter not found:", userChoice)
+      return null
+    }
+
+    return super.getProvider(document)
   }
 }


### PR DESCRIPTION
This is a proof-of-concept.

- Registered by extensions itself (like `coc-pyright`): identified by extension name as expected
- Registered by extensions through a language client (like `@yaegassy/coc-ruff`): identified by extension name as expected
- Registered by coc.nvim for raw LSP `languageserver` configuration: identified as `coc.nvim`
  - TODO: So there is no way to select one from multiple LSP - what it should be in this case?

Priorities are still expected to work (when `coc.preferences.formatterExtension` is null).

Closes #5076