### PR TITLE
feat(list): add refactor keymap for normal list mappings

### DIFF
--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -4027,6 +4027,7 @@ p           - Preview action.
 t           - Do 'tabe' action.
 d           - Do 'drop' action.
 s           - Do 'split' action.
+r           - Do 'refactor' action.
 
 Use |coc-list-mappings-custom| to override default mappings.
 

--- a/src/list/mappings.ts
+++ b/src/list/mappings.ts
@@ -164,6 +164,7 @@ export default class Mappings {
     // normal
     this.addKeyMapping('normal', 't', 'action:tabe')
     this.addKeyMapping('normal', 's', 'action:split')
+    this.addKeyMapping('normal', 'r', 'action:refactor')
     this.addKeyMapping('normal', 'd', 'action:drop')
     this.addKeyMapping('normal', ['<cr>', '<C-m>', '\r'], 'do:defaultaction')
     this.addKeyMapping('normal', '<C-a>', 'do:selectall')


### PR DESCRIPTION
- Mapping `r` to refactor is very practical
- Unmapped r is useless or even not working properly
