### PR TITLE
fix(vim): space prop should be added at last order

### DIFF
--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -409,13 +409,13 @@ def ChangeBufferLines(bufnr: number, start_row: number, start_col: number, end_r
   endif
 enddef
 
-# make sure inserted space first.
+# make sure inserted space last.
 def SortProp(a: dict<any>, b: dict<any>): number
   if a.col != b.col
     return a.col > b.col ? 1 : -1
   endif
   if has_key(a, 'text') && has_key(b, 'text')
-    return a.text ==# ' ' ? -1 : 1
+    return a.text ==# ' ' ? 1 : -1
   endif
   return 0
 enddef


### PR DESCRIPTION
Two props with same lnum and col, the space one should be added at last order. The code: `foo(2)`, the props:

```
{'lnum': 1, 'col': 5, 'type_bufnr': 0, 'end': 1, 'type': 'CocInlayHintParameter_5', 'text': '_num:', 'start': 1} {'bufnr': 1, 'type': 'CocInlayHintParameter_5', 'text': '_num:'}
{'lnum': 1, 'col': 5, 'type_bufnr': 0, 'end': 1, 'type': 'Normal_5', 'text': ' ', 'start': 1} {'bufnr': 1, 'type': 'Normal_5', 'text': ' '}
```

We should set the `_num:` one first, the space one last, and finally got `foo(_num: 2)` result.

Closes #5418