### PR TITLE
fix(tree): Only show item description if different than name

### DIFF
--- a/src/tree/LocationsDataProvider.ts
+++ b/src/tree/LocationsDataProvider.ts
@@ -94,7 +94,9 @@ export default class LocationsDataProvider<T extends LocationDataItem<T>, P> imp
     if (this.config.enableTooltip) {
       item.tooltip = path.relative(workspace.cwd, URI.parse(element.uri).fsPath)
     }
-    item.description = element.detail
+    if (element.name != element.detail) {
+      item.description = element.detail
+    }
     item.deprecated = element.tags?.includes(SymbolTag.Deprecated)
     item.icon = this.getIcon(element.kind)
     item.command = {

--- a/src/tree/LocationsDataProvider.ts
+++ b/src/tree/LocationsDataProvider.ts
@@ -94,7 +94,7 @@ export default class LocationsDataProvider<T extends LocationDataItem<T>, P> imp
     if (this.config.enableTooltip) {
       item.tooltip = path.relative(workspace.cwd, URI.parse(element.uri).fsPath)
     }
-    if (element.name != element.detail) {
+    if (typeof element.detail === 'string' && element.detail.length > 0 && element.name !== element.detail) {
       item.description = element.detail
     }
     item.deprecated = element.tags?.includes(SymbolTag.Deprecated)


### PR DESCRIPTION
For LocationDataItem's in treeview only show description if it different
than name.
