### PR TITLE
fix(coc): rm localstorage-file flag

### DIFF
--- a/autoload/coc/util.vim
+++ b/autoload/coc/util.vim
@@ -136,19 +136,6 @@ function! coc#util#job_command()
   endif
 
   let default = ['--no-warnings']
-  let output = system(node . ' --version')
-  if v:shell_error
-    echohl Error | echom '[coc.nvim] Unexpected result from "'.node.' --version"' | echohl None
-    return
-  endif
-  let ms = matchlist(output, 'v\(\d\+\).\(\d\+\).\(\d\+\)')
-  if empty(ms)
-    echohl Error | echom '[coc.nvim] Unable to get node version by "'.node.' --version"' | echohl None
-    return
-  endif
-  if str2nr(ms[1]) >= 25
-    let default += ['--localstorage-file=' . coc#util#get_data_home() . '/localstorage']
-  endif
   return [node] + get(g:, 'coc_node_args', default) + [s:root.'/build/index.js']
 endfunction
 


### PR DESCRIPTION
Node.js has reverted the change in version 25.2.1. The flag was only necessary in version 25.2.0; it is not required in previous 25.1.0 or later  version. 

Remove this flag for now, and then decide whether to add it back later based on Node.js. 


- https://github.com/nodejs/node/pull/60750
- https://github.com/nodejs/node/issues/60704

Related #5469 #5471 #5472