### PR TITLE
fix(snippets): merge multi-edit snippets into single snippet for correct placeholder navigation

### DIFF
--- a/src/snippets/session.ts
+++ b/src/snippets/session.ts
@@ -19,7 +19,7 @@ import { filterSortEdits, reduceTextEdit } from '../util/textedit'
 import window from '../window'
 import workspace from '../workspace'
 import { executePythonCode, generateContextId, getInitialPythonCode } from './eval'
-import { getPlaceholderId, Placeholder, Text, TextmateSnippet } from './parser'
+import { getPlaceholderId, Placeholder, SnippetParser, Text, TextmateSnippet } from './parser'
 import { CocSnippet, CocSnippetPlaceholder, getNextPlaceholder, getUltiSnipActionCodes } from "./snippet"
 import { SnippetString } from './string'
 import { toSnippetString, UltiSnippetContext, wordsSource } from './util'
@@ -72,30 +72,17 @@ export class SnippetSession {
     const textDocument = this.document.textDocument
     const textEdits = filterSortEdits(textDocument, edits.map(e => TextEdit.replace(e.range, toSnippetString(e.snippet))))
     const len = textEdits.length
-    const snip = new TextmateSnippet()
+    // Build a single combined snippet by interleaving edit snippets with escaped text between them
+    let combined = ''
     for (let i = 0; i < len; i++) {
-      let range = textEdits[i].range
-      let placeholder = new Placeholder(i + 1)
-      placeholder.appendChild(new Text(textDocument.getText(range)))
-      snip.appendChild(placeholder)
-      if (i != len - 1) {
-        let r = Range.create(range.end, textEdits[i + 1].range.start)
-        snip.appendChild(new Text(textDocument.getText(r)))
+      combined += textEdits[i].newText
+      if (i < len - 1) {
+        let r = Range.create(textEdits[i].range.end, textEdits[i + 1].range.start)
+        combined += SnippetParser.escape(textDocument.getText(r))
       }
     }
-    this.deactivate()
-    const resolver = new SnippetVariableResolver(this.nvim, workspace.workspaceFolderControl)
-    let snippet = new CocSnippet(snip, textEdits[0].range.start, this.nvim, resolver)
-    await snippet.init()
-    this.activate(snippet)
-    // reverse insert needed
-    for (let i = len - 1; i >= 0; i--) {
-      let idx = i + 1
-      this.current = snip.placeholders.find(o => o.index === idx)
-      let edit = textEdits[i]
-      await this.start(edit.newText, edit.range, false)
-    }
-    return this.isActive
+    let range = Range.create(textEdits[0].range.start, textEdits[len - 1].range.end)
+    return await this.start(combined, range, false)
   }
 
   public async start(inserted: string, range: Range, select = true, context?: UltiSnippetContext): Promise<boolean> {

--- a/src/snippets/session.ts
+++ b/src/snippets/session.ts
@@ -19,7 +19,7 @@ import { filterSortEdits, reduceTextEdit } from '../util/textedit'
 import window from '../window'
 import workspace from '../workspace'
 import { executePythonCode, generateContextId, getInitialPythonCode } from './eval'
-import { getPlaceholderId, Placeholder, SnippetParser, Text, TextmateSnippet } from './parser'
+import { getPlaceholderId, Placeholder, SnippetParser, TextmateSnippet } from './parser'
 import { CocSnippet, CocSnippetPlaceholder, getNextPlaceholder, getUltiSnipActionCodes } from "./snippet"
 import { SnippetString } from './string'
 import { toSnippetString, UltiSnippetContext, wordsSource } from './util'
@@ -72,11 +72,34 @@ export class SnippetSession {
     const textDocument = this.document.textDocument
     const textEdits = filterSortEdits(textDocument, edits.map(e => TextEdit.replace(e.range, toSnippetString(e.snippet))))
     const len = textEdits.length
-    // Build a single combined snippet by interleaving edit snippets with escaped text between them
+    // Each edit is its own snippet with independent tabstops. Offset the
+    // placeholder indices per segment so they stay unique after merging.
+    // $0 of non-final segments is promoted to a regular tabstop so Tab
+    // navigation visits every edit; only the last $0 remains as the final stop.
+    const parser = new SnippetParser()
     let combined = ''
+    let offset = 0
     for (let i = 0; i < len; i++) {
-      combined += textEdits[i].newText
-      if (i < len - 1) {
+      const isLast = i === len - 1
+      const segment = parser.parse(textEdits[i].newText)
+      let localMax = 0
+      segment.walk(m => {
+        if (m instanceof Placeholder && m.index > localMax) localMax = m.index
+        return true
+      })
+      segment.walk(m => {
+        if (m instanceof Placeholder) {
+          if (m.index === 0) {
+            if (!isLast) m.index = offset + localMax + 1
+          } else {
+            m.index += offset
+          }
+        }
+        return true
+      })
+      combined += segment.toTextmateString()
+      offset += localMax + 1
+      if (!isLast) {
         let r = Range.create(textEdits[i].range.end, textEdits[i + 1].range.start)
         combined += SnippetParser.escape(textDocument.getText(r))
       }


### PR DESCRIPTION
## Problem

When applying a CodeAction that returns multiple SnippetTextEdits (e.g. rust-analyzer's "Add Label" action), the placeholder jump order and selection ranges are abnormal.

**Expected**: Tab/`<C-j>` jumps between `$1`, `$2`, `$0` across all edits with correct selection ranges.

**Actual**: First jump lands on an implicit `$0` within the first sub-snippet (cursor before `loop` instead of selecting `'l`). Subsequent jumps select entire wrapper placeholder content including non-placeholder text (e.g. ` 'l` instead of just `'l`).

## Root Cause

`insertSnippetEdits` treated each snippet edit as an independent sub-snippet nested inside wrapper placeholders. This caused:
1. Each sub-snippet got its own implicit `$0` final tabstop, trapping navigation within individual sub-snippets
2. When navigation escaped up to wrapper placeholders, it selected the entire wrapper content (including literal text like leading spaces)

## Fix

Combine all snippet edits into a single unified snippet string by interleaving their snippet texts with escaped document text between them. This ensures all placeholder indices (`$1`, `$2`, `$0`) form one shared namespace, and navigation works correctly across  matching VSCode's behavior.edits 

Fixes #5485