### PR TITLE
Improve Vim9 highlight performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        neovim:
-          - "stable"
-          - "nightly"
+        versions:
+          - neovim: "stable"
+            vim: "v9.0.0815"
+          - neovim: "nightly"
+            vim: "v9.0.2076"
         node:
           - "20"
         include:
@@ -52,14 +54,14 @@ jobs:
         uses: rhysd/action-setup-vim@v1
         id: vim
         with:
-          version: v9.0.0815
+          version: ${{ matrix.versions.vim }}
 
       - name: Setup neovim
         id: nvim
         uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
-          version: ${{ matrix.neovim }}
+          version: ${{ matrix.versions.neovim }}
 
       - name: Install Dependencies
         run: |

--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -537,9 +537,9 @@ endfunction
 
 def s:funcs.buf_add_highlight(bufnr: number, srcId: number, hlGroup: string, line: number, colStart: number, colEnd: number, ...optionalArguments: list<dict<any>>): any
     const opts: dict<any> = get(optionalArguments, 0, {})
-    return coc#api#funcs_buf_add_highlight(bufnr, src_id, hl_group, line, col_start, col_end, opts)
+    return coc#api#funcs_buf_add_highlight(bufnr, srcId, hlGroup, line, colStart, colEnd, opts)
 enddef
-" To be called directly for performance reason
+" To be called directly for better performance
 def coc#api#funcs_buf_add_highlight(bufnr: number, srcId: number, hlGroup: string, line: number, colStart: number, colEnd: number, propTypeOpts: dict<any> = {}): any
   var sourceId: number
   if srcId == 0

--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -535,7 +535,12 @@ function! s:funcs.buf_get_mark(bufnr, name)
   return [line("'" . a:name), col("'" . a:name) - 1]
 endfunction
 
-def s:funcs.buf_add_highlight(bufnr: number, srcId: number, hlGroup: string, line: number, colStart: number, colEnd: number, ...list: list<dict<any>>): any
+def s:funcs.buf_add_highlight(bufnr: number, srcId: number, hlGroup: string, line: number, colStart: number, colEnd: number, ...optionalArguments: list<dict<any>>): any
+    const opts: dict<any> = get(optionalArguments, 0, {})
+    return coc#api#funcs_buf_add_highlight(bufnr, src_id, hl_group, line, col_start, col_end, opts)
+enddef
+" To be called directly for performance reason
+def coc#api#funcs_buf_add_highlight(bufnr: number, srcId: number, hlGroup: string, line: number, colStart: number, colEnd: number, propTypeOpts: dict<any> = {}): any
   var sourceId: number
   if srcId == 0
     sourceId = s:max_src_id + 1
@@ -550,7 +555,7 @@ def s:funcs.buf_add_highlight(bufnr: number, srcId: number, hlGroup: string, lin
     add(propTypes, propType)
     s:id_types[srcId] = propTypes
     if empty(prop_type_get(propType))
-      prop_type_add(propType, extend({'highlight': hlGroup}, get(list, 0, {})))
+      prop_type_add(propType, extend({'highlight': hlGroup}, propTypeOpts))
     endif
   endif
   const columnEnd: number = colEnd == -1 ? strlen(get(getbufline(bufferNumber, line + 1), 0, '')) + 1 : colEnd + 1

--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -98,12 +98,12 @@ function! s:tabnr_id(nr) abort
   return tid
 endfunction
 
-function! s:generate_id(bufnr) abort
-  let max = get(s:buffer_id, a:bufnr, s:prop_offset)
-  let id = max + 1
-  let s:buffer_id[a:bufnr] = id
+def s:generate_id(bufnr: number): number
+  const max: number = get(s:buffer_id, bufnr, s:prop_offset)
+  const id: number = max + 1
+  s:buffer_id[bufnr] = id
   return id
-endfunction
+enddef
 
 function! s:win_execute(winid, cmd, ...) abort
   let ref = get(a:000, 0, v:null)

--- a/autoload/coc/highlight.vim
+++ b/autoload/coc/highlight.vim
@@ -1,6 +1,6 @@
 scriptencoding utf-8
 let s:is_vim = !has('nvim')
-let s:supports_import_well = has("patch-9.1.0000")
+let s:supports_import_well = has("patch-9.0.2076")
 if s:supports_import_well
   import autoload '../../vim9/coc/highlight.vim' as vim9_coc_highlight
 endif

--- a/autoload/coc/highlight.vim
+++ b/autoload/coc/highlight.vim
@@ -194,7 +194,7 @@ function! coc#highlight#del_markers(bufnr, key, ids) abort
     return
   endif
   if s:is_vim
-    call vim9_coc_highlight.Del_markers(a: bufnr, a:ids)
+    call vim9_coc_highlight.Del_markers(a:bufnr, a:ids)
   else
     let ns = coc#highlight#create_namespace(a:key)
     for id in a:ids

--- a/autoload/coc/highlight.vim
+++ b/autoload/coc/highlight.vim
@@ -195,7 +195,7 @@ function! coc#highlight#del_markers(bufnr, key, ids) abort
   endif
   let ns = coc#highlight#create_namespace(a:key)
   if s:is_vim
-    call vim9_coc_highlight.Del_markers(a:bufnr, a:ids)
+    call vim9_coc_highlight.Del_markers(a:bufnr, a:ids, a:key)
   else
     for id in a:ids
       call nvim_buf_del_extmark(a:bufnr, ns, id)

--- a/autoload/coc/highlight.vim
+++ b/autoload/coc/highlight.vim
@@ -147,7 +147,7 @@ function! coc#highlight#get_highlights(bufnr, key, ...) abort
     return v:lua.require('coc.highlight').getHighlights(a:bufnr, a:key, start, end)
   else
     let ns = s:namespace_map[a:key]
-    return s:vim9_coc_highlight.Get_Highlights(a:bufnr, ns, start, end)
+    return s:vim9_coc_highlight.Get_highlights(a:bufnr, ns, start, end)
   endif
 endfunction
 

--- a/autoload/coc/highlight.vim
+++ b/autoload/coc/highlight.vim
@@ -673,11 +673,11 @@ if !s:is_vim
   " @workaround Prevent nvim running into the branch for vim below
   finish
 else
-  def coc#highlight#add_highlight(bufnr: number, src_id: number, hl_group: string, line: number, col_start: number, col_end: number, ...list: list<dict<any>>)
-    const opts: dict<any> = get(list, 0, {})
+  def coc#highlight#add_highlight(bufnr: number, src_id: number, hl_group: string, line: number, col_start: number, col_end: number, ...optionalArguments: list<dict<any>>)
+    const opts: dict<any> = get(optionalArguments, 0, {})
     if !hlexists(hl_group)
       execute $'highlight {hl_group} ctermfg=NONE'
     endif
-    coc#api#exec('buf_add_highlight', [bufnr, src_id, hl_group, line, col_start, col_end, opts])
+    coc#api#funcs_buf_add_highlight(bufnr, src_id, hl_group, line, col_start, col_end, opts)
   enddef
 endif

--- a/autoload/coc/highlight.vim
+++ b/autoload/coc/highlight.vim
@@ -193,10 +193,10 @@ function! coc#highlight#del_markers(bufnr, key, ids) abort
   if !bufloaded(a:bufnr)
     return
   endif
+  let ns = coc#highlight#create_namespace(a:key)
   if s:is_vim
     call vim9_coc_highlight.Del_markers(a:bufnr, a:ids)
   else
-    let ns = coc#highlight#create_namespace(a:key)
     for id in a:ids
       call nvim_buf_del_extmark(a:bufnr, ns, id)
     endfor

--- a/autoload/coc/highlight.vim
+++ b/autoload/coc/highlight.vim
@@ -1,5 +1,8 @@
 scriptencoding utf-8
 let s:is_vim = !has('nvim')
+if s:is_vim
+  import autoload '../../vim9/coc/highlight.vim' as vim9_coc_highlight
+endif
 let s:namespace_map = {}
 let s:ns_id = 1
 let s:diagnostic_hlgroups = ['CocErrorHighlight', 'CocWarningHighlight', 'CocInfoHighlight', 'CocHintHighlight', 'CocDeprecatedHighlight', 'CocUnusedHighlight']
@@ -176,9 +179,9 @@ function! coc#highlight#set(bufnr, key, highlights, priority) abort
     call v:lua.require('coc.highlight').set(a:bufnr, ns, a:highlights, a:priority)
   else
     if len(a:highlights) > g:coc_highlight_maximum_count
-      call s:add_highlights_timer(a:bufnr, ns, a:highlights, a:priority)
+      call vim9_coc_highlight.Add_highlights_timer(a:bufnr, ns, a:highlights, a:priority)
     else
-      call s:add_highlights(a:bufnr, ns, a:highlights, a:priority)
+      call vim9_coc_highlight.Add_highlights(a:bufnr, ns, a:highlights, a:priority)
     endif
   endif
 endfunction
@@ -639,37 +642,6 @@ function! s:update_highlights_timer(bufnr, changedtick, key, priority, groups, i
   if a:idx < len(a:groups) - 1
     call timer_start(50, { -> s:update_highlights_timer(a:bufnr, a:changedtick, a:key, a:priority, a:groups, a:idx + 1)})
   endif
-endfunction
-
-function! s:add_highlights_timer(bufnr, ns, highlights, priority) abort
-  let lhl = len(a:highlights)
-  let maxc = g:coc_highlight_maximum_count
-  if maxc < lhl
-    let hls = a:highlights[:maxc-1]
-    let next = a:highlights[maxc:]
-  else
-    let hls = a:highlights[:]
-    let next = []
-  endif
-  call s:add_highlights(a:bufnr, a:ns, hls, a:priority)
-  if len(next)
-    call timer_start(30, {->s:add_highlights_timer(a:bufnr, a:ns, next, a:priority)})
-  endif
-endfunction
-
-function! s:add_highlights(bufnr, ns, highlights, priority) abort
-  if bufwinnr(a:bufnr) == -1 " check buffer exists
-    return
-  endif
-  for item in a:highlights
-    let opts = {
-          \ 'priority': a:priority,
-          \ 'combine': get(item, 4, 1) ? 1 : 0,
-          \ 'start_incl': get(item, 5, 0) ? 1 : 0,
-          \ 'end_incl':  get(item, 6, 0) ? 1 : 0,
-          \ }
-    call coc#highlight#add_highlight(a:bufnr, a:ns, item[0], item[1], item[2], item[3], opts)
-  endfor
 endfunction
 
 function! s:to_group(items) abort

--- a/autoload/coc/highlight.vim
+++ b/autoload/coc/highlight.vim
@@ -208,9 +208,9 @@ function! coc#highlight#del_markers(bufnr, key, ids) abort
   let ns = coc#highlight#create_namespace(a:key)
   if s:is_vim
     if s:supports_import_well
-      call vim9_coc_highlight.Del_markers(a:bufnr, a:ids, a:key)
+      call vim9_coc_highlight.Del_markers(a:bufnr, a:ids)
     else
-      call s:del_markers(a:bufnr, a:ids, a:key)
+      call s:del_markers(a:bufnr, a:ids)
     endif
   else
     for id in a:ids
@@ -763,24 +763,7 @@ def s:prop_type_hlgroup(type: string): string
   return substitute(type, '_\d\+$', '', '')
 enddef
 
-def s:del_markers(bufnr: number, ids: list<number>, namespaceKey: string)
-
-  # Script local variables in "../../vim9/coc/highlight.vim"
-  const NAMESPACE_SEMANTIC_TOKENS = 'semanticTokens'
-  const OFFSET_SEMANTIC_HIGHLIGHT_REGIONS: number = &lines
-
-  if namespaceKey == NAMESPACE_SEMANTIC_TOKENS
-    const winTopLine: number = winsaveview()['topline']
-    const winHeight: number = winheight(0)
-    const winBottomLine: number = winTopLine + winHeight - 1
-    const lineStart: number = winTopLine - OFFSET_SEMANTIC_HIGHLIGHT_REGIONS
-    const lineEnd: number = winBottomLine + OFFSET_SEMANTIC_HIGHLIGHT_REGIONS
-    for id in ids
-      prop_remove({'bufnr': bufnr, 'id': id}, max([ lineStart, 1 ]), lineEnd)
-    endfor
-    return
-  endif
-
+def s:del_markers(bufnr: number, ids: list<number>)
   for id in ids
     prop_remove({'bufnr': bufnr, 'id': id})
   endfor

--- a/autoload/coc/highlight.vim
+++ b/autoload/coc/highlight.vim
@@ -193,14 +193,14 @@ function! coc#highlight#del_markers(bufnr, key, ids) abort
   if !bufloaded(a:bufnr)
     return
   endif
-  let ns = coc#highlight#create_namespace(a:key)
-  for id in a:ids
-    if s:is_vim
-      call prop_remove({'bufnr': a:bufnr, 'id': id})
-    else
+  if s:is_vim
+    call vim9_coc_highlight.Del_markers(a: bufnr, a:ids)
+  else
+    let ns = coc#highlight#create_namespace(a:key)
+    for id in a:ids
       call nvim_buf_del_extmark(a:bufnr, ns, id)
-    endif
-  endfor
+    endfor
+  endif
 endfunction
 
 " highlight LSP range, opts contains 'combine' 'priority' 'start_incl' 'end_incl'

--- a/autoload/coc/highlight.vim
+++ b/autoload/coc/highlight.vim
@@ -251,10 +251,10 @@ function! coc#highlight#ranges(bufnr, key, hlGroup, ranges, ...) abort
   endfor
 endfunction
 
-function! coc#highlight#add_highlight(bufnr, src_id, hl_group, line, col_start, col_end, ...) abort
-  let opts = get(a:, 1, {})
-  let priority = get(opts, 'priority', v:null)
-  if !s:is_vim
+if !s:is_vim
+  function! coc#highlight#add_highlight(bufnr, src_id, hl_group, line, col_start, col_end, ...) abort
+    let opts = get(a:, 1, {})
+    let priority = get(opts, 'priority', v:null)
     if a:src_id == -1
       call nvim_buf_add_highlight(a:bufnr, a:src_id, a:hl_group, a:line, a:col_start, a:col_end)
     else
@@ -272,13 +272,16 @@ function! coc#highlight#add_highlight(bufnr, src_id, hl_group, line, col_start, 
         " the end_col could be invalid, ignore this error
       endtry
     endif
-  else
-    if !hlexists(a:hl_group)
-      execute 'highlight '.a:hl_group.' ctermfg=NONE'
+  endfunction
+else
+  def coc#highlight#add_highlight(bufnr: number, src_id: number, hl_group: string, line: number, col_start: number, col_end: number, ...list: list<dict<any>>)
+    const opts: dict<any> = get(list, 0, {})
+    if !hlexists(hl_group)
+      execute $'highlight {hl_group} ctermfg=NONE'
     endif
-    call coc#api#exec('buf_add_highlight', [a:bufnr, a:src_id, a:hl_group, a:line, a:col_start, a:col_end, opts])
-  endif
-endfunction
+    coc#api#exec('buf_add_highlight', [bufnr, src_id, hl_group, line, col_start, col_end, opts])
+  enddef
+endif
 
 function! coc#highlight#clear_highlight(bufnr, key, start_line, end_line) abort
   let bufnr = a:bufnr == 0 ? bufnr('%') : a:bufnr

--- a/vim9/coc/highlight.vim
+++ b/vim9/coc/highlight.vim
@@ -1,0 +1,46 @@
+vim9script
+# Called by `coc#highlight#set(`
+
+# From `coc#highlight#set(`:
+#   type HighlightItem = [hlGroup, lnum, colStart, colEnd, combine?, start_incl?, end_incl?]
+# From `src/core/highlights.ts`:
+#   type HighlightItemDef = [string, number, number, number, number?, number?, number?]
+type HighlightItem = list<any>
+type HighlightItemList = list<HighlightItem>
+
+export def Add_highlights_timer(bufnr: number, ns: number, highlights: HighlightItemList, priority: number)
+  const lengthOfHighlightItemList: number = len(highlights)
+  const maximumCount: number = g:coc_highlight_maximum_count
+  var highlightItemList: HighlightItemList
+  var next: HighlightItemList
+  if maximumCount < lengthOfHighlightItemList
+    highlightItemList = highlights[ : maximumCount - 1]
+    next = highlights[maximumCount : ]
+  else
+    highlightItemList = highlights[ : ]
+    next = []
+  endif
+  Add_highlights(bufnr, ns, highlightItemList, priority)
+  if len(next) > 0
+    timer_start(30,  (_) => Add_highlights_timer(bufnr, ns, next, priority))
+  endif
+enddef
+
+export def Add_highlights(bufnr: number, ns: number, highlights: HighlightItemList, priority: number)
+  if bufwinnr(bufnr) == -1 # check buffer exists
+    return
+  endif
+  for highlightItem in highlights
+    const [ hlGroup: string, lnum: number, colStart: number, colEnd: number; _ ] = highlightItem
+    const combine: number = get(highlightItem, 4, 1)
+    const start_incl: number = get(highlightItem, 5, 0)
+    const end_incl: number = get(highlightItem, 6, 0)
+    const opts: dict<any> = {
+      'priority': priority,
+      'combine': combine,
+      'start_incl': start_incl,
+      'end_incl':  end_incl,
+    }
+    coc#highlight#add_highlight(bufnr, ns, hlGroup, lnum, colStart, colEnd, opts)
+  endfor
+enddef

--- a/vim9/coc/highlight.vim
+++ b/vim9/coc/highlight.vim
@@ -1,4 +1,5 @@
 vim9script
+scriptencoding utf-8
 
 # From `coc#highlight#set(`:
 #   type HighlightItem = [hlGroup, lnum, colStart, colEnd, combine?, start_incl?, end_incl?]

--- a/vim9/coc/highlight.vim
+++ b/vim9/coc/highlight.vim
@@ -50,7 +50,7 @@ enddef
 #   type HighlightItemResult = [string, number, number, number, number?]
 type HighlightItemResult = list<any>
 
-export def Get_Highlights(bufnr: number, ns: number, start: number, end: number): list<HighlightItemResult>
+export def Get_highlights(bufnr: number, ns: number, start: number, end: number): list<HighlightItemResult>
   const types: list<string> = coc#api#get_types(ns)
   if empty(types)
     return []

--- a/vim9/coc/highlight.vim
+++ b/vim9/coc/highlight.vim
@@ -1,6 +1,4 @@
 vim9script
-# From `handler/semanticTokens/buffer.ts`
-const NAMESPACE_SEMANTIC_TOKENS = 'semanticTokens'
 
 # From `coc#highlight#set(`:
 #   type HighlightItem = [hlGroup, lnum, colStart, colEnd, combine?, start_incl?, end_incl?]
@@ -74,22 +72,7 @@ def Prop_type_hlgroup(type: string): string
   return substitute(type, '_\d\+$', '', '')
 enddef
 
-# Used in `src/handler/semanticTokens/buffer.ts highlightRegions(`
-# For better experience when scrolling
-const OFFSET_SEMANTIC_HIGHLIGHT_REGIONS: number = &lines
-export def Del_markers(bufnr: number, ids: list<number>, namespaceKey: string)
-  if namespaceKey == NAMESPACE_SEMANTIC_TOKENS
-    const winTopLine: number = winsaveview()['topline']
-    const winHeight: number = winheight(0)
-    const winBottomLine: number = winTopLine + winHeight - 1
-    const lineStart: number = winTopLine - OFFSET_SEMANTIC_HIGHLIGHT_REGIONS
-    const lineEnd: number = winBottomLine + OFFSET_SEMANTIC_HIGHLIGHT_REGIONS
-    for id in ids
-      prop_remove({'bufnr': bufnr, 'id': id}, max([ lineStart, 1 ]), lineEnd)
-    endfor
-    return
-  endif
-
+export def Del_markers(bufnr: number, ids: list<number>)
   for id in ids
     prop_remove({'bufnr': bufnr, 'id': id})
   endfor

--- a/vim9/coc/highlight.vim
+++ b/vim9/coc/highlight.vim
@@ -69,7 +69,7 @@ def Prop_type_hlgroup(type: string): string
   return substitute(type, '_\d\+$', '', '')
 enddef
 
-def Del_markers(bufnr: number, ids: list<number>)
+export def Del_markers(bufnr: number, ids: list<number>)
   for id in ids
     prop_remove({'bufnr': bufnr, 'id': id})
   endfor

--- a/vim9/coc/highlight.vim
+++ b/vim9/coc/highlight.vim
@@ -68,3 +68,9 @@ enddef
 def Prop_type_hlgroup(type: string): string
   return substitute(type, '_\d\+$', '', '')
 enddef
+
+def Del_markers(bufnr: number, ids: list<number>)
+  for id in ids
+    prop_remove({'bufnr': bufnr, 'id': id})
+  endfor
+enddef

--- a/vim9/coc/highlight.vim
+++ b/vim9/coc/highlight.vim
@@ -44,13 +44,17 @@ export def Add_highlights(bufnr: number, ns: number, highlights: HighlightItemLi
   endfor
 enddef
 
-export def Get_Highlights(bufnr: number, ns: number, start: number, end: number): list<list<any>>
+# From `src/core/highlights.ts`:
+#   type HighlightItemResult = [string, number, number, number, number?]
+type HighlightItemResult = list<any>
+
+export def Get_Highlights(bufnr: number, ns: number, start: number, end: number): list<HighlightItemResult>
   const types: list<string> = coc#api#get_types(ns)
   if empty(types)
     return []
   endif
 
-  final res: list<list<any>> = []
+  final res: list<HighlightItemResult> = []
   const endLnum: number = end == -1 ? -1 : end + 1
   for prop in prop_list(start + 1, {'bufnr': bufnr, 'types': types, 'end_lnum': endLnum})
     if prop['start'] == 0 || prop['end'] == 0

--- a/vim9/coc/highlight.vim
+++ b/vim9/coc/highlight.vim
@@ -1,4 +1,6 @@
 vim9script
+# From `handler/semanticTokens/buffer.ts`
+const NAMESPACE_SEMANTIC_TOKENS = 'semanticTokens'
 
 # From `coc#highlight#set(`:
 #   type HighlightItem = [hlGroup, lnum, colStart, colEnd, combine?, start_incl?, end_incl?]
@@ -72,9 +74,16 @@ def Prop_type_hlgroup(type: string): string
   return substitute(type, '_\d\+$', '', '')
 enddef
 
-export def Del_markers(bufnr: number, ids: list<number>)
-  const [winTopLine: number, winBottomLine: number] = coc#window#visible_range()
+export def Del_markers(bufnr: number, ids: list<number>, namespaceKey: string)
+  if namespaceKey == NAMESPACE_SEMANTIC_TOKENS
+    const [winTopLine: number, winBottomLine: number] = coc#window#visible_range()
+    for id in ids
+      prop_remove({'bufnr': bufnr, 'id': id}, winTopLine, winBottomLine)
+    endfor
+    return
+  endif
+
   for id in ids
-    prop_remove({'bufnr': bufnr, 'id': id}, winTopLine, winBottomLine)
+    prop_remove({'bufnr': bufnr, 'id': id})
   endfor
 enddef

--- a/vim9/coc/highlight.vim
+++ b/vim9/coc/highlight.vim
@@ -44,3 +44,27 @@ export def Add_highlights(bufnr: number, ns: number, highlights: HighlightItemLi
     coc#highlight#add_highlight(bufnr, ns, hlGroup, lnum, colStart, colEnd, opts)
   endfor
 enddef
+
+export def Get_Highlights(bufnr: number, ns: number, start: number, end: number): list<any>
+  final res: list<list<any>> = []
+  const types: list<string> = coc#api#get_types(ns)
+  if empty(types)
+    return res
+  endif
+
+  const endLnum: number = end == -1 ? -1 : end + 1
+  for prop in prop_list(start + 1, {'bufnr': bufnr, 'types': types, 'end_lnum': endLnum})
+    if prop['start'] == 0 || prop['end'] == 0
+      # multi line textprop are not supported, simply ignore it
+      continue
+    endif
+    const startCol: number = prop['col'] - 1
+    const endCol: number = startCol + prop['length']
+    add(res, [ Prop_type_hlgroup(prop['type']), prop['lnum'] - 1, startCol, endCol, prop['id'] ])
+  endfor
+  return res
+enddef
+
+def Prop_type_hlgroup(type: string): string
+  return substitute(type, '_\d\+$', '', '')
+enddef

--- a/vim9/coc/highlight.vim
+++ b/vim9/coc/highlight.vim
@@ -1,5 +1,4 @@
 vim9script
-# Called by `coc#highlight#set(`
 
 # From `coc#highlight#set(`:
 #   type HighlightItem = [hlGroup, lnum, colStart, colEnd, combine?, start_incl?, end_incl?]

--- a/vim9/coc/highlight.vim
+++ b/vim9/coc/highlight.vim
@@ -70,7 +70,8 @@ def Prop_type_hlgroup(type: string): string
 enddef
 
 export def Del_markers(bufnr: number, ids: list<number>)
+  const [winTopLine: number, winBottomLine: number] = coc#window#visible_range()
   for id in ids
-    prop_remove({'bufnr': bufnr, 'id': id})
+    prop_remove({'bufnr': bufnr, 'id': id}, winTopLine, winBottomLine)
   endfor
 enddef

--- a/vim9/coc/highlight.vim
+++ b/vim9/coc/highlight.vim
@@ -74,11 +74,18 @@ def Prop_type_hlgroup(type: string): string
   return substitute(type, '_\d\+$', '', '')
 enddef
 
+# Used in `src/handler/semanticTokens/buffer.ts highlightRegions(`
+# For better experience when scrolling
+const OFFSET_SEMANTIC_HIGHLIGHT_REGIONS: number = &lines
 export def Del_markers(bufnr: number, ids: list<number>, namespaceKey: string)
   if namespaceKey == NAMESPACE_SEMANTIC_TOKENS
-    const [winTopLine: number, winBottomLine: number] = coc#window#visible_range()
+    const winTopLine: number = winsaveview()['topline']
+    const winHeight: number = winheight(0)
+    const winBottomLine: number = winTopLine + winHeight - 1
+    const lineStart: number = winTopLine - OFFSET_SEMANTIC_HIGHLIGHT_REGIONS
+    const lineEnd: number = winBottomLine + OFFSET_SEMANTIC_HIGHLIGHT_REGIONS
     for id in ids
-      prop_remove({'bufnr': bufnr, 'id': id}, winTopLine, winBottomLine)
+      prop_remove({'bufnr': bufnr, 'id': id}, max([ lineStart, 1 ]), lineEnd)
     endfor
     return
   endif

--- a/vim9/coc/highlight.vim
+++ b/vim9/coc/highlight.vim
@@ -45,13 +45,13 @@ export def Add_highlights(bufnr: number, ns: number, highlights: HighlightItemLi
   endfor
 enddef
 
-export def Get_Highlights(bufnr: number, ns: number, start: number, end: number): list<any>
-  final res: list<list<any>> = []
+export def Get_Highlights(bufnr: number, ns: number, start: number, end: number): list<list<any>>
   const types: list<string> = coc#api#get_types(ns)
   if empty(types)
-    return res
+    return []
   endif
 
+  final res: list<list<any>> = []
   const endLnum: number = end == -1 ? -1 : end + 1
   for prop in prop_list(start + 1, {'bufnr': bufnr, 'types': types, 'end_lnum': endLnum})
     if prop['start'] == 0 || prop['end'] == 0


### PR DESCRIPTION
Resolves #5199
Ports some slow functions to `:def` functions.

##### [Benchmark](https://github.com/neoclide/coc.nvim/wiki/F.A.Q#how-can-i-profile-vim):

```vim
FUNCTIONS SORTED ON SELF TIME
count     total (s)      self (s)  function
17513   0.674963885   0.579616606  54()
17513   1.112946488   0.382665796  coc#highlight#add_highlight()
   17   0.304494455   0.304348708  coc#highlight#del_markers()
   45   1.296966406   0.186026396  <SNR>155_add_highlights()
   21   0.204020373   0.159163633  coc#highlight#get_highlights()
17513                 0.095347279  <SNR>50_generate_id()
14798                 0.044771580  <SNR>155_prop_type_hlgroup()

FUNCTIONS SORTED ON SELF TIME
count     total (s)      self (s)  function
   17                 0.237726631  <SNR>156_Del_markers()
17513   0.067899809   0.055712181  coc#api#funcs_buf_add_highlight()
   19   0.046720607   0.027843561  <SNR>156_Get_highlights()
   45   0.114023480   0.025991826  <SNR>156_Add_highlights()
17513   0.088438811   0.020539002  coc#highlight#add_highlight()
14798                 0.018780904  <SNR>156_Prop_type_hlgroup()
17513                 0.012187628  <SNR>50_generate_id()
```


`54()`: `autoload/coc/api.vim s:funcs.buf_add_highlight`, refactored to `coc#api#funcs_buf_add_highlight()`

___

nvim will run into [else branch for vim function](https://github.com/neoclide/coc.nvim/compare/master...atitcreate:coc.nvim:vim9-highlight?expand=1#diff-e8a53eb459c11e4f44c474b7d2ded76d2e57a245de816c7a770315c0de9a3932R675)  and throw `E488: Trailing characters`(worked around by `finish`), but not behave the same [for vim import](https://github.com/neoclide/coc.nvim/compare/master...atitcreate:coc.nvim:vim9-highlight?expand=1#diff-e8a53eb459c11e4f44c474b7d2ded76d2e57a245de816c7a770315c0de9a3932R4). I don't know whether this will affect nvim users.