### PR TITLE
fix(vim9): correct tabSize

### DIFF
--- a/autoload/coc/vim9.vim
+++ b/autoload/coc/vim9.vim
@@ -87,7 +87,7 @@ enddef
 
 # Can't use strdisplaywidth as it doesn't support bufnr
 def Calc_padding_size(bufnr: number, indent: string): number
-  const tabSize: number = getbufvar(bufnr, '&shiftwidth', getbufvar(bufnr, '&tabstop', 8))
+  const tabSize: number = getbufvar(bufnr, '&shiftwidth') ?? getbufvar(bufnr, '&tabstop', 8)
   var padding: number = 0
   for character in indent
     if character == "\t"
@@ -180,7 +180,7 @@ def Add_vtexts_timer(bufnr: number, ns: number, items: list<any>, indent: bool,
   endif
 enddef
 
-export def Set_visual_texts(bufnr: number, ns: number, items: list<any>, indent: bool, priority: number): void
+export def Set_virtual_texts(bufnr: number, ns: number, items: list<any>, indent: bool, priority: number): void
   const maxCount = get(g:, 'coc_highlight_maximum_count', 500)
   const changedtick = getbufvar(bufnr, 'changedtick', 0)
   Add_vtexts_timer(bufnr, ns, items, indent, priority, changedtick, maxCount)

--- a/autoload/coc/vtext.vim
+++ b/autoload/coc/vtext.vim
@@ -15,7 +15,7 @@ let s:is_vim = !has('nvim')
 " priority - Highlight priority
 function! coc#vtext#set(bufnr, ns, items, indent, priority) abort
   if s:is_vim
-    call coc#vim9#Set_visual_texts(a:bufnr, a:ns, a:items, a:indent, a:priority)
+    call coc#vim9#Set_virtual_texts(a:bufnr, a:ns, a:items, a:indent, a:priority)
   else
     call v:lua.require('coc.vtext').set(a:bufnr, a:ns, a:items, a:indent, a:priority)
   endif


### PR DESCRIPTION
cc @atitcreate

https://github.com/neoclide/coc.nvim/commit/a277167aa523983c3f647be448f717276def5ed8#diff-2ecbe67c0b76275c0dddfecefdb420b8489f480c51a8a792518164129dcd7390