### PR TITLE
fix(snippets): discard prior session on programmatic buffer insert (#5448)

### DIFF
--- a/src/snippets/manager.ts
+++ b/src/snippets/manager.ts
@@ -120,7 +120,7 @@ export class SnippetManager {
   public async insertBufferSnippets(bufnr: number, edits: SnippetEdit[], select = false): Promise<boolean> {
     let document = workspace.getAttachedDocument(bufnr)
     const session = this.bufferSync.getItem(bufnr)
-    session.cancel(true)
+    session.deactivate()
     let snippetEdits: SnippetEdit[] = []
     for (const edit of edits) {
       let currentLine = document.getline(edit.range.start.line)
@@ -141,7 +141,7 @@ export class SnippetManager {
   public async insertBufferSnippet(bufnr: number, snippet: string | SnippetString, range: Range, insertTextMode?: InsertTextMode): Promise<boolean> {
     let document = workspace.getAttachedDocument(bufnr)
     const session = this.bufferSync.getItem(bufnr)
-    session.cancel(true)
+    session.deactivate()
     range = toValidRange(range)
     const line = document.getline(range.start.line)
     const snippetStr = toSnippetString(snippet)


### PR DESCRIPTION
Fixes #5448.

## Why

rust-analyzer's "Fill match arms" code action produces corrupted output (existing arm re-indented, new arm duplicated) when invoked a second time after `u` undo. The trigger is any snippet-bearing code action followed by a buffer revert and re-apply at the same range.

## Root cause

`SnippetSession.cancel(true)` is a *pause*, not a teardown: it sets `_paused = true` but leaves `this.snippet` and `this.current` populated. When the user reverts the buffer, `_synchronize` -> `replaceWithText` hits the `marker === this._tmSnippet` early-return in `snippet.ts`, which wipes the placeholder children but never updates `this.current` on the success path. `current` is now an orphan no longer in `_markerSequence`.

On the next `insertBufferSnippets` call, `session.cancel(true)` keeps the stale snippet, then `start()` sees `snippet && rangeInRange(range, snippet.range)` and takes the nested-expansion branch with the orphaned `current`. `findParent` falls back to `TextmateSnippet` and `replaceWithSnippet` wraps the new content using the stale `current.index`, so `this.snippet.text` diverges from the document and `reduceTextEdit` emits a corrupted edit.

## Fix

Programmatic buffer-targeted insertion is a fresh top-level operation, not a nested expansion at the cursor. Replace `session.cancel(true)` with `session.deactivate()` in both `insertBufferSnippets` and `insertBufferSnippet` so `start()` cannot graft onto a stale snippet. The at-cursor `insertSnippet` path is untouched - nested expansion is intentional there.

Closes #5419 too:

Root cause: 
Stale snippet session in `SnippetManager.insertBufferSnippets — cancel(true)` only pauses, keeping this.snippet alive; the next workspace-edit snippet is grafted via the nested branch in SnippetSession.start and corrupts range tracking, triggering the mismatch.

Fix: 

Same root-cause class as #5448, whose reproducer (rust-analyzer "Fill match arms" + "Extract into function") shows identical "snippet still active → next apply grafts onto stale tree" behavior. The existing fix on that branch eliminates the only path that produces the line-40 false-positive change tracked here.
