### PR TITLE
fix(files): persistence cursor position on editing

### DIFF
--- a/src/core/files.ts
+++ b/src/core/files.ts
@@ -516,7 +516,7 @@ export default class Files {
   /**
    * Apply WorkspaceEdit.
    */
-  public async applyEdit(edit: WorkspaceEdit, nested?: boolean): Promise<boolean> {
+  public async applyEdit(edit: WorkspaceEdit, nested?: boolean, cursorPosition?: Position): Promise<boolean> {
     let documentChanges = toDocumentChanges(edit)
     let recovers: RecoverFunc[] = []
     let currentOnly = false
@@ -546,7 +546,7 @@ export default class Files {
             let startLine = snippetEdits[0].range.start.line
             revertEdit = getRevertEdit(oldLines, doc.textDocument.lines, startLine)
           } else {
-            revertEdit = await doc.applyEdits(edits as TextEdit[], false, uri === currentUri)
+            revertEdit = await doc.applyEdits(edits as TextEdit[], false, cursorPosition ?? (uri === currentUri))
           }
           if (revertEdit) {
             let version = doc.version

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -579,8 +579,8 @@ export class Workspace {
   /**
    * Apply WorkspaceEdit.
    */
-  public applyEdit(edit: WorkspaceEdit): Promise<boolean> {
-    return this.files.applyEdit(edit)
+  public applyEdit(edit: WorkspaceEdit, nested?: boolean, cursorPosition?: Position): Promise<boolean> {
+    return this.files.applyEdit(edit, nested, cursorPosition)
   }
 
   /**


### PR DESCRIPTION
Closes #5106

This fix was generated by Claude Code.

Save the cursor position before menu window, and use this position instead of document.cursor that has been moved to menu window.