### PR TITLE
feat(extension): support extensionDependencies

### DIFF
--- a/history.md
+++ b/history.md
@@ -2,6 +2,10 @@
 
 Notable changes of coc.nvim:
 
+## 2025-07-18
+
+- Add `extensionDependencies` support, declare dependencies on other extensions: `"extensionDependencies": ["extension-1", "extension-2"]`
+
 ## 2025-07-17
 
 - Add notifications history, view with `:CocList notifications`

--- a/src/extension/stat.ts
+++ b/src/extension/stat.ts
@@ -32,6 +32,7 @@ export interface ExtensionJson {
     [key: string]: string
   }
   activationEvents?: string[]
+  extensionDependencies?: string[]
   version?: string
   [key: string]: any
 }


### PR DESCRIPTION
extension can set `extensionDependencies` in package.json to declare dependencies on other extensions. coc.nvim will install the dependencies, and activate dependencies first before active the main extension.

cc @statiolake, you might need this, please give it a try