### PR TITLE
Partially fix Vim9 buffer out of sync

### DIFF
--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -2,6 +2,7 @@
   "eslint.validate": ["typescript"],
   "eslint.lintTask.options": ["."],
   "sumneko-lua.enableNvimLuaDev": true,
+  "typescript.format.enable": true,
   "javascript.format.semicolons": "remove",
   "typescript.format.semicolons": "remove",
   "typescript.preferences.importModuleSpecifier": "relative",

--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -360,9 +360,7 @@ export def CreateType(ns: number, hl: string, opts: dict<any>): string
 enddef
 
 def OnBufferChange(bufnr: number, start: number, end: number, added: number, bufchanges: list<any>): void
-  const new_len = end - start + added
-  const lines: list<string> = new_len > 0 ? getbufline(bufnr, start, start + new_len - 1) : []
-  coc#rpc#notify('vim_buf_change_event', [bufnr, getbufvar(bufnr, 'changedtick'), start - 1, end - 1, lines])
+  coc#rpc#notify('vim_buf_change_event', [bufnr, getbufvar(bufnr, 'changedtick'), start - 1, end - 1, getbufline(bufnr, start, end + added - 1)])
 enddef
 
 export def DetachListener(bufnr: number): bool

--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -364,9 +364,9 @@ def OnBufferChange(bufnr: number, start: number, end: number, added: number, cha
   # When selecting an item in Coc's popup menu or Vim's insert completion menu,
   # this callback will be triggered multiple times with only `change.col` different
   if added == 0 && end - start == 1
-   # See comments below for more details
-   coc#rpc#notify('vim_buf_change_event', [bufnr, getbufvar(bufnr, 'changedtick'), start - 1, end - 1, getbufline(bufnr, start)])
-   return
+    # See comments below for more details
+    coc#rpc#notify('vim_buf_change_event', [bufnr, getbufvar(bufnr, 'changedtick'), start - 1, end - 1, getbufline(bufnr, start)])
+    return
   endif
 
   # Simulate unbuffered changes

--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -360,7 +360,15 @@ export def CreateType(ns: number, hl: string, opts: dict<any>): string
 enddef
 
 # Callback of `listener_add()` with its `unbuffered` flag defaulting to `false`
-def OnBufferChange(bufnr: number, _start: number, _end: number, _added: number, changes: list<dict<any>>): void
+def OnBufferChange(bufnr: number, start: number, end: number, added: number, changes: list<dict<any>>): void
+  # When selecting an item in Coc's popup menu or Vim's insert completion menu,
+  # this callback will be triggered multiple times with only `change.col` different
+  if added == 0 && end - start == 1
+   # See comments below for more details
+   coc#rpc#notify('vim_buf_change_event', [bufnr, getbufvar(bufnr, 'changedtick'), start - 1, end - 1, getbufline(bufnr, start)])
+   return
+  endif
+
   # Simulate unbuffered changes
   #
   # Can't simply use `getbufline(bufnr, start, end - 1 + added)` to get updated line content after all changes

--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -359,12 +359,15 @@ export def CreateType(ns: number, hl: string, opts: dict<any>): string
   return type
 enddef
 
-# Callback of `listener_add()`
+# Callback of `listener_add()` with its `unbuffered` flag defaulting to `false`
 def OnBufferChange(bufnr: number, start: number, end: number, added: number, _bufchanges: list<any>): void
   # Trigger `@chemzqm/neovim/src/api/client.ts vim_buf_change_event` which then triggers `src/model/document.ts vim_lines`
   #
   # Convert parameters to the ones of `nvim_buf_lines_event`
   # @see https://neovim.io/doc/user/api/#nvim_buf_lines_event
+  #
+  # Note: When executing `normal! 5o`, this callback will be triggered 5 times with last two changedticks the same
+  #       due to `unbuffered` flag defaulting to `false`
   coc#rpc#notify('vim_buf_change_event', [bufnr, getbufvar(bufnr, 'changedtick'), start - 1, end - 1, getbufline(bufnr, start, end + added - 1)])
 enddef
 

--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -359,7 +359,12 @@ export def CreateType(ns: number, hl: string, opts: dict<any>): string
   return type
 enddef
 
-def OnBufferChange(bufnr: number, start: number, end: number, added: number, bufchanges: list<any>): void
+# Callback of `listener_add()`
+def OnBufferChange(bufnr: number, start: number, end: number, added: number, _bufchanges: list<any>): void
+  # Trigger `@chemzqm/neovim/src/api/client.ts vim_buf_change_event` which then triggers `src/model/document.ts vim_lines`
+  #
+  # Convert parameters to the ones of `nvim_buf_lines_event`
+  # @see https://neovim.io/doc/user/api/#nvim_buf_lines_event
   coc#rpc#notify('vim_buf_change_event', [bufnr, getbufvar(bufnr, 'changedtick'), start - 1, end - 1, getbufline(bufnr, start, end + added - 1)])
 enddef
 

--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -360,15 +360,45 @@ export def CreateType(ns: number, hl: string, opts: dict<any>): string
 enddef
 
 # Callback of `listener_add()` with its `unbuffered` flag defaulting to `false`
-def OnBufferChange(bufnr: number, start: number, end: number, added: number, _bufchanges: list<any>): void
-  # Trigger `@chemzqm/neovim/src/api/client.ts vim_buf_change_event` which then triggers `src/model/document.ts vim_lines`
+def OnBufferChange(bufnr: number, _start: number, _end: number, _added: number, changes: list<dict<any>>): void
+  # Simulate unbuffered changes
   #
-  # Convert parameters to the ones of `nvim_buf_lines_event`
-  # @see https://neovim.io/doc/user/api/#nvim_buf_lines_event
+  # Can't simply use `getbufline(bufnr, start, end - 1 + added)` to get updated line content after all changes
+  # @example
+  #    For start == 2 && end == 5 && added == -1
+  #        && changes == [{'lnum': 2, 'col': 1, 'added': -1, 'end': 3}, {'lnum': 4, 'col': 1, 'added': 0, 'end': 5}]
+  #    last line after all changes are made should be `changes[1].end - 1 + changes[1].added == 4`, rather than `end - 1 + added == 5`
+  #    And it's hard to calculate last line before all changes are made in various cases
   #
-  # Note: When executing `normal! 5o`, this callback will be triggered 5 times with last two changedticks the same
-  #       due to `unbuffered` flag defaulting to `false`
-  coc#rpc#notify('vim_buf_change_event', [bufnr, getbufvar(bufnr, 'changedtick'), start - 1, end - 1, getbufline(bufnr, start, end + added - 1)])
+  for change: dict<any> in changes
+    # First line to be changed, before the change is made
+    const firstLine_beforeChange: number = change.lnum
+    # Last line to be changed, before the change is made
+    const lastLine_beforeChange: number = change.end - 1
+    # First changed line, after the change is made
+    const firstLine_afterChange: number = change.lnum
+    # Last changed line, after the change is made
+    const lastLine_afterChange: number = change.end - 1 + change.added
+
+    # Send the range of affected lines(before `change` is made) and the updated line content(after `change` is made)
+    #
+    # Trigger `@chemzqm/neovim/src/api/client.ts vim_buf_change_event` which then triggers `src/model/document.ts vim_lines`
+    #
+    # Convert parameters to the ones of `nvim_buf_lines_event`
+    # @see https://neovim.io/doc/user/api/#nvim_buf_lines_event
+    #
+    coc#rpc#notify('vim_buf_change_event', [bufnr,
+      # Note: When executing `normal! 5o`, this callback will be triggered 5 times with last two changedticks the same
+      #       due to `unbuffered` flag defaulting to `false`
+      getbufvar(bufnr, 'changedtick'),
+      # `- 1`: zero-based
+      firstLine_beforeChange - 1,
+      # `+ 1`: so that it's end-exclusive
+      # `- 1`: zero-based
+      lastLine_beforeChange + 1 - 1,
+      getbufline(bufnr, firstLine_afterChange, lastLine_afterChange)
+    ])
+  endfor
 enddef
 
 export def DetachListener(bufnr: number): bool

--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -371,10 +371,10 @@ def OnBufferChange(bufnr: number, _start: number, _end: number, _added: number, 
   #    And it's hard to calculate last line before all changes are made in various cases
   #
   for change: dict<any> in changes
-    # First line to be changed, before the change is made
+    # First line of the change, before the change is made
     const firstLine_beforeChange: number = change.lnum
-    # Last line to be changed, before the change is made
-    const lastLine_beforeChange: number = change.end - 1
+    # First line below the change, before the change is made
+    const firstLineBelow_beforeChange: number = change.end
     # First changed line, after the change is made
     const firstLine_afterChange: number = change.lnum
     # Last changed line, after the change is made
@@ -392,10 +392,7 @@ def OnBufferChange(bufnr: number, _start: number, _end: number, _added: number, 
       #       due to `unbuffered` flag defaulting to `false`
       getbufvar(bufnr, 'changedtick'),
       # `- 1`: zero-based
-      firstLine_beforeChange - 1,
-      # `+ 1`: so that it's end-exclusive
-      # `- 1`: zero-based
-      lastLine_beforeChange + 1 - 1,
+      firstLine_beforeChange - 1, firstLineBelow_beforeChange - 1,
       getbufline(bufnr, firstLine_afterChange, lastLine_afterChange)
     ])
   endfor

--- a/src/__tests__/vim.test.ts
+++ b/src/__tests__/vim.test.ts
@@ -918,6 +918,18 @@ describe('document', () => {
     await nvim.command('normal! 2o')
     await nvim.resumeNotification(true)
     await shouldEqual(doc)
+
+    nvim.pauseNotification()
+    await nvim.command('normal! 5o')
+    await nvim.resumeNotification(true)
+    await shouldEqual(doc)
+  })
+  it('should synchronize changes after executing a command with count (2)', async () => {
+    const doc2 = await helper.createDocument()
+    nvim.pauseNotification()
+    await nvim.command('normal! 5o')
+    await nvim.resumeNotification(true)
+    await shouldEqual(doc2)
   })
 
   it('should patch change of current line', async () => {

--- a/src/__tests__/vim.test.ts
+++ b/src/__tests__/vim.test.ts
@@ -932,6 +932,31 @@ describe('document', () => {
     await shouldEqual(doc2)
   })
 
+  it('should synchronize changes after single line change', async () => {
+    const filepath = await createTmpFile(['a', 'b', 'c'].join('\n'), disposables)
+    const doc = await helper.createDocument(filepath)
+
+    nvim.pauseNotification()
+    await nvim.command('normal! O')
+    await nvim.resumeNotification(true)
+    await shouldEqual(doc)
+
+    nvim.pauseNotification()
+    await nvim.command('call append(0, "append")')
+    await nvim.resumeNotification(true)
+    await shouldEqual(doc)
+
+    nvim.pauseNotification()
+    await nvim.command('call setline(2, "set")')
+    await nvim.resumeNotification(true)
+    await shouldEqual(doc)
+
+    nvim.pauseNotification()
+    await nvim.command('call deletebufline("%", 2)')
+    await nvim.resumeNotification(true)
+    await shouldEqual(doc)
+  })
+
   // #5542
   it('should synchronize buffered changes after setlines', async () => {
     const fileContents = [

--- a/src/__tests__/vim.test.ts
+++ b/src/__tests__/vim.test.ts
@@ -892,8 +892,8 @@ describe('document', () => {
     await doc.patchChange()
   })
 
-  // #5524
-  it('should synchronize changes after undo', async () => {
+  // FIXME #5524
+  it.skip('should synchronize changes after undo', async () => {
     const filepath = await createTmpFile('abc', disposables)
     const doc = await helper.createDocument(filepath)
     nvim.pauseNotification()

--- a/src/__tests__/vim.test.ts
+++ b/src/__tests__/vim.test.ts
@@ -952,6 +952,15 @@ describe('document', () => {
     await shouldEqual(doc)
 
     nvim.pauseNotification()
+    await nvim.command('normal! a123')
+    await nvim.resumeNotification(true)
+    await shouldEqual(doc)
+    nvim.pauseNotification()
+    await nvim.command('normal! 5a456')
+    await nvim.resumeNotification(true)
+    await shouldEqual(doc)
+
+    nvim.pauseNotification()
     await nvim.command('call deletebufline("%", 2)')
     await nvim.resumeNotification(true)
     await shouldEqual(doc)

--- a/src/__tests__/vim.test.ts
+++ b/src/__tests__/vim.test.ts
@@ -932,6 +932,25 @@ describe('document', () => {
     await shouldEqual(doc2)
   })
 
+  // #5542
+  it('should synchronize buffered changes after setlines', async () => {
+    const fileContents = [
+      'import { equal } from "assert"',
+      '',
+      'An extra line required to let Vim buffer the changes caused by `undo`, can also be an empty line',
+      'console.log(0)',
+    ]
+    const filepath = await createTmpFile(fileContents.join('\n'), disposables)
+    const doc = await helper.createDocument(filepath)
+    nvim.pauseNotification()
+    // Simulate auto-import
+    await nvim.command(`call setline(4, 'console.log(path)') | call appendbufline('%', 1, 'import path from "path"')`)
+    await nvim.command('normal! u')
+
+    await nvim.resumeNotification(true)
+    await shouldEqual(doc)
+  })
+
   it('should patch change of current line', async () => {
     let doc = await helper.createDocument()
     nvim.call('setline', ['.', 'foo'], true)

--- a/src/__tests__/vim.test.ts
+++ b/src/__tests__/vim.test.ts
@@ -892,6 +892,34 @@ describe('document', () => {
     await doc.patchChange()
   })
 
+  // #5524
+  it('should synchronize changes after undo', async () => {
+    const filepath = await createTmpFile('abc', disposables)
+    const doc = await helper.createDocument(filepath)
+    nvim.pauseNotification()
+    await nvim.command('normal! Ofoo')
+    await nvim.command('normal! u')
+    await nvim.resumeNotification(true)
+    await shouldEqual(doc)
+  })
+  it('should synchronize changes after undo (2)', async () => {
+    const filepath2 = await createTmpFile('abc\ndef', disposables)
+    const doc2 = await helper.createDocument(filepath2)
+    nvim.pauseNotification()
+    await nvim.command('normal! Ofoo')
+    await nvim.command('normal! u')
+    await nvim.resumeNotification(true)
+    await shouldEqual(doc2)
+  })
+
+  it('should synchronize changes after executing a command with count', async () => {
+    const doc = await helper.createDocument()
+    nvim.pauseNotification()
+    await nvim.command('normal! 2o')
+    await nvim.resumeNotification(true)
+    await shouldEqual(doc)
+  })
+
   it('should patch change of current line', async () => {
     let doc = await helper.createDocument()
     nvim.call('setline', ['.', 'foo'], true)

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -233,15 +233,20 @@ export default class Document {
          */
         tick: number,
         /**
-         * First changed line number(zero-based), always >= 0
-         * Converted from `start` of `listener_add()` callback
+         * First line to be changed(zero-based), **before** the change is made,
+         * Always >= 0
+         * Converted from `change.lnum` of `listener_add()` callback
          */
         firstline: number,
         /**
-         * First line number below the change(zero-based), always >= `firstline`
-         * Converted from `end` of `listener_add()` callback
+         * First line below the last line to be changed(zero-based), **before** the change is made,
+         * Always >= `firstline`
+         * Converted from `change.end` of `listener_add()` callback
          */
         lastline: number,
+        /**
+         * Updated line content, **after** the change is made
+         */
         linedata: string[]
       ) => {
         this._changedtick = tick

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -219,24 +219,57 @@ export default class Document {
     }, _e => {
       fireDetach(this.bufnr)
     })
-    const onLinesChange = (_buf: number | Buffer, tick: number | null, firstline: number, lastline: number, linedata: string[]) => {
-      if (tick && tick > this._changedtick) {
-        this._changedtick = tick
-        lines = [...lines.slice(0, firstline), ...linedata, ...(lastline < 0 ? [] : lines.slice(lastline))]
-        if (lines.length == 0) lines = ['']
-        if (this._applying) {
-          this._applyLines = lines
-          return
-        }
-        this.lines = lines
-        fireLinesChanged(bufnr)
-        if (events.completing) return
-        this.fireContentChanges()
-      }
-    }
     if (isVim) {
-      this.buffer.listen('vim_lines', onLinesChange, this.disposables)
-    } else {
+      /**
+       * Triggered by `@chemzqm/neovim/src/api/client.ts vim_buf_change_event` which is triggered by `autoload/coc/api.vim OnBufferChange`
+       *
+       * Corresponds to `nvim_buf_lines_event`
+       * @see {@link https://neovim.io/doc/user/api/#nvim_buf_lines_event}
+       */
+      const vim_onLinesChange = (_buf: number, tick: number,
+        /**
+         * First changed line number(zero-based), always >= 0
+         * Converted from `start` of `listener_add()` callback
+         * */
+        firstline: number,
+        /**
+         * First line number below the change(zero-based), always >= `firstline`
+         * Converted from `end` of `listener_add()` callback
+         * */
+        lastline: number,
+        linedata: string[]
+      ) => {
+        if (tick > this._changedtick) {
+          this._changedtick = tick
+          lines = [...lines.slice(0, firstline), ...linedata, ...lines.slice(lastline)]
+          if (lines.length === 0) lines = ['']
+          if (this._applying) {
+            this._applyLines = lines
+            return
+          }
+          this.lines = lines
+          fireLinesChanged(bufnr)
+          if (events.completing) return
+          this.fireContentChanges()
+        }
+      }
+      this.buffer.listen('vim_lines', vim_onLinesChange, this.disposables)
+    } else { // isNvim
+      const onLinesChange = (_buf: number | Buffer, tick: number | null, firstline: number, lastline: number, linedata: string[]) => {
+        if (tick && tick > this._changedtick) {
+          this._changedtick = tick
+          lines = [...lines.slice(0, firstline), ...linedata, ...(lastline < 0 ? [] : lines.slice(lastline))]
+          if (lines.length == 0) lines = ['']
+          if (this._applying) {
+            this._applyLines = lines
+            return
+          }
+          this.lines = lines
+          fireLinesChanged(bufnr)
+          if (events.completing) return
+          this.fireContentChanges()
+        }
+      }
       this.buffer.listen('lines', onLinesChange, this.disposables)
       this.buffer.listen('detach', () => {
         fireDetach(this.bufnr)

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -233,13 +233,13 @@ export default class Document {
          */
         tick: number,
         /**
-         * First line to be changed(zero-based), **before** the change is made,
+         * First line of the change(zero-based), **before** the change is made,
          * Always >= 0
          * Converted from `change.lnum` of `listener_add()` callback
          */
         firstline: number,
         /**
-         * First line below the last line to be changed(zero-based), **before** the change is made,
+         * First line below the change(zero-based), **before** the change is made,
          * Always >= `firstline`
          * Converted from `change.end` of `listener_add()` callback
          */

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -226,34 +226,35 @@ export default class Document {
        * Corresponds to `nvim_buf_lines_event`
        * @see {@link https://neovim.io/doc/user/api/#nvim_buf_lines_event}
        */
-      const vim_onLinesChange = (_buf: number, tick: number,
+      const vim_onLinesChange = (_buf: number,
+        /**
+         * Always >= the tick of previous call
+         * @example When executing `normal! 5o`, this callback will be triggered 5 times with last two ticks the same
+         */
+        tick: number,
         /**
          * First changed line number(zero-based), always >= 0
          * Converted from `start` of `listener_add()` callback
-         * */
+         */
         firstline: number,
         /**
          * First line number below the change(zero-based), always >= `firstline`
          * Converted from `end` of `listener_add()` callback
-         * */
+         */
         lastline: number,
         linedata: string[]
       ) => {
-        // `=` is required
-        // When executing `normal! 5o`, this callback will be triggered 5 times with last two changedticks the same
-        if (tick >= this._changedtick) {
-          this._changedtick = tick
-          lines = [...lines.slice(0, firstline), ...linedata, ...lines.slice(lastline)]
-          if (lines.length === 0) lines = ['']
-          if (this._applying) {
-            this._applyLines = lines
-            return
-          }
-          this.lines = lines
-          fireLinesChanged(bufnr)
-          if (events.completing) return
-          this.fireContentChanges()
+        this._changedtick = tick
+        lines = [...lines.slice(0, firstline), ...linedata, ...lines.slice(lastline)]
+        if (lines.length === 0) lines = ['']
+        if (this._applying) {
+          this._applyLines = lines
+          return
         }
+        this.lines = lines
+        fireLinesChanged(bufnr)
+        if (events.completing) return
+        this.fireContentChanges()
       }
       this.buffer.listen('vim_lines', vim_onLinesChange, this.disposables)
     } else { // isNvim

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -239,7 +239,9 @@ export default class Document {
         lastline: number,
         linedata: string[]
       ) => {
-        if (tick > this._changedtick) {
+        // `=` is required
+        // When executing `normal! 5o`, this callback will be triggered 5 times with last two changedticks the same
+        if (tick >= this._changedtick) {
           this._changedtick = tick
           lines = [...lines.slice(0, firstline), ...linedata, ...lines.slice(lastline)]
           if (lines.length === 0) lines = ['']


### PR DESCRIPTION
closes: https://github.com/neoclide/coc.nvim/issues/5542
<br>

still a problem: https://github.com/neoclide/coc.nvim/issues/5524
<details>

<summary>With some `echom`</summary>

```diff
diff --git a/autoload/coc/api.vim b/autoload/coc/api.vim
index 76cfda4b..23d3d992 100644
--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -361,6 +361,10 @@ enddef

 # Callback of `listener_add()` with its `unbuffered` flag defaulting to `false`
 def OnBufferChange(bufnr: number, start: number, end: number, added: number, changes: list<dict<any>>): void
+  echom 'changes' changes
+  echom 'lines' getbufline(bufnr, start, end)
+  echom 'changedtick' getbufvar(bufnr, 'changedtick')
+
   # When selecting an item in Coc's popup menu or Vim's insert completion menu,
   # this callback will be triggered multiple times with only `change.col` different
   if added == 0 && end - start == 1
```

</details>

Here is the diff of `buffered` and `unbuffered`
```diff
@@ -1,19 +1,19 @@
 changes [{'lnum': 1, 'col': 1, 'added': 1, 'end': 1}]
 lines ['']
 changedtick 3
 changes [{'lnum': 1, 'col': 1, 'added': 0, 'end': 2}]
 lines ['f', 'abc']
 changedtick 4
 changes [{'lnum': 1, 'col': 2, 'added': 0, 'end': 2}]
 lines ['fo', 'abc']
 changedtick 5
 changes [{'lnum': 1, 'col': 3, 'added': 0, 'end': 2}]
 lines ['foo', 'abc']
 changedtick 6
 changes [{'lnum': 1, 'col': 1, 'added': 0, 'end': 2}]
 lines ['', 'abc']
 changedtick 7
-1 line less; before #72  1 second ago
 changes [{'lnum': 1, 'col': 1, 'added': -1, 'end': 2}]
-lines ['']
-changedtick 9
+lines ['abc']
+changedtick 8
+1 line less; before #72  1 second ago
```

### Notes

If enabling `unbuffered` flag of `listener_add()` added in [patch 9.1.1782](https://github.com/vim/vim/commit/e87d17ecfb4fa252783719a9abb286b5057efe12), all added failed tests passed
```diff
diff --git a/autoload/coc/api.vim b/autoload/coc/api.vim
index d9004e43..0ddd2142 100644
--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -1045,7 +1045,7 @@ export def Buf_attach(id: number = 0, ..._): bool
   const bufnr = GetValidBufnr(id)
   # listener not removed on e!
   DetachListener(bufnr)
-  const result = listener_add(OnBufferChange, bufnr)
+  const result = listener_add(OnBufferChange, bufnr, true)
   if result != 0
     listener_map[bufnr] = result
     return true
```
