### PR TITLE
fix(jump): avoid 'drop' stealing focus in multi-window same-buffer jumps

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -155,15 +155,17 @@ function! coc#util#jump(cmd, filepath, ...) abort
     return
   elseif a:cmd ==# 'drop'
     let dstbuf = bufadd(path)
-    let binfo = getbufinfo(dstbuf)
-    if len(binfo) == 1 && empty(binfo[0].windows)
-      execute 'buffer '.dstbuf
-      let &buflisted = 1
-    else
-      let saved = &wildignore
-      set wildignore=
-      execute 'drop '.fnameescape(file)
-      execute 'set wildignore='.saved
+    if bufnr('%') != dstbuf
+      let binfo = getbufinfo(dstbuf)
+      if len(binfo) == 1 && empty(binfo[0].windows)
+        execute 'buffer '.dstbuf
+        let &buflisted = 1
+      else
+        let saved = &wildignore
+        set wildignore=
+        execute 'drop '.fnameescape(file)
+        execute 'set wildignore='.saved
+      endif
     endif
   elseif a:cmd ==# 'edit' && bufloaded(file)
     exe 'b '.bufnr(file)


### PR DESCRIPTION
When jumping within the same file opened in multiple windows (e.g. via `:vsplit`),
`:call CocAction('jumpDefinition', 'drop')` may switch to the first window containing the buffer, causing the jump
to land in a different window than the user's current one.

This change adds a check to avoid running `drop` when the target buffer is already the current one, improving the UX in split-window navigation.

Before:

https://github.com/user-attachments/assets/9ec99106-0e26-44a6-9012-6d2a8e7ecef3






After:

https://github.com/user-attachments/assets/d8fd8e2b-4f15-4834-b7a9-4b3d3fdcd366








