### PR TITLE
fix(inlayHint): clear hints on InsertEnter for Vim

### DIFF
--- a/src/handler/inlayHint/buffer.ts
+++ b/src/handler/inlayHint/buffer.ts
@@ -123,6 +123,13 @@ export default class InlayHintBuffer implements SyncItem {
     this._changedtick = this.doc.changedtick
     if (this.config.refreshOnInsertMode) return
     this.cancel()
+    // vim's textprop doesn't support nvim's right_gravity like option, will render hints to
+    // wrong column when text inserted. Clear hints during insert and re-render on leave
+    if (workspace.isVim) {
+      this.clearVirtualText()
+      this.regions.clear()
+      this.currentHints = []
+    }
   }
 
   public get current(): ReadonlyArray<InlayHintWithProvider> {


### PR DESCRIPTION
Vim's textprop has no left-gravity option for inline virtual text (the equivalent of Neovim's `right_gravity = false` on extmarks). When text is inserted at the same column as a zero-width inline prop, Vim always pushes the prop together with the new text, so parameter inlay hints drift to the wrong column after a completion confirm — e.g. `foo(bar: v)` becomes `foo(variablebar: )` instead of `foo(bar: variable)`.

There's no Vim-side knob to fix this today, so on Vim we clear all inlay hints on `InsertEnter` and rely on the existing `InsertLeave` path (changedtick comparison) to re-render once the user leaves insert mode. Neovim behavior is unchanged. The clearing is skipped when `inlayHint.refreshOnInsertMode` is enabled, matching the existing short-circuit.

Refs #5449