### PR TITLE
fix(Vim9): Prevent using void return values from built-in functions

### DIFF
--- a/src/__tests__/vim.test.ts
+++ b/src/__tests__/vim.test.ts
@@ -225,7 +225,7 @@ describe('client API', () => {
 
   it('should set current buffer', async () => {
     let bufnr = await nvim.call('bufadd', ['foo']) as number
-    await nvim.call('bufload', [bufnr])
+    await nvim.command(`call bufload(${bufnr})`)
     await nvim.setBuffer(nvim.createBuffer(bufnr))
     let b = await nvim.buffer
     expect(b.id).toBe(bufnr)
@@ -662,7 +662,7 @@ describe('Window API', () => {
 
   it('should set buffer', async () => {
     let bufnr = await nvim.call('bufadd', ['foo']) as number
-    await nvim.call('bufload', [bufnr])
+    await nvim.command(`call bufload(${bufnr})`)
     await win.setBuffer(nvim.createBuffer(bufnr))
     let buf = await win.buffer
     expect(buf.id).toBe(bufnr)
@@ -801,7 +801,7 @@ describe('Popup', () => {
     let tabpage = await win.tabpage
     expect(tabpage.id).toBeGreaterThan(0)
     await win.close(true)
-    await nvim.call('popup_clear', [])
+    await nvim.command(`call popup_clear()`)
   })
 
   it('should create inputBox', async () => {

--- a/src/__tests__/vim.test.ts
+++ b/src/__tests__/vim.test.ts
@@ -893,7 +893,7 @@ describe('document', () => {
   })
 
   // FIXME #5524
-  it.skip('should synchronize changes after undo', async () => {
+  it.failing('[FAILED] should synchronize changes after undo', async () => {
     const filepath = await createTmpFile('abc', disposables)
     const doc = await helper.createDocument(filepath)
     nvim.pauseNotification()

--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -495,7 +495,7 @@ class DiagnosticManager implements Disposable {
     let buf = this.buffers.getItem(bufnr)
     if (buf) {
       let isEnabled = enable == undefined ? await buf.isEnabled() : enable == 0
-      await this.nvim.call('setbufvar', [bufnr, 'coc_diagnostic_disable', isEnabled ? 1 : 0])
+      await buf.doc.buffer.setVar('coc_diagnostic_disable', isEnabled ? 1 : 0)
       await buf.setState(!isEnabled)
     }
   }


### PR DESCRIPTION
More built-in functions return void since patch 9.2.0301 and 9.2.0305
https://github.com/vim/vim/commit/f07a1ed9031333de79abeee5b6b19a895dc72c73
https://github.com/vim/vim/commit/365d58a53969ab2cc96268146c54622127b931f0
<br>By the way, replace `skip` with `failing` in a test.