### PR TITLE
fix(diagnostic): refresh on InsertLeave

### DIFF
--- a/src/diagnostic/buffer.ts
+++ b/src/diagnostic/buffer.ts
@@ -73,7 +73,11 @@ export class DiagnosticBuffer implements SyncItem {
       this._refreshing = true
       timer = setTimeout(() => {
         this._refreshing = false
-        if (!this._autoRefresh) return
+        if (!this.config.enable || !this.config.autoRefresh || !this.dirty) return
+        if (this.doc.hasChanged) {
+          if (!events.insertMode || this.config.refreshOnInsertMode) this.refreshHighlights()
+          return
+        }
         void this._refresh(true)
       }, delay)
     }
@@ -82,10 +86,6 @@ export class DiagnosticBuffer implements SyncItem {
       clearTimeout(timer)
     }
     this.refreshHighlights = fn
-  }
-
-  private get _autoRefresh(): boolean {
-    return this.config.enable && this.config.autoRefresh && this.dirty && !this.doc.hasChanged
   }
 
   public get config(): Readonly<DiagnosticConfig> {
@@ -249,6 +249,10 @@ export class DiagnosticBuffer implements SyncItem {
     let info = await this.getDiagnosticInfo(diagnostics.length === 0)
     // avoid highlights on invalid state or buffer hidden.
     if (!info || info.winid == -1) {
+      this._dirties.add(collection)
+      return
+    }
+    if (this.diagnosticsMap.get(collection) !== diagnostics) {
       this._dirties.add(collection)
       return
     }


### PR DESCRIPTION
Closes #5630

This fix was made Codex. Timing bugs caused this:

1. Race in update() during `await getDiagnosticInfo()`

    update() sets `diagnosticsMap[collection] = diagnostics` before
    awaiting. A concurrent update() (e.g. an empty clear racing with a
    non-empty error batch) could overwrite the map during the await.
    When the first call resumed, refresh() used its stale closure
    `diagnostics` for addSigns/updateHighlights (clearing signs), but
    setDiagnosticInfo() read the now-newer this.diagnosticsMap (showing
    errors in statusline). refresh() then deleted the dirty flag and the
    newer entry, leaving _dirties empty so the retry timer never fired.

    Fix: after the await, re-check `diagnosticsMap.get(collection) ===
    diagnostics`. If a concurrent write happened, defer to _dirties and
    let the newer update or the timer handle it.

2. refreshHighlights timer firing before document sync

    The refreshHighlights timer is 100ms, but fireContentChanges debounce
    is 150ms. When the timer fired with doc.hasChanged still true (lines
    not yet synced), the old _autoRefresh guard returned and the dirty
    state was effectively lost. The 100ms window between InsertLeave and
    the next debounced sync made this reproducible with slow typing plus
    mappings like `inoremap ( ()<left>`.

    Fix: when the timer fires while doc.hasChanged, reschedule
    refreshHighlights() (gated on insert-mode state) instead of giving
    up. After fireContentChanges flushes, the next tick takes the normal
    _refresh(true) path. The inline _autoRefresh getter is removed as it
    is no longer used.
