### PR TITLE
refactor(vtext, vim9): Port `coc#vtext#add` to `:def` function

### DIFF
--- a/autoload/coc/vtext.vim
+++ b/autoload/coc/vtext.vim
@@ -87,18 +87,15 @@ def s:get_option(text_align: string, column: number, text_wrap: string): dict<an
   return {}
 enddef
 
-function! s:calc_padding_size(indent) abort
-  let tabSize = &shiftwidth
-  if tabSize == 0
-    let tabSize = &tabstop
-  endif
-  let padding = 0
-  for c in a:indent
-    if c == "\t"
-      let padding += tabSize - (padding % tabSize)
+def s:calc_padding_size(indent: string): number
+  const tabSize: number = &shiftwidth ?? &tabstop
+  var padding: number = 0
+  for character in indent
+    if character == "\t"
+      padding += tabSize - (padding % tabSize)
     else
-      let padding += 1
+      padding += 1
     endif
   endfor
   return padding
-endfunction
+enddef

--- a/autoload/coc/vtext.vim
+++ b/autoload/coc/vtext.vim
@@ -33,7 +33,7 @@ function! coc#vtext#add(bufnr, src_id, line, blocks, opts) abort
       let column = 0
     endif
     let first = 1
-    let base = s:get_option_vim(align, column, get(a:opts, 'text_wrap', 'truncate'))
+    let base = s:get_option(align, column, get(a:opts, 'text_wrap', 'truncate'))
     for [text, hl] in blocks
       let type = coc#api#create_type(a:src_id, hl, a:opts)
       let opts = extend({ 'text': text, 'type': type, 'bufnr': a:bufnr }, base)
@@ -73,14 +73,19 @@ function! coc#vtext#add(bufnr, src_id, line, blocks, opts) abort
   endif
 endfunction
 
-function! s:get_option_vim(align, column, wrap) abort
-  let opts = {}
-  if a:column == 0
-    let opts['text_align'] = a:align
-    let opts['text_wrap'] = a:wrap
+if !s:is_vim
+  finish
+endif
+
+def s:get_option(text_align: string, column: number, text_wrap: string): dict<any>
+  if column == 0
+    return {
+      'text_align': text_align,
+      'text_wrap': text_wrap,
+    }
   endif
-  return opts
-endfunction
+  return {}
+enddef
 
 function! s:calc_padding_size(indent) abort
   let tabSize = &shiftwidth


### PR DESCRIPTION
Benchmark with `:profile` on a large file(`build/index.js`) after multiple `500j`:
```vim
FUNCTIONS SORTED ON SELF TIME
count     total (s)      self (s)  function
 2024   0.203985531   0.169318569  coc#vtext#add()    " Before
 2024   0.096831518   0.075034772  coc#vtext#add()    " After
```
Profile log shows the total time is almost twice the time of the lines added up, not sure why. <br>
`coc#vtext#add` is called by `coc#api s:call_atomic`, which on each call executes `coc#vtext#add` multiple times.

Benchmark with `reltime(`: 

<details>

<summary>steps</summary>

Apply this patch, then open `build/index.js` and wait for outputs of `:echom`

```diff
diff --git a/autoload/coc/api.vim b/autoload/coc/api.vim
index d62f040..ba52e9c 100644
--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -972,6 +972,10 @@ endfunction
 
 function! coc#api#notify(method, args) abort
   try
+    if (a:method !=# 'set_keymap')
+      let startTime = reltime()
+    endif
+
     let tick = b:changedtick
     " vim throw error with return when vim9 function has no return value.
     if a:method ==# 'call_function'
@@ -988,6 +992,14 @@ function! coc#api#notify(method, args) abort
     if b:changedtick != tick
       call listener_flush()
     endif
+    if (a:method !=# 'set_keymap')
+      const time = reltime(startTime)->reltimefloat()
+       if (time > 0.01)
+         echohl MessageWindow | echom a:method| echohl None
+         echohl MoreMsg | echom a:args| echohl None
+         echom time
+       endif
+    endif
   catch /.*/
     call coc#rpc#notify('nvim_error_event', [0, v:exception.' on api "'.a:method.'" '.json_encode(a:args)])
   endtry
```

</details>

```vim
" Before   " After
0,013629   0.014513
0.143806   0.093922
0.125432   0.08832
```