### PR TITLE
fix(extension): correct npm no-package-lock

### DIFF
--- a/src/__tests__/modules/extensionInstaller.test.ts
+++ b/src/__tests__/modules/extensionInstaller.test.ts
@@ -74,7 +74,7 @@ describe('Installer', () => {
     it('should get install arguments', async () => {
       let installer = new Installer(__dirname, 'npm', 'https://github.com/')
       expect(installer.getInstallArguments('pnpm', 'https://github.com/')).toEqual({ env: 'development', args: ['install'] })
-      expect(installer.getInstallArguments('npm', '')).toEqual({ env: 'production', args: ['install', '--ignore-scripts', '--no-lockfile', '--omit=dev', '--legacy-peer-deps', '--no-global'] })
+      expect(installer.getInstallArguments('npm', '')).toEqual({ env: 'production', args: ['install', '--ignore-scripts', '--no-package-lock', '--omit=dev', '--legacy-peer-deps', '--no-global'] })
       expect(installer.getInstallArguments('yarn', '')).toEqual({ env: 'production', args: ['install', '--ignore-scripts', '--no-lockfile', '--production', '--ignore-engines'] })
       expect(installer.getInstallArguments('pnpm', '')).toEqual({ env: 'production', args: ['install', '--ignore-scripts', '--no-lockfile', '--production', '--config.strict-peer-dependencies=false'] })
     })

--- a/src/extension/installer.ts
+++ b/src/extension/installer.ts
@@ -203,21 +203,24 @@ export class Installer extends EventEmitter implements IInstaller {
 
   public getInstallArguments(exePath: string, url: string | undefined): { env: string, args: string[] } {
     let env = 'production'
-    let args = ['install', '--ignore-scripts', '--no-lockfile']
+    let args = ['install', '--ignore-scripts']
     if (url && url.startsWith('https://github.com')) {
       args = ['install']
       env = 'development'
     } else {
       if (isNpmCommand(exePath)) {
+        args.push('--no-package-lock')
         args.push('--omit=dev')
         args.push('--legacy-peer-deps')
         args.push('--no-global')
       }
       if (isYarn(exePath)) {
+        args.push('--no-lockfile')
         args.push('--production')
         args.push('--ignore-engines')
       }
       if (isPnpm(exePath)) {
+        args.push('--no-lockfile')
         args.push('--production')
         args.push('--config.strict-peer-dependencies=false')
       }


### PR DESCRIPTION
npm use --no-lockfile before, reports error: 

```
[npm stderr] npm warn Expanding --lockfile to --lockfile-version. This will stop working in the next major version of npm.
```