### PR TITLE
Make use of the new CocFloatBorder highlight group

### DIFF
--- a/autoload/coc/dialog.vim
+++ b/autoload/coc/dialog.vim
@@ -674,7 +674,7 @@ function! s:create_prompt_win(bufnr, title, default, opts) abort
         \ 'title': a:title,
         \ 'lines': s:is_vim ? v:null : [a:default],
         \ 'highlight': get(a:opts, 'highlight', 'CocFloating'),
-        \ 'borderhighlight': [get(a:opts, 'borderhighlight', 'CocFloating')],
+        \ 'borderhighlight': [get(a:opts, 'borderhighlight', 'CocFloatBorder')],
         \ }))
 endfunction
 

--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -1463,7 +1463,7 @@ function! s:scroll_win(winid, forward, amount) abort
 endfunction
 
 function! s:get_borderhighlight(config) abort
-  let hlgroup = get(a:config, 'highlight',  'CocFloating')
+  let hlgroup = get(a:config, 'highlight', 'CocFloating')
   let borderhighlight = get(a:config, 'borderhighlight', v:null)
   if empty(borderhighlight)
     return hlgroup

--- a/data/schema.json
+++ b/data/schema.json
@@ -1204,7 +1204,7 @@
       "type": ["string", "null"],
       "default": null,
       "scope": "application",
-      "description": "Highlight group for border of dialog window/popup, default to 'CocFloating'"
+      "description": "Highlight group for border of dialog window/popup, default to 'CocFloatBorder'"
     },
     "dialog.floatHighlight": {
       "type": ["string", "null"],

--- a/src/__tests__/modules/menu.test.ts
+++ b/src/__tests__/modules/menu.test.ts
@@ -167,7 +167,7 @@ describe('Menu', () => {
     menu = new Menu(nvim, { items: ['one', 'two', 'three'] })
     expect(menu.buffer).toBeUndefined()
     await menu.onInputChar('session', 'j')
-    await menu.show({ floatHighlight: 'CocFloating', floatBorderHighlight: 'CocFloating' })
+    await menu.show({ floatHighlight: 'CocFloating', floatBorderHighlight: 'CocFloatBorder' })
     let id = await nvim.call('GetFloatWin') as number
     expect(id).toBeGreaterThan(0)
     let win = nvim.createWindow(id)

--- a/src/completion/pum.ts
+++ b/src/completion/pum.ts
@@ -119,7 +119,7 @@ export default class PopupMenu {
     if (pumFloatConfig.border) {
       obj.border = [1, 1, 1, 1]
       obj.rounded = pumFloatConfig.rounded ? 1 : 0
-      obj.borderhighlight = pumFloatConfig.borderhighlight ?? 'CocFloating'
+      obj.borderhighlight = pumFloatConfig.borderhighlight ?? 'CocFloatBorder'
     }
     obj.reverse = reversePumAboveCursor === true
     this._pumConfig = obj

--- a/src/model/dialog.ts
+++ b/src/model/dialog.ts
@@ -49,7 +49,7 @@ export interface DialogConfig {
    */
   highlights?: ReadonlyArray<HighlightItem>
   /**
-   * highlight groups for border, default to `"dialog.borderhighlight"` or 'CocFloating'
+   * highlight groups for border, default to `"dialog.borderhighlight"` or 'CocFloatBorder'
    */
   borderhighlight?: string
   /**

--- a/src/model/input.ts
+++ b/src/model/input.ts
@@ -142,7 +142,7 @@ export default class InputBox implements Disposable {
 
   public async show(title: string, preferences: InputPreference): Promise<boolean> {
     this.title = title
-    this.borderhighlight = preferences.borderhighlight ?? 'CocFloating'
+    this.borderhighlight = preferences.borderhighlight ?? 'CocFloatBorder'
     this.loading = false
     if (preferences.placeHolder && !this._input && !this.nvim.isVim) {
       this.clear = true


### PR DESCRIPTION
This makes use of the `CocFloatBorder` highlight group introduced in d825dbae9e59fb17a64d172b779ea8bc795aecf5. See also #5298. Without these changes, the `CocFloatBorder` highlight group is not used.

I searched the codebase for usage of `CocFloating` and replaced it with `CocFloatBorder` where it looked to me like it would be appropriate. I might have missed some spots and maybe not all changes in the PR should be applied.