### PR TITLE
fix(Vim9): Hide popup on creation

### DIFF
--- a/autoload/coc/api.vim
+++ b/autoload/coc/api.vim
@@ -124,12 +124,12 @@ const API_FUNCTIONS = [
 # Create a window with bufnr for execute win_execute
 def CreatePopup(bufnr: number): number
   noa const id = popup_create(bufnr, {
-      \ 'line': 1,
-      \ 'col': &columns,
-      \ 'maxwidth': 1,
-      \ 'maxheight': 1,
-      \ })
-  popup_hide(id)
+    'line': 1,
+    'col': &columns,
+    'maxwidth': 1,
+    'maxheight': 1,
+    'hidden': true,
+  })
   return id
 enddef
 


### PR DESCRIPTION
This prevents `Error event from nvim: 0 Vim(return):E863: Not allowed for a terminal in a popup window - on notification "call_function"` when typing in the quickpick dialog of `CocCommand workspace.showOutput`