### PR TITLE
fix(prompt): correct format of escape sequence

### DIFF
--- a/bin/prompt.js
+++ b/bin/prompt.js
@@ -41,7 +41,7 @@ rl._ttyWrite = function (code, key) {
 }
 
 function createSequences(str) {
-  return '\033]51;' + str + '\x07'
+  return '\x1b]51;' + str + '\x07'
 }
 
 function send(args) {


### PR DESCRIPTION
changing the octal escape sequence `\033` to hexadecimal `\x1b`, as tsserver reported error:

`Octal escape sequences are not allowed. Use the syntax '\x1b'`