### PR TITLE
fix(workspaceFolder): load rootPatterns of user-defined language servers

### DIFF
--- a/src/__tests__/core/workspaceFolder.test.ts
+++ b/src/__tests__/core/workspaceFolder.test.ts
@@ -131,12 +131,10 @@ describe('WorkspaceFolderController', () => {
     })
 
     it('should add patterns from languageserver', () => {
-      workspaceFolder.addServerRootPatterns({
-        test: {
-          filetypes: ['vim'],
-          rootPatterns: ['bar']
-        }
-      })
+      updateConfiguration('languageserver.test', {
+        filetypes: ['vim'],
+        rootPatterns: ['bar']
+      }, undefined)
       workspaceFolder.addRootPattern('vim', ['foo'])
       let res = workspaceFolder.getServerRootPatterns('vim')
       expect(res.includes('foo')).toBe(true)


### PR DESCRIPTION
Previously, `rootPatterns` defined for custom language servers would not be picked up by coc.nvim. For example, if I have this in my configuration:
```vim
  autocmd User CocNvimInit call coc#config('languageserver.lua_ls', {
  \ 'filetypes': ['lua'],
  \ 'command': 'lua-language-server',
  \ 'rootPatterns': ['.luarc.json', '.luarc.jsonc'],
  \ 'settings': { 'Lua': coc#util#get_config('Lua') },
  \ })
```
and if I run `echo coc#util#root_patterns()` in a Lua buffer, I would get
```vim
{'global': ['.vim', '.git', '.hg', '.projections.json'], 'buffer': [], 'server': []}
```
which is clearly wrong. With my PR, I now get:
```vim
{'global': ['.vim', '.git', '.hg', '.projections.json'], 'buffer': [], 'server': ['.luarc.json', '.luarc.jsonc']}
```