### PR TITLE
fix: invalid buffer name

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -679,7 +679,7 @@ endfunction
 
 function! coc#util#get_changedtick(bufnr) abort
   if s:is_vim
-    call listener_flush(a:bufnr)
+    call listener_flush(bufname(a:bufnr))
   endif
   return getbufvar(a:bufnr, 'changedtick')
 endfunction


### PR DESCRIPTION
I got such error.

```
2025-04-07T11:58:50.396 ERROR (pid:5945) [node-client] - request error on "nvim_call_function" [ [32m'coc#util#get_changedtick'[39m, [ [33m1[39m ] ] Error: request error on "nvim_call_function" - Vim(call):E158: Invalid buffer name: 1 on api "call_function" ["coc#util#get_changedtick",[1]]
    at lg.patchChange [90m(/Users/unclebill/.vim/plugged/coc.nvim/[39mbuild/index.js:185:892[90m)[39m
    at ug.onBufEnter [90m(/Users/unclebill/.vim/plugged/coc.nvim/[39mbuild/index.js:187:9238[90m)[39m
    at [90m/Users/unclebill/.vim/plugged/coc.nvim/[39mbuild/index.js:58:6294
    at new Promise (<anonymous>)
    at a [90m(/Users/unclebill/.vim/plugged/coc.nvim/[39mbuild/index.js:58:6252[90m)[39m
    at [90m/Users/unclebill/.vim/plugged/coc.nvim/[39mbuild/index.js:58:5943
    at [90m/Users/unclebill/.vim/plugged/coc.nvim/[39mbuild/index.js:58:6024
    at Array.map (<anonymous>)
```
