### PR TITLE
feat(notification)!: ensure the ui notification is shown

### DIFF
--- a/src/core/notifications.ts
+++ b/src/core/notifications.ts
@@ -91,7 +91,8 @@ export class Notifications {
           return await this.showMenuPicker(`Choose an action`, message, `Coc${kind}Float`, items)
       }
     }
-    let idx = await this.createNotification(kind.toLowerCase() as NotificationKind, message, items)
+    let texts = items.map(o => typeof o === 'string' ? o : o.title)
+    let idx = await this.createNotification(kind.toLowerCase() as NotificationKind, message, texts)
     return items[idx]
   }
 
@@ -103,13 +104,12 @@ export class Notifications {
     this._history = []
   }
 
-  public createNotification<T extends MessageItem | string>(kind: NotificationKind, message: string, items: T[]): Promise<number> {
+  public createNotification(kind: NotificationKind, message: string, items: string[]): Promise<number> {
     return new Promise((resolve, reject) => {
-      let labels = items.map(o => typeof o === 'string' ? o : o.title)
       let config: NotificationConfig = {
         kind,
         content: message,
-        buttons: toButtons(labels),
+        buttons: toButtons(items),
         callback: idx => {
           resolve(idx)
         }


### PR DESCRIPTION
The notification using plain echo is so useless, for the most part it is first not using echom but echo, meaning that it often gets lost, second you can esily miss that in the chaos of other messages getting echoed into the echo line, or the user is using options such as showmode which override the echo area pretty much all the time. It is also not convenient to keep opening the notification history to see if you have missed something, or you have to actually know there was a notification that you need to look at / have missed in the first place. Do not force the use of echoMessage at all, it is plain useless and not user friendly, an explicit config should be exposed for users that really want to get the old echo behavior.