### PR TITLE
Allow the user to select and configure the type of message UI element he interacts with

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -579,7 +579,15 @@
       "type": "boolean",
       "scope": "application",
       "default": false,
-      "description": "Enable messages shown in notification dialog."
+      "deprecationMessage": "Use configuration 'coc.preferences.messageDialogKind' instead.",
+      "description": "Enable messages shown in notification dialog, or fallback to native vim confirm action."
+    },
+    "coc.preferences.messageDialogKind": {
+      "type": "string",
+      "scope": "application",
+      "default": "confirm",
+      "description": "The kind of interactive element to show the messages with.",
+      "enum": ["notification", "confirm", "menu"]
     },
     "coc.preferences.excludeImageLinksInMarkdownDocument": {
       "type": "boolean",

--- a/doc/coc-config.txt
+++ b/doc/coc-config.txt
@@ -205,9 +205,15 @@ PREFERENCES
 
 "coc.preferences.enableMessageDialog"			*coc-preferences-enableMessageDialog*
 
-	Enable messages shown in notification dialog.
+	Enable messages shown in notification dialog. Deprecated, prefer configuration 'coc.preferences.messageDialogKind' instead.
 
 	Scope: `application`, default: `false`
+
+"coc.preferences.messageDialogKind"			*coc-preferences-messageDialogKind*
+
+	Configure the type of user interaction when a message dialog occurs with more than one actions to trigger.
+
+	Scope: `application`, default: `confirm'
 
 "coc.preferences.excludeImageLinksInMarkdownDocument"	*coc-preferences-excludeImageLinksInMarkdownDocument*
 

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -403,6 +403,9 @@ Configure |coc-preferences-enableMessageDialog| to show messages as
 notifications (except for the messages of unexpected errors which are always
 echoed).
 
+Use |coc-preferences-messageDialogKind| to configure how the messages are shown
+this configuration supersedes the |coc-preferences-enableMessageDialog|. 
+
 ==============================================================================
 LSP FEATURES 						*coc-lsp*
 

--- a/history.md
+++ b/history.md
@@ -2,6 +2,11 @@
 
 Notable changes of coc.nvim:
 
+## 2025-07-30
+
+- Add configurable kind for dialog messages, through the use of the new configuration
+  'messageDialogKind' which can be set to 'menu', 'notification', or 'confirm'.
+
 ## 2025-07-18
 
 - Add `extensionDependencies` support, declare dependencies on other extensions: `"extensionDependencies": ["extension-1", "extension-2"]`

--- a/src/core/notifications.ts
+++ b/src/core/notifications.ts
@@ -11,6 +11,7 @@ import { CancellationToken } from '../util/protocol'
 import { toText } from '../util/string'
 import { callAsync } from './funcs'
 import { echoMessages, MsgTypes } from './ui'
+import { Dialogs } from './dialogs'
 
 export type MessageKind = 'Error' | 'Warning' | 'Info'
 
@@ -61,7 +62,9 @@ export class Notifications {
   public configuration: WorkspaceConfiguration
   public statusLine: StatusLine
   private _history: NotificationItem[] = []
-  constructor() {}
+
+  constructor(private dialogs: Dialogs) {
+  }
 
   private getCurrentTimestamp(): string {
     const now = new Date()
@@ -78,13 +81,16 @@ export class Notifications {
 
   public async _showMessage<T extends MessageItem | string>(kind: MessageKind, message: string, items: T[]): Promise<T | undefined> {
     this._history.push({ time: this.getCurrentTimestamp(), kind, message })
-    if (!this.enableMessageDialog) {
-      if (items.length > 0) {
-        return await this.showConfirm(message, items, kind)
-      }
+
+    let notificationKind = this.messageDialogKind === 'notification' || this.enableMessageDialog === true
+    if (notificationKind !== true) {
       let msgType: MsgTypes = kind == 'Info' ? 'more' : kind == 'Error' ? 'error' : 'warning'
-      this.echoMessages(message, msgType)
-      return undefined
+      if (msgType === 'error' || items.length === 0) {
+        this.echoMessages(message, msgType)
+        return undefined
+      } else {
+        return this.messageDialogKind === 'confirm' ? await this.showConfirm(message, items, kind) : await this.showMenuPicker(`Choose an action`, message, `Coc${kind}Float`, items)
+      }
     }
     let texts = items.map(o => typeof o === 'string' ? o : o.title)
     let idx = await this.createNotification(kind.toLowerCase() as NotificationKind, message, texts)
@@ -117,22 +123,32 @@ export class Notifications {
     })
   }
 
-  // fallback for vim without dialog
-  private async showConfirm<T extends MessageItem | string>(message: string, items: T[], kind: MessageKind): Promise<T> {
+  public async showConfirm<T extends MessageItem | string>(message: string, items: T[], kind: MessageKind): Promise<T> {
     let titles = toTitles(items)
     let choices = titles.map((s, i) => `${i + 1}${s}`)
     let res = await callAsync(this.nvim, 'confirm', [message, choices.join('\n'), 1, kind]) as number
     return items[res - 1]
   }
 
-  public echoMessages(msg: string, messageType: MsgTypes): void {
-    let level = this.configuration.get<string>('coc.preferences.messageLevel', 'more')
-    echoMessages(this.nvim, msg, messageType, level)
+  public async showMenuPicker<T extends MessageItem | string>(title: string, content: string, hlGroup: string, items: T[]): Promise<T> {
+    let texts = items.map(o => typeof o === 'string' ? o : o.title)
+    let res = await this.dialogs.showMenuPicker(texts, {
+      position: 'center',
+      content,
+      title: title.replace(/\r?\n/, ' '),
+      borderhighlight: hlGroup
+    })
+    return items[res]
   }
 
   public async showNotification(config: NotificationConfig, stack: string): Promise<void> {
     let notification = new Notification(this.nvim, config)
     await notification.show(this.getNotificationPreference(stack))
+  }
+
+  public echoMessages(msg: string, messageType: MsgTypes): void {
+    let level = this.configuration.get<string>('coc.preferences.messageLevel', 'more')
+    echoMessages(this.nvim, msg, messageType, level)
   }
 
   public async withProgress<R>(options: ProgressOptions, task: (progress: Progress, token: CancellationToken) => Thenable<R>): Promise<R> {
@@ -173,6 +189,10 @@ export class Notifications {
 
   private get enableMessageDialog(): boolean {
     return this.configuration.get<boolean>('coc.preferences.enableMessageDialog', false)
+  }
+
+  private get messageDialogKind(): string {
+    return this.configuration.get<string>('coc.preferences.messageDialogKind', 'confirm')
   }
 
   private getNotificationPreference(source?: string, isProgress = false): NotificationPreferences {

--- a/src/window.ts
+++ b/src/window.ts
@@ -33,9 +33,9 @@ export class Window {
   private nvim: Neovim
   public highlights: Highlights = new Highlights()
   private terminalManager: Terminals = new Terminals()
-  public readonly notifications = new Notifications()
-  public readonly dialogs = new Dialogs()
   public readonly cursors: Cursors
+  public readonly dialogs = new Dialogs()
+  public readonly notifications = new Notifications(this.dialogs)
   private workspace: Workspace
   constructor() {
     Object.defineProperty(this.highlights, 'nvim', {


### PR DESCRIPTION
Add the ability to configure which type of message ui element the user can interact with, it aims at keeping the default / current behavior while still being able to restore the old behavior which allowed the user to menu select actions instead of having to focus the notification window to select an action, also it is not possible to type-to-filter actions as it is in the menu picker.