### PR TITLE
feat(language-client): modify log time format

### DIFF
--- a/src/language-client/utils/index.ts
+++ b/src/language-client/utils/index.ts
@@ -15,7 +15,7 @@ export function toMethod(type: string | MessageSignature): string {
 }
 
 export function currentTimeStamp(): string {
-  return getTimestamp(new Date())
+  return new Date().toLocaleTimeString()
 }
 
 export function getTraceMessage(data: any): string {


### PR DESCRIPTION
same as VSCode's `new Date().toLocaleTimeString()`