### PR TITLE
fix(inlayHint): re-render on CompleteDone for Vim

### DIFF
--- a/src/handler/inlayHint/buffer.ts
+++ b/src/handler/inlayHint/buffer.ts
@@ -123,13 +123,16 @@ export default class InlayHintBuffer implements SyncItem {
     this._changedtick = this.doc.changedtick
     if (this.config.refreshOnInsertMode) return
     this.cancel()
-    // vim's textprop doesn't support nvim's right_gravity like option, will render hints to
-    // wrong column when text inserted. Clear hints during insert and re-render on leave
-    if (workspace.isVim) {
-      this.clearVirtualText()
-      this.regions.clear()
-      this.currentHints = []
-    }
+  }
+
+  // Vim's textprop has no right_gravity like option, so inline hints drift to the wrong column
+  // after completion inserts text at the same column. Force a re-render on CompleteDone to fix it.
+  public onCompleteDone(): void {
+    if (!workspace.isVim) return
+    if (this.config.refreshOnInsertMode) return
+    if (!this.enabled) return
+    this.clearCache()
+    this.render(undefined, 0, true).catch(onUnexpectedError)
   }
 
   public get current(): ReadonlyArray<InlayHintWithProvider> {
@@ -208,9 +211,9 @@ export default class InlayHintBuffer implements SyncItem {
     }, 0).catch(onUnexpectedError)
   }
 
-  public async render(config?: RenderConfig, delay?: number): Promise<void> {
+  public async render(config?: RenderConfig, delay?: number, force = false): Promise<void> {
     if (!this.enabled) return
-    if (!this.config.refreshOnInsertMode && events.bufnr === this.doc.bufnr && events.insertMode) return
+    if (!force && !this.config.refreshOnInsertMode && events.bufnr === this.doc.bufnr && events.insertMode) return
     this.cancel()
     this.tokenSource = new CancellationTokenSource()
     let token = this.tokenSource.token

--- a/src/handler/inlayHint/index.ts
+++ b/src/handler/inlayHint/index.ts
@@ -48,6 +48,10 @@ export default class InlayHintHandler {
       let item = this.buffers.getItem(bufnr)
       if (item) item.onInsertEnter()
     }, null, this.disposables)
+    events.on('CompleteDone', (_item, _line, bufnr) => {
+      let item = this.buffers.getItem(bufnr)
+      if (item) item.onCompleteDone()
+    }, null, this.disposables)
     commands.register({
       id: 'document.toggleInlayHint',
       execute: (bufnr?: number) => {


### PR DESCRIPTION
Vim's textprop has no `right_gravity` like option for inline virtual text, so existing parameter inlay hints drift to the wrong column once completion inserts text at the same column (e.g. confirming `v` into `variable` turns `foo(bar: v)` into `foo(variablebar: )`).

#5643 worked around this by clearing all hints on `InsertEnter` for Vim and re-rendering on `InsertLeave`, which meant no hints were visible during the entire insert session. This PR takes a more targeted approach:

- Revert the `InsertEnter` clear-all branch.
- On `CompleteDone` (Vim only), clear the cached hints/regions and force a re-render so positions are recomputed against the post-completion buffer state.
- Add a `force` flag to `render()` so `CompleteDone` can bypass the insert-mode guard without enabling `refreshOnInsertMode` globally.

Hints can still drift on subsequent free typing in insert mode, which is the underlying Vim textprop limitation; this change specifically targets the completion-confirm case from #5449.

Refs #5449