### PR TITLE
Guard against unlisted or invalid buffers

### DIFF
--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -264,12 +264,11 @@ function! s:Autocmd(...) abort
 endfunction
 
 function! s:HandleBufEnter(bufnr) abort
-  if !bufexists(a:bufnr) || !buflisted(a:bufnr)
-    return
-  endif
   if s:is_vim
-      "" The buffer could be hidden before, lines may not synchronized
-    call listener_flush(a:bufnr)
+    if type(a:bufnr) == v:t_number && bufloaded(a:bufnr)
+      " The buffer could be hidden before, lines may not synchronized
+      call listener_flush(a:bufnr)
+    endif
   endif
   call s:Autocmd('BufEnter', a:bufnr)
 endfunction

--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -264,6 +264,9 @@ function! s:Autocmd(...) abort
 endfunction
 
 function! s:HandleBufEnter(bufnr) abort
+  if !bufexists(a:bufnr) || !buflisted(a:bufnr)
+    return
+  endif
   if s:is_vim
       "" The buffer could be hidden before, lines may not synchronized
     call listener_flush(a:bufnr)


### PR DESCRIPTION
When attempting to open new directory as buffer, I'd bump into the below error message:

> Error detected while processing function <SNR>1_opendir[4]..BufEnter Autocommands for "*"..function <SNR>82_HandleBufEnter:
line    3:
E158: Invalid buffer name: 25

My interpretation of the error is that something on the Coc side is trying to interpret the buffer number (25) as a buffer name (a path string), and fails when the buffer is invalid (e.g., it's a directory or not yet fully loaded). Adding the conditions to guard against unlisted or invalid buffers.