### PR TITLE
fix comment char

### DIFF
--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -39,7 +39,7 @@ if get(g:, 'coc_start_at_startup', 1) && !s:is_gvim
 endif
 
 function! CocTagFunc(pattern, flags, info) abort
-  # tagfunc can't be set in the sandbox mode, preload the following functions
+  " tagfunc can't be set in the sandbox mode, preload the following functions
   silent! call coc#cursor#move_to()
   silent! call coc#string#character_index()
   if a:flags !=# 'c'


### PR DESCRIPTION
Fixes the comment marker, which was causing parsing errors in vim.