### PR TITLE
fix(core): Early return from `getWorkspaceFolder`

### DIFF
--- a/src/__tests__/core/workspaceFolder.test.ts
+++ b/src/__tests__/core/workspaceFolder.test.ts
@@ -118,6 +118,10 @@ describe('WorkspaceFolderController', () => {
       workspaceFolder.setWorkspaceFolders([process.cwd()])
       res = workspaceFolder.getWorkspaceFolder(URI.file(filepath))
       expect(URI.parse(res.uri).fsPath).toBe(process.cwd())
+
+      const nonWorkspaceFolderFilePath=path.join(path.dirname(process.cwd()), 'NonWorkspaceFolder/file')
+      res = workspaceFolder.getWorkspaceFolder(URI.file(nonWorkspaceFolderFilePath))
+      expect(res).toBeUndefined()
     })
   })
 

--- a/src/core/workspaceFolder.ts
+++ b/src/core/workspaceFolder.ts
@@ -112,10 +112,12 @@ export default class WorkspaceFolderController {
 
   public getWorkspaceFolder(uri: URI): WorkspaceFolder | undefined {
     if (uri.scheme !== 'file') return undefined
+    if (this._workspaceFolders.length === 0) return undefined
     let folders = Array.from(this._workspaceFolders).map(o => URI.parse(o.uri).fsPath)
     folders.sort((a, b) => b.length - a.length)
     let fsPath = uri.fsPath
     let folder = folders.find(f => isParentFolder(f, fsPath, true))
+    if (folder === undefined) return undefined
     return toWorkspaceFolder(folder)
   }
 


### PR DESCRIPTION
When opening a file in a folder ignored by `"workspace.ignoredFolders"`, `this._workspaceFolders` remains `[]` -> `folders.length === 0` -> `folders.find(.....) === undefined` and finally `toWorkspaceFolder` logs `Invalid folder: undefined, full path required.`

When opening a file outside current workspace folder and `this._workspaceFolders` not updated, `folders.find(...isParentFolder...) === undefined` and finally `toWorkspaceFolder` logs `Invalid folder: undefined, full path required.`