### PR TITLE
chore(util): adjust to vim's Patch 9.1.327

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -525,7 +525,13 @@ function! coc#util#get_config_home()
     if s:is_win
       return resolve($HOME."/vimfiles")
     endif
-    return resolve($HOME.'/.vim')
+    if isdirectory(resolve($HOME.'/.vim'))
+      return resolve($HOME.'/.vim')
+    endif
+    if exists('$XDG_CONFIG_HOME') && isdirectory(resolve($XDG_CONFIG_HOME))
+      return resolve($XDG_CONFIG_HOME.'/vim')
+    endif
+    return resolve($HOME.'/.config/vim')
   endif
 endfunction
 


### PR DESCRIPTION
Vim supports $XDG_CONFIG_HOME as an optional source in [Patch 9.1.0327](https://github.com/vim/vim/commit/c9df1fb35a1866901c32df37dd39c8b39dbdb64a), thus `$XDG_CONFIG_HOME/vim/` will be one of the possible paths of `vimrc`. Therefore, we need to include it as one of the coc configuration paths. Refer to the [patch](https://github.com/vim/vim/commit/c9df1fb35a1866901c32df37dd39c8b39dbdb64a#diff-df93833f5ada39e41ded6f5a6b804b1aa3a75d270848dee769afd9c55f1fcc07R1114-R1117), `$XDG_CONFIG_HOME` will be used as the config path if and only if no other initialization file is found in `$HOME` or `$HOME/.vim`. Consequently, we should first check the `$HOME/.vim`, and the last and default path will be `$HOME/.config/vim`.