### PR TITLE
fix(diagnostic): avoid extra refresh after moveTo

### DIFF
--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -320,6 +320,8 @@ class DiagnosticManager implements Disposable {
     if (pos) {
       await window.moveTo(pos)
       await item.echoMessage(false, pos)
+      await item.showVirtualTextCurrentLine(pos.line + 1)
+      if (this.messageTimer) clearTimeout(this.messageTimer)
     } else {
       void window.showWarningMessage(`No more diagnostic before cursor position`)
     }
@@ -350,6 +352,8 @@ class DiagnosticManager implements Disposable {
     if (pos) {
       await window.moveTo(pos)
       await item.echoMessage(false, pos)
+      await item.showVirtualTextCurrentLine(pos.line + 1)
+      if (this.messageTimer) clearTimeout(this.messageTimer)
     } else {
       void window.showWarningMessage(`No more diagnostic after cursor position`)
     }


### PR DESCRIPTION
Closes #5635

The moveTo fires CursorMoved, will schedule a delayed onCursorHold/showVirtualTextCurrentLine refresh.

Refresh inline and cancel the pending messageTimer so only one refresh happens per jump.
