### PR TITLE
fix(snippets): getTextEdit without cursor position

### DIFF
--- a/src/snippets/session.ts
+++ b/src/snippets/session.ts
@@ -344,7 +344,7 @@ export class SnippetSession {
     if (tokenSource.token.isCancellationRequested) return
     let change = documentChange?.change
     if (!change) {
-      let edit = getTextEdit(textDocument.lines, newDocument.lines, cursor, events.insertMode)
+      let edit = getTextEdit(textDocument.lines, newDocument.lines, null, events.insertMode)
       change = { range: edit.range, text: edit.newText }
     }
     const { range, start } = snippet


### PR DESCRIPTION
There may be multiple changes applied, the cursor could be put in wrong place while fetching textEdit.