### PR TITLE
fix(jump): add buf events for `tab drop`

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -226,9 +226,14 @@ function! s:safer_open(cmd, file) abort
       execute 'noautocmd '.a:cmd.' '.fnameescape(a:file)
       if tabpagenr('$') > l:max_page_num
         doautocmd TabNew
+        doautocmd BufNew
+        doautocmd BufAdd
       endif
       if tabpagenr() != l:current_page_num
         doautocmd TabEnter
+        doautocmd BufRead
+        doautocmd BufReadPost
+        doautocmd BufEnter
       endif
       execute 'set wildignore='.saved
     else


### PR DESCRIPTION
Added buffer-related events, as some plugins will depend on these events.