### PR TITLE
fix(completion): keep snippet placeholder cursor on Vim with additionalTextEdits

### DIFF
--- a/src/__tests__/completion/language.test.ts
+++ b/src/__tests__/completion/language.test.ts
@@ -490,6 +490,34 @@ describe('language source', () => {
       expect(col).toBe(3)
     })
 
+    it('should move cursor to empty placeholder with delete before snippet on additionalTextEdits', async () => {
+      // Faithful rust-analyzer postfix payload (#5411): the snippet textEdit
+      // replaces the trigger char with `$0`, additionalTextEdits delete the
+      // prefix located before the snippet, the cursor must land on `$0`.
+      let text = 'Some(2).'
+      await nvim.setLine(text)
+      let provider: CompletionItemProvider = {
+        provideCompletionItems: async (): Promise<CompletionItem[]> => [{
+          label: 'let',
+          insertTextFormat: InsertTextFormat.Snippet,
+          textEdit: { range: Range.create(0, text.length, 0, text.length + 1), newText: 'let $0 = Some(2);' },
+          additionalTextEdits: [TextEdit.del(Range.create(0, 0, 0, text.length))],
+          preselect: true
+        }]
+      }
+      disposables.push(languages.registerCompletionItemProvider('edits', 'edit', null, provider))
+      await nvim.input('Al')
+      await helper.waitPopup()
+      let res = await helper.items()
+      let idx = res.findIndex(o => o.source?.name == 'edits')
+      await helper.confirmCompletion(idx)
+      await helper.waitFor('getline', ['.'], 'let  = Some(2);')
+      await helper.wait(50)
+      let [, lnum, col] = await nvim.call('getcurpos') as [number, number, number]
+      expect(lnum).toBe(1)
+      expect(col).toBe(5)
+    })
+
     it('should not cancel current snippet session when additionalTextEdits inside snippet', async () => {
       await nvim.input('i')
       snippetManager.cancel()

--- a/src/completion/source-language.ts
+++ b/src/completion/source-language.ts
@@ -1,5 +1,5 @@
 'use strict'
-import { CompletionItem, InsertReplaceEdit, Range, TextEdit } from 'vscode-languageserver-types'
+import { CompletionItem, InsertReplaceEdit, Position, Range, TextEdit } from 'vscode-languageserver-types'
 import commands from '../commands'
 import { getLineAndPosition } from '../core/ui'
 import { createLogger } from '../logger'
@@ -125,8 +125,14 @@ export default class LanguageSource implements ISource<CompletionItem> {
     let version = doc.version
     let isSnippet = await this.applyTextEdit(doc, additionalEdits, item, opt)
     if (additionalEdits) {
-      // move cursor after edit
-      await doc.applyEdits(item.additionalTextEdits, doc.version != version, !isSnippet)
+      // Carry the real cursor through the edits for snippets so the placeholder
+      // cursor isn't left at the stale winrestview position on Vim (see #5411).
+      let move: boolean | Position = !isSnippet
+      if (isSnippet) {
+        let pos = await getLineAndPosition(workspace.nvim)
+        move = Position.create(pos.line, pos.character)
+      }
+      await doc.applyEdits(item.additionalTextEdits, doc.version != version, move)
       if (isSnippet) await snippetManager.selectCurrentPlaceholder()
     }
     if (item.command) {


### PR DESCRIPTION
## Why

Fixes #5411. On Vim (not Neovim), confirming a snippet completion whose `additionalTextEdits` delete text *before* the snippet, such as the rust-analyzer `let`/`if let` postfix, intermittently left the cursor in the middle of the leftover text instead of on the placeholder `$0`. The inserted text was always correct; only the cursor landed wrong.

## Root cause

In `onCompleteDone` (`src/completion/source-language.ts`), a snippet's `additionalTextEdits` were applied with `move=false`. That makes `getCursorAndCol` skip passing a cursor to the Vim `Set_lines` call, so only `winrestview` ran and restored the stale pre-delete cursor. Because the deletion removed characters to the left of the cursor, that restored column pointed too far right.

That stale cursor then became the only diff disambiguation signal for the snippet session: `_synchronize` reads `window.getCursorPosition()` and feeds it into `getTextEdit`, so the wrong cursor corrupted the computed placeholder range and the final `coc#snippet#move` landed off target. Neovim is unaffected because it tracks placeholders via extmarks rather than the cursor.

## Fix

Only the snippet branch changes: read the real cursor right before applying the `additionalTextEdits` and pass it through, so `getPositionFromEdits` shifts it left past the deletion and `Set_lines` overrides the stale `winrestview` position. With a correct post-delete cursor, `_synchronize` computes the right placeholder range. The non-snippet path is unchanged.

## Testing

- Typecheck passes.
- nvim: full snippets + completion suites and `language.test.ts` pass.
- vim: `language.test.ts` passes.
- Added a regression test modeling the rust-analyzer payload (snippet `$0` with a delete before it), passing on both Vim and Neovim.

Note: the bug is timing/undo specific and reproduces only on the reporter's Vim 9.1, which I could not reproduce on Vim 9.2 locally, so the added test documents the expected behavior and guards against gross regressions rather than proving the exact intermittent failure. Maintainer verification on Vim 9.1 is appreciated.