### PR TITLE
docs: add deepwiki badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
       <a href="https://codecov.io/gh/neoclide/coc.nvim"><img alt="Codecov Coverage Status" src="https://img.shields.io/codecov/c/github/neoclide/coc.nvim.svg?style=flat-square"></a>
     <a href="doc/coc.txt"><img alt="Doc" src="https://img.shields.io/badge/doc-%3Ah%20coc.txt-brightgreen.svg?style=flat-square"></a>
     <a href="https://matrix.to/#/#coc.nvim:matrix.org"><img alt="Matrix" src="https://img.shields.io/matrix/coc.nvim%3Amatrix.org?style=flat-square"></a>
+    <a href="https://deepwiki.com/neoclide/coc.nvim"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
   </p>
 </p>
 


### PR DESCRIPTION
> Add a badge to this wiki in the repo's README file to auto refresh the wiki weekly with the latest code. [Create badge](https://deepwiki.com/badge-maker?url=https%3A%2F%2Fdeepwiki.com%2Fneoclide%2Fcoc.nvim)