### PR TITLE
chore(package): rm tslib and importHelpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "semver": "^7.6.3",
         "strip-ansi": "^6.0.1",
         "tar": "^6.2.1",
-        "tslib": "^2.6.3",
         "unidecode": "^1.0.1",
         "unzip-stream": "^0.3.4",
         "uuid": "^9.0.1",
@@ -6475,7 +6474,9 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "license": "0BSD"
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "semver": "^7.6.3",
     "strip-ansi": "^6.0.1",
     "tar": "^6.2.1",
-    "tslib": "^2.6.3",
     "unidecode": "^1.0.1",
     "unzip-stream": "^0.3.4",
     "uuid": "^9.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "noEmit": true,
     "sourceMap": true,
-    "importHelpers": true,
     "allowUnreachableCode": false,
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": false,


### PR DESCRIPTION
esbuild won't use tslib, and importHelpers is ignored