### PR TITLE
Improve handling of whitespaces on remove word

### DIFF
--- a/src/list/prompt.ts
+++ b/src/list/prompt.ts
@@ -167,7 +167,9 @@ export default class Prompt {
     if (cusorIndex == 0) return
     let pre = input.slice(0, cusorIndex)
     let post = input.slice(cusorIndex)
-    let remain = pre.replace(/[\w\s$\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]+([^\w\s$\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]+)?$/u, '')
+    let remain = pre
+      .trimEnd()  // to remove last whitespaces
+      .replace(/[\w$\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]+$/u, '')  // to remove the last word
     this.cusorIndex = cusorIndex - (pre.length - remain.length)
     this._input = `${remain}${post}`
     this.drawPrompt()


### PR DESCRIPTION
Fixes remaining issue in #5134.

This fixes the issue where:

- entire lines are removed on <C-w> even if there are spaces in the middle, and
- the initial spaces are not removed on <C-w>.