### PR TITLE
fix(event): use completing to prevent synchronize

### DIFF
--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -230,7 +230,7 @@ export default class Document {
         }
         this.lines = lines
         fireLinesChanged(bufnr)
-        if (events.pumInserted) return
+        if (events.completing) return
         this.fireContentChanges()
       }
     }


### PR DESCRIPTION
in b6d9e5263e04bf593218b3215bf334a4f2a904cd, coc.nvim uses `pumInserted` to prevent document synchronize instead of completing, this fix revert to use `completing`, and leave inline completion to use pumInserted

Closes #5415