### PR TITLE
feat: add fixed position support for floating windows

### DIFF
--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -127,6 +127,52 @@ function! coc#float#create_float_win(winid, bufnr, config) abort
     " happens when using getchar() #3921
     return []
   endtry
+
+  " Calculate position when relative is editor
+  if get(a:config, 'relative', '') ==# 'editor'
+    let top = get(a:config, 'top', v:null)
+    let bottom = get(a:config, 'bottom', v:null)
+    let left = get(a:config, 'left', v:null)
+    let right = get(a:config, 'right', v:null)
+
+    if top isnot v:null || bottom isnot v:null || left isnot v:null || right isnot v:null
+      let height = &lines
+      let width = &columns
+
+      " Calculate row
+      let calc_row = a:config.row
+      if bottom isnot v:null
+        let calc_row = height - bottom - a:config.height - 2
+      elseif top isnot v:null
+        let calc_row = top
+      endif
+
+      " Calculate col
+      let calc_col = a:config.col
+      if right isnot v:null
+        let calc_col = width - right - a:config.width - 3
+      elseif left isnot v:null
+        let calc_col = left
+      endif
+
+      " Check if window would overlap cursor position
+      let pos = screenpos(0, line('.'), col('.'))
+      let currow = pos.row - 1
+      let curcol = pos.col - 1
+      let win_top = calc_row
+      let win_bottom = win_top + a:config.height + 2
+      let win_left = calc_col
+      let win_right = win_left + a:config.width + 3
+
+      " If window would overlap cursor, switch to cursor relative
+      if currow >= win_top && currow <= win_bottom && curcol >= win_left && curcol <= win_right
+        let a:config.relative = 'cursor'
+      else
+        let a:config.row = calc_row
+        let a:config.col = calc_col
+      endif
+    endif
+  endif
   let lnum = max([1, get(a:config, 'index', 0) + 1])
   let zindex = get(a:config, 'zindex', 50)
   " use exists

--- a/data/schema.json
+++ b/data/schema.json
@@ -60,6 +60,28 @@
           "minimum": 0,
           "maximum": 100,
           "description": "Enables pseudo-transparency by set 'winblend' option of window, neovim only."
+        },
+        "position": {
+          "type": "string",
+          "default": "auto",
+          "description": "Controls how floating windows are positioned. When set to `'fixed'`, the window will be positioned according to the `top`, `bottom`, `left`, and `right` settings. When set to `'auto'`, the window follows the default position.",
+          "enum": ["fixed", "auto"]
+        },
+        "top": {
+          "type": "number",
+          "description": "Distance from the top of the editor window in characters. Only takes effect when `position` is set to `'fixed'`. Will be ignored if `bottom` is set."
+        },
+        "bottom": {
+          "type": "number",
+          "description": "Distance from the bottom of the editor window in characters. Only takes effect when `position` is set to `'fixed'`. Takes precedence over `top` if both are set."
+        },
+        "left": {
+          "type": "number",
+          "description": "Distance from the left edge of the editor window in characters. Only takes effect when `position` is set to `'fixed'`. Will be ignored if `right` is set."
+        },
+        "right": {
+          "type": "number",
+          "description": "Distance from the right edge of the editor window in characters. Only takes effect when `position` is set to `'fixed'`. Takes precedence over `left` if both are set."
         }
       }
     },
@@ -970,7 +992,12 @@
         "maxWidth": {},
         "winblend": {},
         "focusable": {},
-        "shadow": {}
+        "shadow": {},
+        "position": {},
+        "top": {},
+        "bottom": {},
+        "left": {},
+        "right": {}
       }
     },
     "diagnostic.format": {
@@ -1242,7 +1269,12 @@
         "maxHeight": {},
         "winblend": {},
         "focusable": {},
-        "shadow": {}
+        "shadow": {},
+        "position": {},
+        "top": {},
+        "bottom": {},
+        "left": {},
+        "right": {}
       }
     },
     "hover.autoHide": {
@@ -1268,7 +1300,12 @@
         "maxWidth": {},
         "winblend": {},
         "focusable": {},
-        "shadow": {}
+        "shadow": {},
+        "position": {},
+        "top": {},
+        "bottom": {},
+        "left": {},
+        "right": {}
       }
     },
     "hover.previewMaxHeight": {
@@ -1861,7 +1898,12 @@
         "maxWidth": {},
         "winblend": {},
         "focusable": {},
-        "shadow": {}
+        "shadow": {},
+        "position": {},
+        "top": {},
+        "bottom": {},
+        "left": {},
+        "right": {}
       }
     },
     "signature.hideOnTextChange": {

--- a/doc/coc-config.txt
+++ b/doc/coc-config.txt
@@ -1723,6 +1723,11 @@ supported:
 	  `0`.
 	- "focusable": Set to false to make window not focusable, neovim only.
 	- "shadow": Set to true to enable shadow, neovim only.
+	- "position": Controls how floating windows are positioned. When set to `'fixed'`, the window will be positioned according to the `top`, `bottom`, `left`, and `right` settings. When set to `'auto'`, the window follows the default position.
+	- "top": Distance from the top of the editor window in characters. Only takes effect when `position` is set to `'fixed'`. Will be ignored if `bottom` is set.
+	- "bottom": Distance from the bottom of the editor window in characters. Only takes effect when `position` is set to `'fixed'`. Takes precedence over `top` if both are set.
+	- "left": Distance from the left edge of the editor window in characters. Only takes effect when `position` is set to `'fixed'`. Will be ignored if `right` is set.
+	- "right": "Distance from the right edge of the editor window in characters. Only takes effect when `position` is set to `'fixed'`. Takes precedence over `left` if both are set."
 
 ------------------------------------------------------------------------------
 Languageserver~

--- a/src/model/floatFactory.ts
+++ b/src/model/floatFactory.ts
@@ -34,6 +34,11 @@ export interface FloatWinConfig extends FloatConfig {
   cursorline?: boolean
   modes?: string[]
   excludeImages?: boolean
+  position?: "fixed" | "auto";
+  top?: number;
+  bottom?: number;
+  left?: number;
+  right?: number;
 }
 
 /**
@@ -155,6 +160,11 @@ export default class FloatFactoryImpl implements Disposable {
     if (opts.highlight) config.highlight = opts.highlight
     if (opts.borderhighlight) config.borderhighlight = opts.borderhighlight
     if (opts.cursorline) config.cursorline = 1
+    if (opts.position) config.relative = opts.position === "fixed" ? config.relative = "editor" : "cursor"
+    if (typeof opts.top === 'number' && opts.top >= 0) config.top = opts.top
+    if (typeof opts.left === 'number' && opts.left >= 0) config.left = opts.left
+    if (typeof opts.bottom === 'number' && opts.bottom >= 0) config.bottom = opts.bottom
+    if (typeof opts.right === 'number' && opts.right >= 0) config.right = opts.right
     let autoHide = opts.autoHide === false ? false : true
     if (autoHide) config.autohide = 1
     this.unbind()

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -9829,6 +9829,11 @@ declare module 'coc.nvim' {
     cursorline?: boolean
     modes?: string[]
     excludeImages?: boolean
+    position?: "fixed" | "auto";
+    top?: number;
+    bottom?: number;
+    left?: number;
+    right?: number;
   }
 
   export interface FloatFactory {


### PR DESCRIPTION
This PR adds a new feature to support fixed positioning for floating windows.

Sometimes while coding, I find the diagnostic floating windows can be distracting as they often overlap with the code I'm trying to read. Many diagnostics are temporary and appear during the coding process, and I don't always need to see these less important diagnostic messages. However, they still pop up large floating windows that disrupt my focus.

I took inspiration from Helix editor's diagnostic design, which displays the current cursor's diagnostic message in a fixed position at the top-right corner of the editor. I find this design very effective as it keeps the main editing area clean and uncluttered.

This implementation allows for a more focused coding experience.

![image](https://github.com/user-attachments/assets/3c22500e-5f66-43ed-878b-0f23558c9bf1)
