### PR TITLE
fix(handler): correct indent onEnter

### DIFF
--- a/src/__tests__/handler/format.test.ts
+++ b/src/__tests__/handler/format.test.ts
@@ -319,9 +319,9 @@ describe('format handler', () => {
       await nvim.command(`normal! gg$`)
       await nvim.input('i')
       await nvim.eval(`feedkeys("\\<CR>", 'im')`)
-      await helper.waitFor('getline', [2], '  ')
+      await helper.waitFor('getline', [2], '    ')
       let lines = await buf.lines
-      expect(lines).toEqual(['  {', '  ', '  }'])
+      expect(lines).toEqual(['  {', '    ', '  }'])
     })
   })
 


### PR DESCRIPTION
Closes #5547

Before:

1. for vim filetype: applyEdits handles the new line indention
2. for other filetype: use `feedkeys("\<Esc>O", 'in')` to handle the indention by vim itself. But `\<esc>` brought an `undo` point that made the redo error

After: use applyEdits for all filetypes, with special `\` for vim files.