### PR TITLE
feat(diagnostic): add `diagnostic.displayByVimDiagnostic`

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -938,6 +938,12 @@
       "description": "Use Ale, coc-diagnostics-shim.nvim, or other provider to display diagnostics in vim. This setting will disable diagnostic display using coc's handler. A restart required on change.",
       "default": false
     },
+    "diagnostic.displayByVimDiagnostic": {
+      "type": "boolean",
+      "scope": "language-overridable",
+      "description": "Display diagnostics with nvim's `vim.diagnostic`. This setting will disable diagnostic display using coc's handler. A restart required on change. Neovim only.",
+      "default": false
+    },
     "diagnostic.enable": {
       "type": "boolean",
       "scope": "language-overridable",

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -1998,6 +1998,10 @@ b:coc_diagnostic_info					*b:coc_diagnostic_info*
 
 	can be used to customize statusline. See |coc-status|.
 
+b:coc_diagnostic_map					*b:coc_diagnostic_map*
+
+	Diagnostics of current buffer, the format is same as *diagnostic-structure*
+
 b:coc_current_function					*b:coc_current_function*
 
 	Function string that current cursor in.

--- a/history.md
+++ b/history.md
@@ -1,86 +1,94 @@
-# 2024-12-10
+# Changelog
+
+Notable changes of coc.nvim:
+
+## 2025-01-03
+
+- Add `diagnostic.displayByVimDiagnostic` configuration, set diagnostics to `vim.diagnostic` on nvim, and prevent coc.nvim's handler to display in virtualText/sign/floating etc.
+
+## 2024-12-10
 
 - Floating window can be set to fixed position, try `diagnostic.floatConfig`
 - `ensureDocument` and `hasProvider` support to accept specified bufnr
 
-# 2024-11-29
+## 2024-11-29
 
 - Increase `g:coc_highlight_maximum_count` default to 500 for better performance.
 - Add `uriConverter.code2Protocol` for extensions
 
-# 2024-10-25
+## 2024-10-25
 
 - Mention [davidosomething/coc-diagnostics-shim.nvim](https://github.com/davidosomething/coc-diagnostics-shim.nvim) as alternative to ALE for diagnostics display.
 
-# 2024-08-28
+## 2024-08-28
 
 - Add configuration `codeLens.display`
 
-# 2024-08-20
+## 2024-08-20
 
 - Add `CocAction('removeWorkspaceFolder')`.
 - Expanded the quick pick API in typings
 
-# 2024-08-12
+## 2024-08-12
 
 - Added `coc.preferences.formatterExtension` configuration
 
-# 2024-07-04
+## 2024-07-04
 
 - Added `NVIM_APPNAME` support
 
-# 2024-06-27
+## 2024-06-27
 
 - Added `inlayHint.position` configuration, with `inline` and `eol` options
 
-# 2024-06-20
+## 2024-06-20
 
 - Added `coc.preferences.extensionUpdateUIInTab` to open `CocUpdate` UI in tab
 
-# 2024-05-29
+## 2024-05-29
 
 - Break change: increase minimum vim/nvim version requirement
   - vim 9.0.0438
   - nvim 0.8.0
 
-# 2024-05-14
+## 2024-05-14
 
 - Added `suggest.reTriggerAfterIndent` to control re-trigger or not after indent changes
 
-# 2024-05-07
+## 2024-05-07
 
 - Allow `CocInstall` to install extension from Github in development mode
 
-# 2024-04-12
+## 2024-04-12
 
 - Change scope of codeLens configuration to `language-overridable`
 
-# 2024-03-26
+## 2024-03-26
 
 - Added new `--workspace-folder` argument for diagnostics lists
 - Added new `--buffer` argument for diagnostics lists
 
-# 2024-02-28
+## 2024-02-28
 
 - Increase `g:coc_highlight_maximum_count` default to 200
 - Break change: semanticTokens highlight groups changed:
   - `CocSem + type` to `CocSemType + type`
   - `CocSem + modifier + type` to `CocSemTypeMod + type + modifier`
 
-# 2024-03-06
+## 2024-03-06
 
 - add `outline.autoHide` configuration to automatically hide the outline window when an item is clicked
 
-# 2024-02-27
+## 2024-02-27
 
 - Add `g:coc_disable_mappings_check` to disable key-mappings checking
 - Add `suggest.chineseSegments` configuration to control whether to divide Chinese sentences into segments or not
 
-# 2023-09-02
+## 2023-09-02
 
 - Support `g:coc_list_preview_filetype`.
 
-# 2023-08-31
+## 2023-08-31
 
 - Minimal node version changed from 14.14.0 to 16.18.0.
 - Inlay hint support requires neovim >= 0.10.0.
@@ -89,57 +97,57 @@
   - `inlayHint.typeSeparator`
   - `inlayHint.parameterSeparator`
 
-# 2023-01-30
+## 2023-01-30
 
 - Always show `cancellable` progress as notification without check
   `notification.statusLineProgress`.
 
-# 2023-01-29
+## 2023-01-29
 
 - Exclude `source` actions when request code actions with range.
 - Any character can be used for channel name.
 
-# 2023-01-26
+## 2023-01-26
 
 - Add escape support to `coc#status()`.
 
-# 2023-01-24
+## 2023-01-24
 
 - Add `encoding` and `CancellationToken` support for `runCommand` function.
 
-# 2023-01-23
+## 2023-01-23
 
 - Make `vscode.open` command work with file uri.
 - Cancel option for `workspace.registerExprKeymap()`.
 - Support `suggest.filterOnBackspace` configuration.
 
-# 2023-01-22
+## 2023-01-22
 
 - `maxRestartCount` configuration for configured language server.
 
-# 2022-12-25
+## 2022-12-25
 
 - Create symbol tree from SymbolInformation list.
 
-# 2022-12-23
+## 2022-12-23
 
 - Support `URI` as param for API `workspace.jumpTo()`.
 
-# 2022-12-22
+## 2022-12-22
 
 - Support popup window for window related APIs.
 
-# 2022-12-21
+## 2022-12-21
 
 - When create `CocSem` highlight group, replace invalid character of token types
   and token modifiers with underline.
 
-# 2022-12-20
+## 2022-12-20
 
 - Export `Buffer.setKeymap` and `Buffer.deleteKeymap` with vim and neovim support.
 - Make `workspace.registerLocalKeymap` accept bufnr argument.
 
-# 2022-12-12
+## 2022-12-12
 
 - Allow configuration of `window` scoped used by folder configuration file, like
   VSCode.
@@ -147,36 +155,36 @@
 - Use unique id for each tab on vim.
 - Chinese word segmentation for keywords.
 
-# 2022-12-05
+## 2022-12-05
 
 - Add `switchConsole` method to `LanguageClient`
 
-# 2022-12-03
+## 2022-12-03
 
 - Add configuration `suggest.insertMode`.
 
-# 2022-12-02
+## 2022-12-02
 
 - Expand variables for string configuration value.
 
-# 2022-11-30
+## 2022-11-30
 
 - File fragment support for `workspace.jumpTo()`.
 - Support `g:coc_open_url_command`.
 - Support `contributes.configuration` from extension as array.
 
-# 2022-11-29
+## 2022-11-29
 
 - Add documentations for develop of coc.nvim extensions.
 - Remove unused variable `g:coc_channel_timeout`.
 
-# 2022-11-28
+## 2022-11-28
 
 - Placeholder and update value support for `InputBox` and `QuickPick`.
 - `triggerOnly` option property for vim completion source.
 - Export `getExtensionById` from `extensions` module.
 
-# 2022-11-26
+## 2022-11-26
 
 - Use CTRL-R expression instead of timer for pum related functions:
 
@@ -188,47 +196,47 @@
   - `coc#pum#cancel()`
   - `coc#pum#confirm()`
 
-# 2022-11-25
+## 2022-11-25
 
 - Avoid view change on list create.
 - Add configurations `links.enable` and `links.highlight`.
 - Use cursorline for list on neovim (to have correct highlight).
 - Fix highlight not work on neovim 0.5.0 by use `luaeval`.
 
-# 2022-11-22
+## 2022-11-22
 
 - Add command `document.toggleCodeLens`.
 
-# 2022-11-21
+## 2022-11-21
 
 - Add `CocAction('addWorkspaceFolder')`.
 
-# 2022-11-20
+## 2022-11-20
 
 - Support code lens feature on vim9.
 - `codeLens.subseparator` default changed to `|`, like VSCode.
 - Add configuration `coc.preferences.enableGFMBreaksInMarkdownDocument`, default to `true`
 - Add key-mappings `<Plug>(coc-codeaction-selected)` and `<Plug>(coc-codeaction-refactor-selected)`.
 
-# 2022-11-19
+## 2022-11-19
 
 - Create highlights after VimEnter.
 - Action 'organizeImport' return false instead of throw error when import code
   action not found.
 
-# 2022-11-18
+## 2022-11-18
 
 - Throw error when rpc request error, instead of echo message.
 
-# 2022-11-13
+## 2022-11-13
 
 - Plugin emit ready after extensions activated.
 
-# 2022-11-12
+## 2022-11-12
 
 - Not cancel completion when request for in complete sources.
 
-# 2022-11-11
+## 2022-11-11
 
 - Support filter and display completion items with different start positions.
 - Remove configuration `suggest.fixInsertedWord`, insert word would always
@@ -236,94 +244,94 @@
 - Configuration `suggest.invalidInsertCharacters` default to line break
   characters.
 
-# 2022-11-10
+## 2022-11-10
 
 - Not reset 'Search' highlight on float window as it could be used.
 - Note remap `<esc>` on float preview window.
 - Add new action `feedkeys!` to list.
 - Add new configuration `list.floatPreview`.
 
-# 2022-11-07
+## 2022-11-07
 
 - Add API `CocAction('snippetInsert')` for snippet insert from vim plugin.
 - Snippet support for vim source, snippet item should have `isSnippet` to be
   `true` and `insertText` to be snippet text, when `on_complete` function exists,
   the snippet expand should be handled completion source.
 
-# 2022-11-06
+## 2022-11-06
 
 - `window.createQuickPick()` API that show QuickPick by default, call `show()`
 - Fix change value property for QuickPick not works.
 
-# 2022-10-30
+## 2022-10-30
 
 - Add configuration `colors.enable`, mark `colors.filetypes` deprecated.
 - Add command `document.toggleColors` for toggle colors of current buffer.
 - Changed filter of completion to use code from VSCode.
 - Add configuration `suggest.filterGraceful`
 
-# 2022-10-39
+## 2022-10-39
 
 - Add configuration `suggest.enableFloat` back.
 
-# 2022-10-27
+## 2022-10-27
 
 - Use `workspace.rootPatterns` replace `coc.preferences.rootPatterns`, old
   configuration still works when exists.
 - Store configurations with configuration registry.
 
-# 2022-10-25
+## 2022-10-25
 
 - Add `--height` support to `CocList`.
 
-# 2022-10-24
+## 2022-10-24
 
 - Use builtin static words source for snippet choices.
 - Remove configuration `"snippet.choicesMenuPicker"`
 - Remove unused internal functions `coc#complete_indent()` and
   `coc#_do_complete()`
 
-# 2022-10-21
+## 2022-10-21
 
 - Consider utf-16 code unit instead of unicode code point.
 - Add `coc#string#character_index()` `coc#string#byte_index()` and
   `coc#string#character_length()`.
 
-# 2022-10-20
+## 2022-10-20
 
 - Add `coc#pum#one_more()`
 
-# 2022-10-19
+## 2022-10-19
 
 - Trigger for trigger sources when no filter results available.
 
-# 2022-10-18
+## 2022-10-18
 
 - Change `suggest.maxCompleteItemCount` default to 256.
 
-# 2022-10-17
+## 2022-10-17
 
 - Set `g:coc_service_initialized` to `0` before service restart.
 - Show warning when diagnostic jump failed.
 - Use strwidth.wasm module for string display width.
 - Add API `workspace.getDisplayWidth`.
 
-# 2022-10-15
+## 2022-10-15
 
 - Add configuration `inlayHint.display`.
 
-# 2022-10-07
+## 2022-10-07
 
 - Use `CocFloatActive` for highlight active parameters.
 
-# 2022-09-28
+## 2022-09-28
 
 - Limit popupmenu width when exceed screen to &pumwidth, instead of change
   completion column.
 - Make escape of `${name}` for ultisnip snippets the same behavior as
   Ultisnip.vim.
 
-# 2022-09-27
+## 2022-09-27
 
 - Use fuzzy.wasm for native fuzzy match.
 - Add `binarySearch` and `isFalsyOrEmpty` functions for array.
@@ -332,7 +340,7 @@
 - Rework keywords parse for better performance (parse changed lines only and use
   yield to reduce iteration).
 
-# 2022-09-12
+## 2022-09-12
 
 - All configurations are now scoped #4185
 - No `onDidChangeConfiguration` event fired when workspace folder changed.
@@ -341,37 +349,37 @@
 - Deprecated configuration `semanticTokens.filetypes`, use `semanticTokens.enable` with scoped languages instead.
 - Use `workspaceFolderValue` instead of `workspaceValue` for `ConfigurationInspect` returned by `WorkspaceConfiguration.inspect()`.
 
-# 2022-09-04
+## 2022-09-04
 
 - Add configuration "snippet.choicesMenuPicker".
 
-# 2022-09-03
+## 2022-09-03
 
 - Send "WinClosed" event to node client.
 - Add `onDidFilterStateChange` and `onDidCursorMoved` to `TreeView`.
 - Support `autoPreview` for outline.
 
-# 2022-09-02
+## 2022-09-02
 
 - Support `diagnostic.virtualTextFormat`.
 - Add command `workspace.writeHeapSnapshot`.
 
-# 2022-09-01
+## 2022-09-01
 
 - Add configuration "suggest.asciiMatch"
 - Support `b:coc_force_attach`.
 
-# 2022-08-31
+## 2022-08-31
 
 - Add configuration "suggest.reversePumAboveCursor".
 - Use `DiagnosticSign*` highlight groups when possible.
 - Use `DiagnosticUnderline*` highlight groups when possible.
 
-# 2022-08-30
+## 2022-08-30
 
 - Export `LineBuilder` class.
 
-# 2022-08-29
+## 2022-08-29
 
 - Fix semanticTokens highlights unexpected cleared
 - Fix range of `doQuickfix` action.
@@ -379,7 +387,7 @@
 - Make `CocInlayHint` use background of `SignColumn`.
 - Add command `document.toggleInlayHint`.
 
-# 2022-08-28
+## 2022-08-28
 
 - Make `CocMenuSel` use background of `PmenuSel`.
 - Snippet related configuration changed (old configuration still works until next release)
@@ -394,12 +402,12 @@
   - "inlayHint.parameterSeparator"
   - "inlayHint.subSeparator"
 
-# 2022-08-27
+## 2022-08-27
 
 - Avoid use `EasyMotion#is_active`, use autocmd to disable linting.
 - Show message when call hierarchy provider not found or bad position.
 
-# 2022-08-26
+## 2022-08-26
 
 - Remove `completeOpt` from `workspace.env`.
 - Add configuration `"diagnostic.virtualTextAlign"`.
@@ -407,27 +415,27 @@
 - Not echo error for semanticTokens request (log only).
 - Merge results form providers when possible.
 
-# 2022-08-24
+## 2022-08-24
 
 - Virtual text of suggest on vim9.
 - Virtual text of diagnostics on vim9.
 - Add configuration `inlayHint.filetypes`.
 - Inlay hint support on vim9.
 
-# 2022-08-23
+## 2022-08-23
 
 - Retry semanticTokens request on server cancel (LSP 3.17).
 - `RelativePattern` support for `workspace.createFileSystemWatcher()`.
 - `relativePatternSupport` for `DidChangeWatchedFiles` (LSP 3.17).
 - Not echo error on `doComplete()`.
 
-# 2022-08-21
+## 2022-08-21
 
 - Added `window.createFloatFactory()`, deprecated `FloatFactory` class.
 - Support `labelDetails` field of `CompleteItem`(LSP 3.17).
 - Added `triggerKind` to `CodeActionContext`, export `CodeActionTriggerKind`.
 
-# 2022-08-20
+## 2022-08-20
 
 - Support pull diagnostics `:h coc-pullDiagnostics`.
 - Break change: avoid extension overwrite builtin configuration defaults.
@@ -435,85 +443,85 @@
 - 'line' changes to 'currline' for `CocAction('codeAction')`.
 - Check NodeJS version on syntax error.
 
-# 2022-08-10
+## 2022-08-10
 
 - Change "notification.highlightGroup" default to "Normal".
 
-# 2022-08-07
+## 2022-08-07
 
 - Add configuration 'suggest.pumFloatConfig'.
 
-# 2022-08-04
+## 2022-08-04
 
 - Make diagnostic float window with the same background as CocFloating.
 
-# 2022-08-03
+## 2022-08-03
 
 - Add highlight group 'CocFloatingDividingLine'.
 
-# 2022-08-01
+## 2022-08-01
 
 - Use custom popup menu, #3862.
 - Use "first" instead of "none" for configuration `suggest.selection`.
 - Make "first" default for `suggest.selection`, like VSCode.
 - Add default blue color for hlgroup `CocMenuSel`.
 
-# 2022-06-14
+## 2022-06-14
 
 - Add highlight groups `CocListLine` and `CocListSearch`.
 
-# 2022-06-11
+## 2022-06-11
 
 - Add configuration "notification.disabledProgressSources"
 - Add "rounded" property to "floatConfig"
 
-# 2022-06-04
+## 2022-06-04
 
 - Add configuration `workspace.openOutputCommand`.
 - Log channel message of vim when `g:node_client_debug` enabled.
 
-# 2022-05-30
+## 2022-05-30
 
 - Disable `progressOnInitialization` for language client by default.
 
-# 2022-05-28
+## 2022-05-28
 
 - Support `repeat#set` for commands that make changes only.
 
-# 2022-05-24
+## 2022-05-24
 
 - Add transition and annotation support for `workspace.applyEdits()`.
 - Add command `workspace.undo` and `workspace.redo`.
 - Remove configuration `coc.preferences.promptWorkspaceEdit`.
 - Remove command `CocAction` and `CocFix`.
 
-# 2022-05-22
+## 2022-05-22
 
 - Check for previous position when not able to find completion match.
 - Add `content` support to `window.showMenuPicker()`
 
-# 2022-05-17
+## 2022-05-17
 
 - Add `QuickPick` module.
 - Add API `window.showQuickPick()` and `window.createQuickPick()`.
 
-# 2022-05-16
+## 2022-05-16
 
 - Add properties `title`, `loading` & `borderhighlight` to `InputBox`
 
-# 2022-05-14
+## 2022-05-14
 
 - Add `InputOption` support to `window.requestInput`
 - Add API `window.createInputBox()`.
 
-# 2022-05-13
+## 2022-05-13
 
-- Notification support like VSCode https://github.com/neoclide/coc.nvim/discussions/3813
+- Notification support like VSCode <https://github.com/neoclide/coc.nvim/discussions/3813>
 - Add configuration `notification.minProgressWidth`
 - Add configuration `notification.preferMenuPicker`
 - Support `source` in notification windows.
 
-# 2022-05-07
+## 2022-05-07
 
 - Show sort method as description in outline view.
 - Add configuration `outline.switchSortKey`, default to `<C-s>`.
@@ -521,81 +529,78 @@
 - Add variable `g:coc_max_treeview_width`.
 - Add `position: 'center'` support to `window.showMenuPicker()`
 
-# 2022-05-06
+## 2022-05-06
 
 - Use menu for `window.showQuickpick()`.
 - Add configuration `outline.autoWidth`, default to `true`.
 
-# 2022-05-05
+## 2022-05-05
 
 - Add key bindings to dialog (created by `window.showDialog()`) on neovim.
 
-# 2022-05-04
+## 2022-05-04
 
 - Add `languages.registerInlayHintsProvider()` for inlay hint support.
 
-# 2022-04-25
+## 2022-04-25
 
 - Add `LinkedEditing` support
 
-# 2022-04-23
+## 2022-04-23
 
 - Add `WinScrolled` event to events.
 
-# 2022-04-20
+## 2022-04-20
 
 - Select recent item when input is empty and selection is `recentUsedByPrefix`.
 - Add `coc#snippet#prev()` and `coc#snippet#next()`.
 - Add command `document.checkBuffer`.
 - Add `region` param to `window.diffHighlights()`.
 
-# 2022-04-06
+## 2022-04-06
 
 - `workspace.onDidOpenTextDocument` fire `contentChanges` as empty array when
   document changed with same lines.
 
-# 2022-04-04
+## 2022-04-04
 
 - Avoid `CompleteDone` cancel next completion.
 - Avoid indent change on `<C-n>` and `<C-p>` during completion.
 - Support `joinUndo` and `move` with `document.applyEdits()`.
 
-# 2022-04-02
+## 2022-04-02
 
 - Change `suggest.triggerCompletionWait` default to `0`.
 - Not trigger completion on `TextChangedP`.
 - Remove configuration `suggest.echodocSupport`.
 - Fix complettion triggered after `<C-e>`.
 
-# 2022-03-31
+## 2022-03-31
 
 - Check buffer rename on write.
 
-# 2022-03-30
+## 2022-03-30
 
 - Improve words parse performance.
 - Remove configurations `coc.source.around.firstMatch` and `coc.source.buffer.firstMatch`.
 - Fix `coc.source.buffer.ignoreGitignore` not works
-
-# 2022-03-30
-
 - Check document reload on detach.
 
-# 2022-03-29
+## 2022-03-29
 
 - Add menu actions to refactor buffer.
 
-# 2022-03-12
+## 2022-03-12
 
 - Avoid use `<sapce><bs>` for cancel completion.
 
-# 2022-03-05
+## 2022-03-05
 
 - Make `WinClosed` event fires on `CursorHold` to support vim8.
 - Add events `TabNew` and `TabClose`.
 - Make outline reuse TreeView buffer.
 
-# 2022-03-02
+## 2022-03-02
 
 - Add ultisnip option to `snippetManager.insertSnippet()` and
   `snippetManager.resolveSnippet()`.
@@ -605,18 +610,18 @@
   - Escape sequence `\u` `\l` `\U` `\L` `\E` `\n` `\t`
   - Conditional replacement: `(?no:text:other text)`
 
-# 2022-02-28
+## 2022-02-28
 
 - Change `workspace.ignoredFiletypes` default value to `[]`
 
-# 2022-02-24
+## 2022-02-24
 
 - Add `window.activeTextEditor`, `window.visibleTextEditors`.
 - Add events `window.onDidChangeActiveTextEditor` `window.onDidChangeVisibleTextEditors`.
 - Add class `RelativePattern`.
 - Add `workspace.findFiles()`.
 
-# 2022-02-23
+## 2022-02-23
 
 - Add `workspace.openTextDocument()`
 - Add `Workspace.getRelativePath()`.
@@ -627,50 +632,50 @@
 - Deprecated warning for `workspace.createTerminal()`,
   `workspace.onDidOpenTerminal` and `workspace.onDidCloseTerminal`
 
-# 2022-02-18
+## 2022-02-18
 
 - Clear all highlights created by coc.nvim before restart.
 - Support strike through for ansiparse.
 - Support `highlights` for `Documentation` in float window.
 
-# 2022-02-17
+## 2022-02-17
 
 - Change workspace configuration throw error when workspace folder can't be
   resolved.
 - Remove configuration `diagnostic.highlightOffset`.
 
-# 2022-02-15
+## 2022-02-15
 
 - Add `events.race`.
 - Change default `suggest.triggerCompletionWait` to 50.
 - Support trigger completion after indent fix.
 
-# 2022-02-14
+## 2022-02-14
 
 - Add `pumvisible` property to events.
 
-# 2022-02-10
+## 2022-02-10
 
 - Add shortcut support for `window.showMenuPicker()`.
 - Add configuration `dialog.shortcutHighlight` for shortcut highlight.
 - Add configuration `list.menuAction` for choose action by menu picker.
 
-# 2022-02-09
+## 2022-02-09
 
 - Add error log to `nvim_error_event`.
 - Add `nvim.lua()` which replace `nvim.executeLua()` to typings.d.ts.
 
-# 2022-02-08
+## 2022-02-08
 
 - Support `MenuItem` with disabled property for `window.showMenuPicker`
 - Support show disabled code actions in menu picker.
 
-# 2022-02-07
+## 2022-02-07
 
 - Change `:CocLocalConfig` to open configuration file of current workspace
   folder.
 
-# 2022-02-05
+## 2022-02-05
 
 - Support `version` from `textDocument/publishDiagnostics` notification's parameter.
 - Support `codeDescription` of diagnostics by add href to float window.
@@ -681,12 +686,12 @@
 - Add `trimTrailingWhitespace`, `insertFinalNewline` and `trimFinalNewlines` to FormattingOptions.
 - Add configuration `links.tooltip`, default to `false`.
 
-# 2022-02-04
+## 2022-02-04
 
 - Add `--reverse` option to list.
 - Add `<esc>` key-mapping to cancel list in preview window (neovim only).
 
-# 2022-02-02
+## 2022-02-02
 
 - Remove `disableWorkspaceFolders` `disableDiagnostics` and `disableCompletion`
   from language client option.
@@ -694,31 +699,31 @@
 - Add `tabPersist` option to `ListAction`.
 - Add `refactor` to `LocationList`
 
-# 2022-01-30
+## 2022-01-30
 
 - Add configuration `diagnostics.virtualTextLevel`.
 - Remove configuration `suggest.numberSelect`
 
-# 2022-01-26
+## 2022-01-26
 
 - Use `nvim_buf_set_text` when possible to keep extmarks.
 
-# 2022-01-25
+## 2022-01-25
 
 - Not trigger completion when filtered is succeed.
 - Move methods `workspace.getSelectedRange` `workspace.selectRange` to `window`
   module, show deprecated warning when using old methods.
 
-# 2022-01-23
+## 2022-01-23
 
 - Support semantic tokens highlights from range provider.
 
-# 2022-01-22
+## 2022-01-22
 
 - Not set `gravity` with api `nvim_buf_set_extmark` because highlight bug, wait neovim fix.
 - Support watch later created workspace folders for file events.
 
-# 2022-01-21
+## 2022-01-21
 
 - Changed semantic token highlight prefix from `CocSem_` to `CocSem`.
 - Changed semantic token highlight disabled by default, use configuration
@@ -727,47 +732,44 @@
 - Add configuration `semanticTokens.highlightPriority`.
 - Add configuration `semanticTokens.incrementTypes`.
 - Add configuration `semanticTokens.combinedModifiers`.
+- Add configuration `workspace.ignoredFolders`.
+- Add configuration `workspace.workspaceFolderFallbackCwd`.
 - Add command `semanticTokens.refreshCurrent`.
 - Add command `semanticTokens.inspect`.
 - Add action `inspectSemanticToken`.
 - Rework command `semanticTokens.checkCurrent` to show highlight information.
 - Support semantic tokens highlight group composed with type and modifier.
 
-# 2022-01-21
-
-- Add configuration `workspace.ignoredFolders`.
-- Add configuration `workspace.workspaceFolderFallbackCwd`.
-
-# 2022-01-20
+## 2022-01-20
 
 - Remove deprecated method `workspace.resolveRootFolder`.
 
-# 2022-01-17
+## 2022-01-17
 
 - Extend `buffer.updateHighlights` to support `priority`, `combine`, `start_incl` and `end_incl`.
 - Add configuration `diagnostic.highlightPriority`.
 - Add configuration `colors.filetypes` and `colors.highlightPriority`.
 
-# 2022-01-16
+## 2022-01-16
 
 - Add configuration `codeLens.position`.
 
-# 2022-01-14
+## 2022-01-14
 
 - Add configuration `suggest.selection`.
 
-# 2022-01-13
+## 2022-01-13
 
 - `codeLens.separator` now defaults to `""` and will be placed above lines on neovim >= 0.6.0 .
 - Add configurations 'diagnostic.locationlistLevel', 'diagnostic.signLevel', 'diagnostic.messageLevel'.
 
-# 2022-01-12
+## 2022-01-12
 
 - Add document.lineAt(), export TextLine class.
 - Upgrade node-client, support nvim.exec().
 - Add documentHighlight.priority configuration.
 
-# 2019-08-18 0.0.74
+## 2019-08-18 0.0.74
 
 - feat(cursors): support multiple cursors.
 - feat(extensions): install missing extensions by CocInstall.
@@ -780,7 +782,7 @@
 - refactor(outline): not exclude variables and callback.
 - refactor(diagnostic): remove timeout on InsertLeave.
 
-# 2019-07-11 0.0.73
+## 2019-07-11 0.0.73
 
 - fix(completion): fix map of number select
 - fix(languages): fix cursor position with snippet
@@ -812,7 +814,7 @@
 - feat(diagnostic): use text properties on vim8
 - feat(handler): improve signature float window
 
-# 2019-07-01
+## 2019-07-01
 
 - feat(plugin): add CocStatusChange autocmd
 - feat(extension): support both npm and yarn.
@@ -833,7 +835,7 @@
 - feat(diagnostic): add keymaps for jump error diagnostics
 - feat(plugin): delay start on gvim, fix #659
 
-# 2019-06-15
+## 2019-06-15
 
 - feat(plugin): add popup support of vim
 - refactor(completion): improve float support
@@ -847,7 +849,7 @@
 - fix(floatFactory): escape feedkeys
 - fix(handler): fix getCurrentFunctionSymbol not work
 
-# 2019-06-12
+## 2019-06-12
 
 - feat(document): add getVar method
 - fix(util): not break selection on message
@@ -862,7 +864,7 @@
 - fix(workspace): fix jump with tab drop
 - refactor(language-client): change API of selectionRanges
 
-# 2019-06-09
+## 2019-06-09
 
 - **Break change** `CocHighlightText` link to `CursorColumn` by default.
 - **Break change** logger folder changed to `$XDG_RUNTIME_DIR` when exists.
@@ -880,7 +882,7 @@
 - Add `codeActions` action.
 - Fix issues with list.
 
-# 2019-05-30
+## 2019-05-30
 
 - **Break change** logger folder changed.
 - Add support of vim-repeat for `<Plug>` keymaps.
@@ -895,7 +897,7 @@
 - Add warning for duplicate extension.
 - Bug fixes.
 
-# 2019-05-07
+## 2019-05-07
 
 - **New feature** load extensions from coc-extensions folder.
 - Add `workspace.renameCurrentFile` command.
@@ -905,7 +907,7 @@
 - Fix ansiparser for empty color ranges.
 - Fix highlight only work with first 8 items.
 
-# 2019-04-27
+## 2019-04-27
 
 - **Break change** vim-node-rpc not required on vim.
 - **Break change** python not required on vim.
@@ -914,7 +916,7 @@
 - Add support for jumpCommand as false.
 - Fix `diagnostic.level` not work.
 
-# 2019-04-09
+## 2019-04-09
 
 - **Break change** `--strictMatch` option of list renamed to `--strict`
 - **Break change** `suggest.reloadPumOnInsertChar` support removed.
@@ -936,7 +938,7 @@
 - Improve completion by support trigger completion when pumvisible.
 - Remove document check on `BufWritePre`.
 
-# 2019-03-31
+## 2019-03-31
 
 - **Break change** not using vim-node-rpc from npm modules any more.
 - **Break change** rename `<Plug>_` to `<Plug>CocRefresh`.
@@ -947,7 +949,7 @@
 - Fix error throw on file watch.
 - Fix unexpected update of user configuration.
 
-# 2019-03-28
+## 2019-03-28
 
 - Add `workspace.resolveRootFolder`.
 - Add `diagnostic.joinMessageLines` setting.
@@ -961,7 +963,7 @@
 - Fix document create possible wrong uri & filetype.
 - Improve highlight with floating window.
 
-# 2019-03-24
+## 2019-03-24
 
 - **Break change** make number input not trigger completion.
 - **Break change** make none keywords character doesn't filter completion.
@@ -972,7 +974,7 @@
 - Fix EPIPE error of node-client.
 - Fix wrong root of FileWatchSysmtem.
 
-# 2019-03-19
+## 2019-03-19
 
 - **Break change** signature settings now starts `signature`.
 - **Break change** default request timeout changed to 5s.
@@ -989,7 +991,7 @@
 - Improve sort of complete items.
 - Improve extension list with version and open action.
 
-# 2019-03-16
+## 2019-03-16
 
 - **Break change** change vim config home on windows to '\$HOME/vimfiles'.
 - Add highlights to float windows.
@@ -1003,7 +1005,7 @@
 - Fix CocUpdateSync not work without service start.
 - Fix wrong indent spaces of snippets.
 
-# 2019-03-11
+## 2019-03-11
 
 - **Break change** change buffers instead of disk file for `workspace.applyEdits`.
 - **Break change** add config errors to diagnostic list instead of jump locations.
@@ -1021,7 +1023,7 @@
 - Fix relative path of watchman.
 - Improve Mru model.
 
-# 2019-03-03
+## 2019-03-03
 
 - **Break change** signature change of `workspace.registerKeymap`.
 - **Break change** `<esc>` of CocList can't be remapped any more.
@@ -1035,7 +1037,7 @@
 - Fix possible infinite create of documents.
 - Fix check for resume completion.
 
-# 2019-02-25
+## 2019-02-25
 
 - **Break change** default of `suggest.detailMaxLength` changed to 100.
 - **Break change** option of `workspace.registerKeymap` changed.
@@ -1046,7 +1048,7 @@
 - Add `source` option for completion start.
 - Add `sources.createSource` method.
 
-# 2019-02-22
+## 2019-02-22
 
 - **Break change** some configurations have been renamed, checkout #462.
 - **Break change** no longer automatic trigger for CursorHoldI #452.
@@ -1059,7 +1061,7 @@
 - Fix wrong line for TextEdit of complete item.
 - Fix diagnostics not cleared on service restart.
 
-# 2019-02-17
+## 2019-02-17
 
 - **Break change** completion resolve requires CompleteChanged autocmd.
 - **Break change** mapping of space on insert mode of list removed.
@@ -1071,7 +1073,7 @@
 - Fix CocJumpPlaceholder not fired.
 - Fix vscode-open command not work.
 
-# 2019-02-12
+## 2019-02-12
 
 - **Break change** function `coc#util#clearmatches` signature changed.
 - Add check for python gtk module.
@@ -1080,7 +1082,7 @@
 - Fix empty buffers created on preview.
 - Fix trigger of `CursorHoldI`.
 
-# 2019-02-11
+## 2019-02-11
 
 - **Break change:** internal filetype of settings file changed to jsonc.
 - **Break change:** `coc#util#install` changed to synchronize by default.
@@ -1103,7 +1105,7 @@
 - Fix CursorHoldI not triggered on neovim.
 - Fix sort of list not stable.
 
-# 2019-02-04
+## 2019-02-04
 
 - **Break change:** no messages when documentSymbol and workspaceSymbol provider
   not found.
@@ -1114,7 +1116,7 @@
 - Fix cancel list without close ui.
 - Improve startup time by remove jobwait.
 
-# 2019-02-02
+## 2019-02-02
 
 - **Break change:** extensions now update automatically, prompt is removed.
 - Add check for extension compatibility.
@@ -1128,7 +1130,7 @@
 - Improve extension load.
 - Improve list experience.
 
-# 2019-01-28
+## 2019-01-28
 
 - **Break change:** `coc.preferences.diagnostic.echoMessage` changed to enum.
 - Add mru support for commands and lists list.
@@ -1138,7 +1140,7 @@
 - Fix `findLocations` not work with nest locations.
 - Fix cursor position after apply additionalTextEdits.
 
-# 2019-01-24
+## 2019-01-24
 
 - **Break change:** python code for denite support moved to separated repo.
 - **Break change:** Quickfix list no longer used.
@@ -1158,7 +1160,7 @@
 - Fix crash when `righleft` set to 1 on neovim.
 - Fix snippet position could be wrong.
 
-# 2019-01-09
+## 2019-01-09
 
 - **Break change:** throw error when languageserver id is invalid.
 - Add watcher for languageserver configuration change.
@@ -1168,7 +1170,7 @@
 - Fix log file not writeable.
 - Improve completion performance.
 
-# 2019-01-03
+## 2019-01-03
 
 - **Break change:** using of `g:rooter_patterns` is removed.
 - **Break change:** diagnostics would be updated in insert mode now.
@@ -1177,11 +1179,11 @@
 - Fix check of latest insert char failed.
 - Fix highlight not cleared sometimes.
 
-# 2019-01-01
+## 2019-01-01
 
 - Fix issues with completion.
 
-# 2018-12-31
+## 2018-12-31
 
 - **Break change:** created keymaps use rpcrequest instead of rpcnotify.
 - **Break change:** snippets provider is removed, use `coc-snippets` for
@@ -1200,7 +1202,7 @@
 - Fix `CocJumpPlaceholder` not fired
 - Optimize content synchronize.
 
-# 2018-12-27
+## 2018-12-27
 
 - **Break change:** no more message on service ready.
 - **Break change:** vim source now registered as extension.
@@ -1225,7 +1227,7 @@
 - Not echo message on vim exit.
 - Not send empty configuration change to languageserver.
 
-# 2018-12-20
+## 2018-12-20
 
 - **Break change** configuration for module language server, transport now
   require specified value.
@@ -1242,7 +1244,7 @@
 - Fix uri is wrong with whitespace.
 - Improve highlight performance with `nvim_call_atomic`.
 
-# 2018-12-17
+## 2018-12-17
 
 - **Break change** `vim-node-rpc` now upgrade in background.
 - Add `ignoredRootPaths` to `languageserver` option.
@@ -1253,7 +1255,7 @@
 - Fix default timeout to 2000.
 - Fix file mode of log file.
 
-# 2018-12-12
+## 2018-12-12
 
 - **Break change** `fixInsertedWord` fix inserted word which ends with word
   after.
@@ -1267,7 +1269,7 @@
 - Fix possible wrong line used for textEdit of complete item.
 - Fix possible wrong cursor position of snippet after inserted.
 
-# 2018-12-08
+## 2018-12-08
 
 - **Break change** default rootPath would be directory of current file, not cwd.
 - **Break change** codeLens feature now disabled by default.
@@ -1279,7 +1281,7 @@
 - Fix rootPath could be null.
 - Fix highlight not cleared on restart.
 
-# 2018-12-06
+## 2018-12-06
 
 - **Break change** `RevealOutputChannelOn` of language client default to
   `never`.
@@ -1290,7 +1292,7 @@
 - Improve apply `WorkspaceEdit`, support `0` as document version and merge
   edits for same document.
 
-# 2018-12-05
+## 2018-12-05
 
 - Add `CocJumpPlaceholder` autocmd.
 - Add `rootPatterns` to `languageserver` config.
@@ -1313,7 +1315,7 @@
 - Rework diagnostics with task sequence.
 - Rework configuration with more tests.
 
-# 2018-11-28
+## 2018-11-28
 
 - _Break change_ signature help reworked, vim API for echo signature changed.
 - Add `:CocInfo` command.
@@ -1336,7 +1338,7 @@
 - Fix line indent for snippet.
 - Fix trigger of `signatureHelp` and `onTypeFormat`.
 
-# 2018-11-24
+## 2018-11-24
 
 - **Break change** sources excluding `around`, `buffer` or `file` are extracted
   as extensions.
@@ -1351,7 +1353,7 @@
 - Fix workspace methods: `renameFile`, `deleteFile` and `resolveRoot`.
 - Fix textEdit of builtin sources not works.
 
-# 2018-11-19
+## 2018-11-19
 
 - **Break change** snippet support reworked: support nest snippets, independent
   session in each buffer and lots of fixes.
@@ -1368,7 +1370,7 @@
 - Improve colors module, only highlight current buffer and when buffer changed.
 - Improve `doc/coc.txt`
 
-# 2018-11-13
+## 2018-11-13
 
 - **Break change** default completion timeout changed to 2s.
 - **Break change** snippet session not canceled on `InsertLeave`, use
@@ -1390,7 +1392,7 @@
 - Fix file source throw undefined error.
 - Improve logic of sorting completion items, strict match items comes first.
 
-# 2018-11-07
+## 2018-11-07
 
 - **Break change** word source removed from custom sources, enabled for markdown
   by default.
@@ -1402,7 +1404,7 @@
 - Improve document highlight, no highlight when cursor moved.
 - Improve completion score, use fuzzaldrin-plus replace fuzzaldrin.
 
-# 2018-11-02
+## 2018-11-02
 
 - **Break change** no items from snippets source when input is empty.
 - **Break change** `javascript.jsx` would changed to `javascriptreact` as languageId.
@@ -1420,7 +1422,7 @@
 - Fix diagnostic for quickfix buffer.
 - Fix resolve of `coc.preferences.rootPath`
 
-# 2018-10-29
+## 2018-10-29
 
 - **Break change** diagnostic reworked, no refresh on insert mode.
 - **Break change** keep `sortText` on filter for better result.
@@ -1444,7 +1446,7 @@
 - Remove change of `virtualedit` option of snippet.
 - Improved performance of filter completion items.
 
-# 2018-10-25
+## 2018-10-25
 
 - Fix `implementation` and `typeDefinition` of language client not working.
 - Fix `diffLines` return wrong range.
@@ -1456,7 +1458,7 @@
 - Add `workspace.registerTextDocumentContentProvider` for handle custom uri.
 - Add `workspace.createStatusBarItem` method.
 
-# 2018-10-21
+## 2018-10-21
 
 - **Break change**: `triggerAfterInsertEnter` now respect `minTriggerInputLength`.
 - Add `coc.preferences.minTriggerInputLength`.
@@ -1469,7 +1471,7 @@
 - Fix first item not resolved when `noselect` is disabled
 - Remove using of `diff` module.
 
-# 2018-10-18
+## 2018-10-18
 
 - **Break change**: all buffers are created as document.
 - **Break change**: retrieve workspace root on document create.
@@ -1489,7 +1491,7 @@
 - Add support of scoped configuration.
 - Disable buffer highlight on vim.
 
-# 2018-10-14
+## 2018-10-14
 
 - **Break change** API: `workspace.resoleModule` only does resolve.
 - **Break change** extension would still be loaded even if current coc version
@@ -1510,7 +1512,7 @@
   for buffer parse.
 - Rework completion for performance and accuracy.
 
-# 2018-10-05
+## 2018-10-05
 
 - **Break change**, `workspace.onDidChangeConfiguration` emit `ConfigurationChangeEvent` now.
 - Add `position` to function `coc#util#open_terminal`.
@@ -1519,7 +1521,7 @@
 - Fix parse of `iskeyword` option, consider `@-@`.
 - Fix completion of snippet: cancel on line change.
 
-# 2018-10-01
+## 2018-10-01
 
 - Improved document `didChange` before trigger completion.
 - Add option `coc.preferences.triggerCompletionWait`, default 60.
@@ -1529,7 +1531,7 @@
 - Fix highlight of highlight action not using terminal colors.
 - Fix detect for insert new line character.
 
-# 2018-09-30
+## 2018-09-30
 
 - Add quickfix source of denite and fzf
 - Add option `coc.preferences.rootPath`
@@ -1537,7 +1539,7 @@
 - Fix jump of placeholder.
 - Fix empty root on language server initialize.
 
-# 2018-09-28
+## 2018-09-28
 
 - **Break change**: `coc.preferences.formatOnType` default to `false`.
 - **Break change**: snippet completion disabled in `string` and `comment`.
@@ -1549,7 +1551,7 @@
 - Fix `triggerKind` of completion.
 - Fix install extension from url not reloaded.
 
-# 2018-09-27
+## 2018-09-27
 
 - **Break change**: `:CocDisable` disabled all events from vim.
 - **Break change**: new snippet implementation.
@@ -1568,7 +1570,7 @@
 - Fix buffer highlight not cleared on `highlight` action.
 - Fix format on type not work as expected.
 
-# 2018-09-24
+## 2018-09-24
 
 - **Break change**: use `CursorMove` instead of `CursorHold` for diagnostic
   message.
@@ -1582,13 +1584,13 @@
 - Fix active extension on command not working.
 - Fix delete file from resource edit not works.
 
-# 2018-09-20
+## 2018-09-20
 
 - Fix diagnostic check next offset for diagnostics.
 - Add `<Plug>(coc-diagnostic-info)` for show diagnostic message without
   truncate.
 
-# 2018-09-15
+## 2018-09-15
 
 - Fix wrong configuration on update.
 - Fix install command with tag version.
@@ -1597,7 +1599,7 @@
 - Add support of json validation for extension.
 - Add support of format on save by `coc.preferences.formatOnSaveFiletypes`
 
-# 2018-09-10
+## 2018-09-10
 
 - Add `Denite coc-extension` for manage extensions.
 - Add actions for manage extension including `toggleExtension` `reloadExtension`
@@ -1606,7 +1608,7 @@
 - Fix extensions using same process of coc itself.
 - Fix `configurationSection` should be null if none was specified.
 
-# 2018-09-07
+## 2018-09-07
 
 - **Break change**: all extension all separated from core, checkout
   [Using coc extension](https://github.com/neoclide/coc.nvim/wiki/Using-coc-extensions)
@@ -1619,13 +1621,13 @@
 - Add support for `prepareRename`.
 - Add support for `CodeActionOptions`
 
-# 2018-08-30
+## 2018-08-30
 
 - Fix wrong `triggerKind` from VSCode.
 - Add `<Plug>(coc-openlink)` for open link.
 - Add `typescript.jsx` as valid typescript type.
 
-# 2018-08-23
+## 2018-08-23
 
 - Fix sometimes client status invalid.
 - Add multiply provider support for all features.
@@ -1634,7 +1636,7 @@
 - Add `foldingRange` support
 - Add support of `documentSelector` same as VSCode
 
-# 2018-08-21
+## 2018-08-21
 
 - Fix diagnostic and arguments of tsserver.
 - Add `keepfocus` option for `open_terminal`.
@@ -1646,7 +1648,7 @@
 - Use `callAsync` for async request to vim.
 - Add `CocActionAsync` function send async request to server.
 
-# 2018-08-17
+## 2018-08-17
 
 - Fix exists terminal buffer not watched.
 - Fix buffer not attached after `edit!`.
@@ -1669,7 +1671,7 @@
 
 - Add test for workspace.
 
-# 2018-08-16
+## 2018-08-16
 
 - Improved for tsserver:
 
@@ -1687,7 +1689,7 @@
 - **Break change** all buffer types except `nofile` `help` and `quickfix` are
   watched for changes.
 
-# 2018-08-15
+## 2018-08-15
 
 - Fix filter of completion items on fast input.
 - Fix sometimes fails of include & neosnippet source.
@@ -1713,7 +1715,7 @@
 
 - Add tests for completion sources.
 
-# 2018-08-14
+## 2018-08-14
 
 - Fix remote source not working.
 - Fix sort of completion items.
@@ -1722,7 +1724,7 @@
 - Add config `coc.preferences.maxCompleteItemCount`.
 - Add `g:coc_auto_copen`, default to `1`.
 
-# 2018-08-12
+## 2018-08-12
 
 - **Break change** `:CocRefresh` replaced with `call CocAction('refreshSource')`.
 - Add support filetype change of buffer.
@@ -1732,7 +1734,7 @@
 - Improve interface of workspace.
 - Fix loading of configuration content.
 
-# 2018-08-11
+## 2018-08-11
 
 - Fix configuration content not saved on change.
 - Fix thrown error on watchman not found.
@@ -1747,19 +1749,19 @@
 - Fix signature help behaviour, truncate messages to not overlap.
 - Reworks sources use async import.
 
-# 2018-08-10
+## 2018-08-10
 
 - Fix dispose for all modules.
 - Add support for multiple `addWillSaveUntilListener`.
 - Fix `startcol` for json server.
 - Add support filetype `javascriptreact` for tsserver.
 
-# 2018-08-09
+## 2018-08-09
 
 - Add `coc#util#install` for installation.
 - Add `install.cmd` for windows.
 
-# 2018-08-08
+## 2018-08-08
 
 - Improved location list for diagnostics.
 - Add `internal` option to command.
@@ -1768,18 +1770,18 @@
 
 - Add support for multiple save wait until requests.
 
-# 2018-08-07
+## 2018-08-07
 
 - Add `forceFullSync` to language server option.
 
-# 2018-08-05
+## 2018-08-05
 
 - Improve eslint extension to use workspaceFolder.
 - Fix watchman not works with multiple roots.
 - Add feature: dynamic root support for workspace.
 - **Break change** output channel of watchman is removed.
 
-# 2018-08-04
+## 2018-08-04
 
 - Fix order of document symbols.
 - Fix completion snippet with `$variable`.
@@ -1790,12 +1792,12 @@
 
 - **Break change** `emoji` `include` used for all filetypes by default.
 
-# 2018-08-03
+## 2018-08-03
 
 - Add command `:CocErrors` for debug.
 - Support `DocumentSymbol` for 'textDocument/documentSymbol'
 
-# 2018-08-02
+## 2018-08-02
 
 - Fix error of language client with unsupported schema.
 
@@ -1803,11 +1805,11 @@
 
 - Fix update empty configuration not works.
 
-# 2018-07-31
+## 2018-07-31
 
 - Improve file source triggered with dirname started path.
 
-# 2018-07-30
+## 2018-07-30
 
 - Fix source ultisnip not working.
 - Fix custom language client with command not working.
@@ -1817,7 +1819,7 @@
   - Completion is resumed when search is empty.
   - Completion is triggered when user try to fix search.
 
-# 2018-07-29
+## 2018-07-29
 
 - **Break change** all servers are decoupled from coc.nvim
 
@@ -1829,14 +1831,14 @@
 
 - Add command `CocConfig`
 
-# 2018-07-28
+## 2018-07-28
 
 - Fix uncaught exception error on windows.
 - Use plugin root for assets resolve.
 - Fix emoji source not triggered by `:`.
 - Improve file source to recognize `~` as user home.
 
-# 2018-07-27
+## 2018-07-27
 
 - Prompt user for download server module with big extension like `vetur` and `wxml-langserver`
 - **Break change**, section of settings changed: `cssserver.[languageId]` moved to `[languageId]`
@@ -1847,7 +1849,7 @@
 
 - **Break change**, `stylelint` extension is disabled by default, add
 
-  ```
+  ```json
   "stylelint.enable": true,
   ```
 
@@ -1858,7 +1860,7 @@
 
 - **Break change**, `triggerAfterInsertEnter` is always `true`, add
 
-  ```
+  ```json
   "coc.preferences.triggerAfterInsertEnter": false,
   ```
 
@@ -1867,51 +1869,51 @@
 - **Break change**, when `autoTrigger` is `always` completion would be triggered
   after completion item select.
 
-# 2018-07-24
+## 2018-07-24
 
 - better statusline integration with airline and lightline.
 
-# 2018-07-23
+## 2018-07-23
 
 - Coc service start much faster.
 - Add vim-node-rpc module.
 - **Break change** global function `CocAutocmd` and `CocResult` are removed.
 - Support Vue with vetur
 
-# 2018-07-21
+## 2018-07-21
 
 - Fix issue with `completeopt`.
 - Add source `neosnippet`.
 - Add source `gocode`.
 
-# 2018-07-20
+## 2018-07-20
 
 - Add documentation for language server debug.
 - Rework register of functions, avoid undefined function.
 
-# 2018-07-19
+## 2018-07-19
 
 - Fix error of `isFile` check.
 - Ignore undefined function on service start.
 
-# 2018-07-17
+## 2018-07-17
 
 - Add `coc.preference.jumpCommand` to settings.
 - Make coc service standalone.
 
-# 2018-07-16
+## 2018-07-16
 
 - Support arguments for `runCommand` action.
 - Add coc command `workspace.showOutput`.
 - Support output channel for language server.
 - Support `[extension].trace.server` setting for trace server communication.
 
-# 2018-07-15
+## 2018-07-15
 
 - Support location list for diagnostic.
 - Add tsserver project errors command.
 
-# 2018-07-14
+## 2018-07-14
 
 - Add support for `preselect` of complete item.
 - Add support for socket language server configuration.
@@ -1920,16 +1922,16 @@
 - Fix buffer sometimes not attached.
 - Improve completion of JSON extension.
 
-# 2018-07-13
+## 2018-07-13
 
 - **Break change:** `diagnostic` in setting.json changed to `diagnostic`.
 - Fix clearHighlight arguments.
-- Add eslint extension https://github.com/Microsoft/vscode-eslint.
+- Add eslint extension <https://github.com/Microsoft/vscode-eslint>.
 - Fix snippet break with line have \$variable.
 - Use jsonc-parser replace json5.
 - Add `data/schema.json` for coc-settings.json.
 
-# 2018-07-12
+## 2018-07-12
 
 - Fix restart of tsserver not working.
 - Fix edit of current buffer change jumplist by using `:keepjumps`.

--- a/lua/coc/diagnostic.lua
+++ b/lua/coc/diagnostic.lua
@@ -1,0 +1,33 @@
+local M = {}
+
+local ns = vim.api.nvim_create_namespace('coc_diagnostic')
+
+function M.on_diagnostic_change()
+  vim.diagnostic.reset(ns)
+
+  local bufnr = vim.api.nvim_get_current_buf()
+  local ok, items = pcall(vim.api.nvim_buf_get_var, bufnr, 'coc_diagnostic_map')
+  if not ok or type(items) ~= 'table' or vim.tbl_isempty(items) then
+    return
+  end
+
+  local diagnostics = {}
+  for _, d in ipairs(items) do
+    diagnostics[#diagnostics + 1] = {
+      bufnr = 0,
+      lnum = d.location.range.start.line,
+      end_lnum = d.location.range['end'].line,
+      col = d.location.range.start.character,
+      end_col = d.location.range['end'].character,
+      severity = d.level,
+      message = d.message,
+      source = d.source,
+      code = d.code,
+      namespace = ns,
+    }
+  end
+
+  vim.diagnostic.set(ns, bufnr, diagnostics)
+end
+
+return M

--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -414,6 +414,10 @@ function! s:Enable(initialize)
     autocmd BufReadCmd,FileReadCmd,SourceCmd list://* call coc#list#setup(expand('<amatch>'))
     autocmd BufWriteCmd __coc_refactor__* :call coc#rpc#notify('saveRefactor', [+expand('<abuf>')])
     autocmd ColorScheme * call s:Highlight() | call s:Autocmd('ColorScheme')
+
+    if has('nvim-0.10')
+      autocmd User CocDiagnosticChange call v:lua.require('coc.diagnostic').on_diagnostic_change()
+    endif
   augroup end
   if a:initialize == 0
      call coc#rpc#request('attach', [])

--- a/src/__tests__/modules/diagnosticManager.test.ts
+++ b/src/__tests__/modules/diagnosticManager.test.ts
@@ -631,6 +631,21 @@ describe('diagnostic manager', () => {
       await nvim.command('bd!')
       await helper.waitFor('eval', ['get(g:,"items",[])'], [])
     })
+
+    it('should send to vim.diagnostic', async () => {
+      helper.updateConfiguration('diagnostic.displayByVimDiagnostic', true)
+
+      let doc = await createDocument()
+      let buf = nvim.createBuffer(doc.bufnr)
+      let items = await buf.getVar('coc_diagnostic_map') as any
+      expect(items.length).toBe(5)
+
+      let res = await nvim.lua('return vim.diagnostic.get()') as any[]
+      expect(res.length).toBe(5)
+      expect(res[0].severity).toBe(1)
+      expect(res[0].message).toBe('error')
+      expect(res[1].source).toBe('test')
+    })
   })
 
   describe('severityLevel & getNameFromSeverity', () => {
@@ -672,6 +687,8 @@ describe('diagnostic manager', () => {
       await manager.toggleDiagnosticBuffer(doc.bufnr, 1)
       res = await buf.getVar('coc_diagnostic_info') as any
       expect(res.error).toBe(2)
+      let items = await buf.getVar('coc_diagnostic_map') as any
+      expect(items.length).toBe(5)
     })
   })
 

--- a/src/diagnostic/util.ts
+++ b/src/diagnostic/util.ts
@@ -39,6 +39,7 @@ export interface DiagnosticConfig {
   checkCurrentLine: boolean
   enableMessage: string
   displayByAle: boolean
+  displayByVimDiagnostic: boolean
   signPriority: number
   level: number
   locationlistLevel: number | undefined


### PR DESCRIPTION
The `diagnostic.displayByVimDiagnostic` configuration will set diagnostics to nvim's `vim.diagnostic`, and prevent coc.nvim's handler to display them in virtualText/sign/floating etc.