### PR TITLE
fix(snippets): keep textDocument fresh when synchronize is canceled mid-flight

### DIFF
--- a/src/snippets/session.ts
+++ b/src/snippets/session.ts
@@ -341,7 +341,6 @@ export class SnippetSession {
     const startTs = Date.now()
     let tokenSource = this.tokenSource = new CancellationTokenSource()
     const cursor = events.bufnr == document.bufnr ? await window.getCursorPosition() : undefined
-    if (tokenSource.token.isCancellationRequested) return
     let change = documentChange?.change
     if (!change) {
       let edit = getTextEdit(textDocument.lines, newDocument.lines, cursor, events.insertMode)
@@ -386,6 +385,7 @@ export class SnippetSession {
       this.deactivate()
       return
     }
+    if (tokenSource.token.isCancellationRequested) return
     const nextPlaceholder = getNextPlaceholder(current, true)
     const id = getPlaceholderId(current)
     const res = await this.snippet.replaceWithText(change.range, change.text, tokenSource.token, current, cursor)


### PR DESCRIPTION
On vim, confirming a completion item that produces a snippet (e.g. rust-analyzer's postfix `.let`) sometimes left the cursor at the typing column instead of jumping to `$0`. The snippet was being deactivated right after `selectPlaceholder` should have run.

## Root cause

`SnippetSession._synchronize` awaits `window.getCursorPosition()` near the top, then bails on `tokenSource.token.isCancellationRequested`. When two `session.onChange` events fired back-to-back during a postfix expansion (the third `applyEdits` for prefix removal, plus a debounced `fireContentChanges` flushing a late vim tick), the second one's `cancel()` aborted the first `_synchronize` mid-await. The early return then skipped both `this.textDocument = newDocument` and `snippet.resetStartPosition`, leaving a stale snapshot.

The next `_synchronize` ran with that stale `this.textDocument`, fell through to the `getTextEdit` fallback, and synthesized a diff that spanned the snippet boundary. `!rangeInRange` then deactivated the session before the placeholder could be selected.

## Fix

The cancellation only needs to gate the async `replaceWithText` that pushes edits back to vim. The before/after-snippet branches are pure in-memory updates and must always run so the snapshot stays consistent with `document.textDocument`. Move the cancel check to right before `replaceWithText`.

Closes #5411