### PR TITLE
docs: use BufRead in b:coc_enabled example

### DIFF
--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -1589,10 +1589,10 @@ Buffer variables 					*coc-buffer-variables*
 b:coc_enabled						*b:coc_enabled*
 
 	Set to `0` on buffer create if you don't want coc.nvim receive content
-	from buffer. Normally used with |BufAdd| autocmd, example:
+	from buffer. Normally used with |BufRead| autocmd, example:
 >
 	" Disable file with size > 1MB
-	autocmd BufAdd * if getfsize(expand('<afile>')) > 1024*1024 |
+	autocmd BufRead * if getfsize(expand('<afile>')) > 1024*1024 |
 				\ let b:coc_enabled=0 |
 				\ endif
 <


### PR DESCRIPTION
When the `BufAdd` event triggers, `<afile>` is not yet entered. So `b:coc_enabled = 0` is set to the wrong buffer, the one before you switch to the new buffer. The event should be `BufRead`.