### PR TITLE
fix(jump): improve the events for `tab drop`

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -222,9 +222,9 @@ function! s:safer_open(cmd, file) abort
       let saved = &wildignore
       set wildignore=
       let l:old_page_idx = tabpagenr()
-      let l:old_page_num = tabpagenr('$')
+      let l:old_page_cnt = tabpagenr('$')
       execute 'noautocmd '.a:cmd.' '.fnameescape(a:file)
-      if tabpagenr('$') > l:old_page_num
+      if tabpagenr('$') > l:old_page_cnt
         doautocmd TabNew
         doautocmd BufNew
         doautocmd BufAdd

--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -221,7 +221,7 @@ function! s:safer_open(cmd, file) abort
       endif
       let saved = &wildignore
       set wildignore=
-      let l:current_page_num = tabpagenr()
+      let l:last_page_num = tabpagenr()
       let l:max_page_num = tabpagenr('$')
       execute 'noautocmd '.a:cmd.' '.fnameescape(a:file)
       if tabpagenr('$') > l:max_page_num
@@ -229,12 +229,19 @@ function! s:safer_open(cmd, file) abort
         doautocmd BufNew
         doautocmd BufAdd
       endif
+      let l:curr_page_num = tabpagenr()
+      if l:curr_page_num != l:last_page_num
+        exec 'noautocmd tabnext '.l:last_page_num
+        doautocmd TabLeave
+        doautocmd BufLeave
+        exec 'noautocmd tabnext '.l:curr_page_num
+      endif
       doautocmd TabEnter
       doautocmd BufReadPre
       doautocmd BufRead
       doautocmd BufReadPost
       doautocmd BufEnter
-      if tabpagenr() != l:current_page_num
+      if l:curr_page_num != l:last_page_num
         doautocmd BufWinEnter
       endif
       execute 'set wildignore='.saved

--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -221,7 +221,7 @@ function! s:safer_open(cmd, file) abort
       endif
       let saved = &wildignore
       set wildignore=
-      let l:last_page_num = tabpagenr()
+      let l:old_page_num = tabpagenr()
       let l:max_page_num = tabpagenr('$')
       execute 'noautocmd '.a:cmd.' '.fnameescape(a:file)
       if tabpagenr('$') > l:max_page_num
@@ -229,19 +229,19 @@ function! s:safer_open(cmd, file) abort
         doautocmd BufNew
         doautocmd BufAdd
       endif
-      let l:curr_page_num = tabpagenr()
-      if l:curr_page_num != l:last_page_num
-        exec 'noautocmd tabnext '.l:last_page_num
+      let l:new_page_num = tabpagenr()
+      if l:new_page_num != l:old_page_num
+        exec 'noautocmd tabnext '.l:old_page_num
         doautocmd TabLeave
         doautocmd BufLeave
-        exec 'noautocmd tabnext '.l:curr_page_num
+        exec 'noautocmd tabnext '.l:new_page_num
       endif
       doautocmd TabEnter
       doautocmd BufReadPre
       doautocmd BufRead
       doautocmd BufReadPost
       doautocmd BufEnter
-      if l:curr_page_num != l:last_page_num
+      if l:new_page_num != l:old_page_num
         doautocmd BufWinEnter
       endif
       execute 'set wildignore='.saved

--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -226,9 +226,16 @@ function! s:safer_open(cmd, file) abort
       execute 'noautocmd '.a:cmd.' '.fnameescape(a:file)
       if tabpagenr('$') > l:max_page_num
         doautocmd TabNew
+        doautocmd BufNew
+        doautocmd BufAdd
       endif
+      doautocmd TabEnter
+      doautocmd BufReadPre
+      doautocmd BufRead
+      doautocmd BufReadPost
+      doautocmd BufEnter
       if tabpagenr() != l:current_page_num
-        doautocmd TabEnter
+        doautocmd BufWinEnter
       endif
       execute 'set wildignore='.saved
     else

--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -221,27 +221,27 @@ function! s:safer_open(cmd, file) abort
       endif
       let saved = &wildignore
       set wildignore=
-      let l:old_page_num = tabpagenr()
-      let l:max_page_num = tabpagenr('$')
+      let l:old_page_idx = tabpagenr()
+      let l:old_page_num = tabpagenr('$')
       execute 'noautocmd '.a:cmd.' '.fnameescape(a:file)
-      if tabpagenr('$') > l:max_page_num
+      if tabpagenr('$') > l:old_page_num
         doautocmd TabNew
         doautocmd BufNew
         doautocmd BufAdd
       endif
-      let l:new_page_num = tabpagenr()
-      if l:new_page_num != l:old_page_num
-        exec 'noautocmd tabnext '.l:old_page_num
+      let l:new_page_idx = tabpagenr()
+      if l:new_page_idx != l:old_page_idx
+        exec 'noautocmd tabnext '.l:old_page_idx
         doautocmd TabLeave
         doautocmd BufLeave
-        exec 'noautocmd tabnext '.l:new_page_num
+        exec 'noautocmd tabnext '.l:new_page_idx
       endif
       doautocmd TabEnter
       doautocmd BufReadPre
       doautocmd BufRead
       doautocmd BufReadPost
       doautocmd BufEnter
-      if l:new_page_num != l:old_page_num
+      if l:new_page_idx != l:old_page_idx
         doautocmd BufWinEnter
       endif
       execute 'set wildignore='.saved


### PR DESCRIPTION
Simulated the events triggered by tab drop when jumping to the target page:
- Added events for leaving the tab.
- Added buffer-related events, as some plugins will depend on these events.
- Fix the problem of no events when navigating within one tab