### PR TITLE
feat(autocmd): backwards compatible

### DIFF
--- a/src/core/autocmds.ts
+++ b/src/core/autocmds.ts
@@ -112,7 +112,13 @@ export default class Autocmds implements Disposable {
       this.nvim.command(cmd, true)
     } else {
       let opt = toAutocmdOption(item)
-      this.nvim.createAutocmd(item.option.event, opt, true)
+      this.nvim.createAutocmd(
+        Array.isArray(item.option.event)
+          ? item.option.event
+          : item.option.event.split(","),
+        opt,
+        true
+      )
     }
   }
 


### PR DESCRIPTION
autocmd is broken with latest update
```
2025-05-04T14:50:45.339 ERROR (pid:17884) [node-client] - Error event from nvim: [33m1[39m Invalid 'event': 'CursorMoved,CursorMovedI'
```