### PR TITLE
Fix pum matches highlight fallback pre

### DIFF
--- a/src/completion/pum.ts
+++ b/src/completion/pum.ts
@@ -285,7 +285,7 @@ export default class PopupMenu {
               positionHighlights(hls, item.filterText, item.positions, pre, index, labelMaxLength)
             } else {
               let score = anyScore(input, lowInput, 0, item.abbr, item.abbr.toLowerCase(), 0)
-              positionHighlights(hls, item.abbr, score, 0, index, labelMaxLength)
+              positionHighlights(hls, item.abbr, score, len, index, labelMaxLength)
             }
           }
           let abbr = label.text


### PR DESCRIPTION
Cursor on `|`

```rust
fn foo() -> impl Iterator<Ite|>
```

**Before this PR**:

```text
Item =(as Iterator) pub type Item
^^
```

**After this PR**:

```text
Item =(as Iterator) pub type Item
^^^
```
