### PR TITLE
fix(snippets): avoid nesting snippets from stale sessions

### DIFF
--- a/src/__tests__/snippets/session.test.ts
+++ b/src/__tests__/snippets/session.test.ts
@@ -257,6 +257,26 @@ describe('SnippetSession', () => {
       let line = await nvim.line
       expect(line).toBe('foo bar')
     })
+
+    it('should not nest when stale session range contains new snippet', async () => {
+      await nvim.command('startinsert')
+      let doc = await workspace.document
+      let session = new SnippetSession(nvim, doc, { highlight: false, nextOnDelete: false, preferComplete: false })
+      disposables.push(session)
+      await session.start('if let ${1} = ${2:Some(()).and(optb)} {$0', defaultRange, false)
+
+      // Undo can leave the snippet session active while the buffer has returned
+      // to text that only happens to fall inside the old snippet range.
+      await nvim.setLine('    Some(())')
+      await doc.patchChange()
+      expect(session.isActive).toBe(true)
+
+      let res = await session.start('${1:Some(())}', Range.create(0, 4, 0, 12), false)
+      expect(res).toBe(true)
+      let line = await nvim.line
+      expect(line).toBe('    Some(())')
+      expect(session.snippet.text).toBe('Some(())')
+    })
   })
 
   describe('getRanges()', () => {

--- a/src/snippets/session.ts
+++ b/src/snippets/session.ts
@@ -104,7 +104,7 @@ export class SnippetSession {
     const edits: TextEdit[] = []
     let textmateSnippet: TextmateSnippet
     if (inserted.length === 0) return this.isActive
-    if (snippet && rangeInRange(range, snippet.range)) {
+    if (snippet && this.canNestSnippet(range, snippet)) {
       // update all snippet.
       let oldRange = snippet.range
       let previous = snippet.text
@@ -142,6 +142,11 @@ export class SnippetSession {
     let { placeholder } = this
     if (select && placeholder) await this.selectPlaceholder(placeholder, true)
     return this.isActive
+  }
+
+  private canNestSnippet(range: Range, snippet: CocSnippet): boolean {
+    let placeholder = this.placeholder
+    return !!placeholder && rangeInRange(range, snippet.range) && rangeInRange(range, placeholder.range)
   }
 
   private async tryPostExpand(textmateSnippet: TextmateSnippet): Promise<void> {


### PR DESCRIPTION
When undo leaves an old snippet session active, a new completion snippet can
still fall inside the stale snippet range and be treated as nested. Require the
new snippet range to be inside the current placeholder before nesting, so fresh
completion snippets start a new session instead.

Closes #5411

Co-authored with Codex.