### PR TITLE
improve performance for large file

### DIFF
--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -508,7 +508,7 @@ endfunction
 function! s:funcs.buf_clear_namespace(bufnr, srcId, startLine, endLine) abort
   let bufnr = a:bufnr == 0 ? bufnr('%') : a:bufnr
   let start = a:startLine + 1
-  let end = a:endLine == -1 ? len(getbufline(bufnr, 1, '$')) : a:endLine
+  let end = a:endLine == -1 ? s:buf_line_count(bufnr) : a:endLine
   if a:srcId == -1
     if has_key(s:buffer_id, a:bufnr)
       unlet s:buffer_id[a:bufnr]


### PR DESCRIPTION
improve performance for large file
(still don't know why this func is called for a buf with b:coc_enabled = 0)