### PR TITLE
feat(model): resolve languageID for spring-boot

### DIFF
--- a/src/__tests__/modules/document.test.ts
+++ b/src/__tests__/modules/document.test.ts
@@ -188,6 +188,22 @@ describe('Document', () => {
       await nvim.command(`edit +setl\\ filetype=txt.vim foo`)
       let doc = await workspace.document
       expect(doc.languageId).toBe('txt')
+
+      await nvim.command(`edit +setl\\ filetype=jproperties application.properties`)
+      doc = await workspace.document
+      expect(doc.languageId).toBe('spring-boot-properties')
+
+      await nvim.command(`edit +setl\\ filetype=jproperties bootstrap.test.properties`)
+      doc = await workspace.document
+      expect(doc.languageId).toBe('spring-boot-properties')
+
+      await nvim.command(`edit +setl\\ filetype=yaml application.yml`)
+      doc = await workspace.document
+      expect(doc.languageId).toBe('spring-boot-properties-yaml')
+
+      await nvim.command(`edit +setl\\ filetype=yaml application.test.yaml`)
+      doc = await workspace.document
+      expect(doc.languageId).toBe('spring-boot-properties-yaml')
     })
 
     it('should parse iskeyword of character range', async () => {

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -128,7 +128,16 @@ export default class Document {
    */
   public get languageId(): string {
     let { _filetype } = this
-    return _filetype.includes('.') ? _filetype.match(/(.*?)\./)[1] : _filetype
+    const ft = _filetype.includes('.') ? _filetype.match(/(.*?)\./)[1] : _filetype
+
+    if (ft === 'jproperties' && /(application|bootstrap).*\.properties$/.test(this._bufname)) {
+      return 'spring-boot-properties'
+    }
+    if (ft === 'yaml' && /(application|bootstrap).*\.ya?ml$/.test(this._bufname)) {
+      return 'spring-boot-properties-yaml'
+    }
+
+    return ft
   }
 
   /**


### PR DESCRIPTION
Edit: this will change languageID for all language server, not a good way to resolve the issue. Close for now.

Related #5112. A better way is adding a languageID pattern in languageserver/extension configuration, but this needs pass through more layers, needs more works, just made this quickfix for now.

@asmodeus812 can you make a test with this PR?