### PR TITLE
fix(language-client): different diagnostic collection name for pull mode

### DIFF
--- a/src/language-client/diagnostic.ts
+++ b/src/language-client/diagnostic.ts
@@ -255,7 +255,7 @@ export class DiagnosticRequestor extends BaseFeature<DiagnosticProviderMiddlewar
     this.onDidChangeDiagnosticsEmitter = new Emitter<void>()
     this.provider = this.createProvider()
 
-    this.diagnostics = languages.createDiagnosticCollection(defaultValue(options.identifier, client.id))
+    this.diagnostics = languages.createDiagnosticCollection(`${client.id}:pull:${defaultValue(options.identifier, client.id)}`)
     this.openRequests = new Map()
     this.documentStates = new DocumentPullStateTracker()
     this.workspaceErrorCounter = 0


### PR DESCRIPTION
Closes https://github.com/fannheyward/coc-rust-analyzer/issues/1376

Related

- https://github.com/neoclide/coc.nvim/issues/5612#issuecomment-4367652896
- https://github.com/fannheyward/coc-rust-analyzer/pull/1287
