### PR TITLE
fix(snippets): keep sibling placeholders on non-minimal content change

### DIFF
--- a/src/__tests__/snippets/session.test.ts
+++ b/src/__tests__/snippets/session.test.ts
@@ -326,6 +326,30 @@ describe('SnippetSession', () => {
       expect(session.isActive).toBe(true)
     })
 
+    it('should keep sibling placeholder on non minimal content change', async () => {
+      // A stale cursor reported by Vim during pending key mappings makes the
+      // diff non-minimal: editing placeholder 1 reports a range that engulfs
+      // the unchanged trailing text and placeholder 2. The change must be
+      // reduced so placeholder 2 survives the jump (#5624).
+      let session = await createSession()
+      let doc = await workspace.document
+      await nvim.input('i')
+      await session.start('foo(${1:attrs}, ${2:x})', defaultRange)
+      expect(session.placeholder.index).toBe(1)
+      await nvim.setLine('foo(a, x)')
+      await doc.patchChange()
+      await session.synchronize({
+        version: doc.textDocument.version,
+        change: { range: Range.create(0, 4, 0, 13), text: 'a, x)' }
+      })
+      expect(session.isActive).toBe(true)
+      expect(session.snippet.text).toBe('foo(a, x)')
+      await session.nextPlaceholder()
+      expect(session.isActive).toBe(true)
+      expect(session.placeholder.index).toBe(2)
+      expect(session.placeholder.value).toBe('x')
+    })
+
     it('should reset snippet when cancelled', async () => {
       let session = await createSession()
       await nvim.input('i')

--- a/src/snippets/session.ts
+++ b/src/snippets/session.ts
@@ -346,6 +346,15 @@ export class SnippetSession {
       let edit = getTextEdit(textDocument.lines, newDocument.lines, cursor, events.insertMode)
       change = { range: edit.range, text: edit.newText }
     }
+    // The reported change can be non-minimal, for example when Vim reports a
+    // stale cursor during pending key mappings the diff engulfs unchanged text
+    // that follows the edit. A non-minimal range makes replaceWithText splice
+    // out and destroy sibling placeholders, so reduce it to the minimal edit
+    // that keeps the change local to the affected placeholder (see #5624).
+    if (!emptyRange(change.range)) {
+      let reduced = reduceTextEdit(TextEdit.replace(change.range, change.text), textDocument.getText(change.range))
+      change = { range: reduced.range, text: reduced.newText }
+    }
     const { range, start } = snippet
     let c = comparePosition(change.range.start, range.end)
     // consider insert at the end


### PR DESCRIPTION
## Why

Reported in #5624: after an ambiguous key mapping (e.g. `inoremap ab` / `snoremap ab`), editing a snippet placeholder and then jumping with `<C-j>` skips the next placeholder and cancels the snippet session instead of selecting it.

## Root cause

During the select->insert transition caused by a pending key mapping, Vim reports a stale cursor (`insert=false`, cursor at end of line). `getTextEdit` uses that bad cursor to compute the diff, which disables suffix matching and produces a non-minimal, suffix-greedy edit. For `foo(${1:attrs}, ${2:x})`, editing placeholder 1 yields a range that engulfs the trailing `, x)` (including placeholder 2 and the closing paren) instead of the minimal edit on placeholder 1.

`replaceWithText` then hands that engulfing range to `replaceWithMarker`, which splices out placeholder 1, the `, ` text, placeholder 2, and `)` and replaces them with a single plain text node. Placeholder 2 is destroyed, the placeholder list collapses to just the final tabstop, and the next jump lands on `$0` and cancels the session.

## Fix

Reduce the content change to its minimal form in `_synchronize` (using the existing `reduceTextEdit` helper) before any range comparison or `replaceWithText` call. This keeps the edit local to the affected placeholder and leaves siblings intact.

This is fixed at the session layer rather than in `getTextEdit` or `replaceWithMarker`: the wrong cursor from Vim's pending-mapping state is hard to fix reliably, `getTextEdit` is widely used and risky to change, and the non-minimal edit is still a correct edit for LSP consumers. Only snippet placeholder tracking is sensitive to range minimality.

## Testing

- Added a regression test in `session.test.ts` that feeds a non-minimal change and asserts the sibling placeholder survives and `nextPlaceholder` selects it. Verified it fails on the unfixed code and passes with the fix.
- Reproduced the original bug in real Vim and confirmed the fix selects placeholder `x` correctly.
- Full snippets suite (254 tests), typecheck, and lint all pass.

Closes #5624