### PR TITLE
fix(snippets): mirror shared editable final tabstops across snippet edits

### DIFF
--- a/src/__tests__/snippets/session.test.ts
+++ b/src/__tests__/snippets/session.test.ts
@@ -201,6 +201,86 @@ describe('SnippetSession', () => {
       expect(line).toBe('foo')
       expect(ses.selected).toBe(false)
     })
+
+    it('should keep independent snippet edit tabstop namespaces separate', async () => {
+      let session = await createSession()
+      let doc = session.document
+      await doc.applyEdits([TextEdit.insert(Position.create(0, 0), 'foo\n\nbar')])
+      let edits: SnippetEdit[] = [
+        { range: Range.create(0, 0, 0, 3), snippet: 'foo(${1:one})' },
+        { range: Range.create(2, 0, 2, 3), snippet: 'bar(${1:two})' },
+      ]
+      let res = await session.insertSnippetEdits(edits)
+      expect(res).toBe(true)
+      let lines = await doc.buffer.lines
+      expect(lines).toEqual(['foo(one)', '', 'bar(two)'])
+      expect(session.placeholder!.range).toEqual(Range.create(0, 4, 0, 7))
+      await nvim.call('cursor', [1, 5])
+      await nvim.setLine('foo(first)')
+      await doc.synchronize()
+      await session.forceSynchronize()
+      lines = await doc.buffer.lines
+      expect(lines).toEqual(['foo(first)', '', 'bar(two)'])
+    })
+
+    it('should mirror same-index placeholders across multiple snippet edits (#5485)', async () => {
+      let session = await createSession()
+      let doc = session.document
+      await doc.applyEdits([TextEdit.insert(Position.create(0, 0), [
+        'fn main() {',
+        '    loop {',
+        '        break;',
+        '        continue;',
+        '    }',
+        '}'
+      ].join('\n'))])
+      // edits produced by rust-analyzer "Add Label": the same placeholder
+      // ${0:'l} is reused at every site so the three labels stay linked.
+      let edits: SnippetEdit[] = [
+        { range: Range.create(1, 4, 1, 4), snippet: "${0:'l}: " },
+        { range: Range.create(2, 13, 2, 13), snippet: " ${0:'l}" },
+        { range: Range.create(3, 16, 3, 16), snippet: " ${0:'l}" },
+      ]
+      let res = await session.insertSnippetEdits(edits)
+      expect(res).toBe(true)
+      let lines = await doc.buffer.lines
+      expect(lines).toEqual([
+        'fn main() {',
+        "    'l: loop {",
+        "        break 'l;",
+        "        continue 'l;",
+        '    }',
+        '}'
+      ])
+      // selection is "'l" with no leading space, and it is a normal tabstop
+      // (not the final $0) so the session stays active for editing
+      expect(session.placeholder!.index).toBe(1)
+      expect(session.placeholder!.range).toEqual(Range.create(1, 4, 1, 6))
+      // the three labels are mirrors of a single tabstop
+      let ranges = session.snippet.getRanges(session.placeholder!.marker)
+      expect(ranges).toEqual([
+        Range.create(1, 4, 1, 6),
+        Range.create(2, 14, 2, 16),
+        Range.create(3, 17, 3, 19),
+      ])
+      // editing the primary label syncs to every mirror
+      await nvim.call('cursor', [2, 5])
+      await nvim.setLine("    'outer: loop {")
+      await doc.synchronize()
+      await session.forceSynchronize()
+      lines = await doc.buffer.lines
+      expect(lines).toEqual([
+        'fn main() {',
+        "    'outer: loop {",
+        "        break 'outer;",
+        "        continue 'outer;",
+        '    }',
+        '}'
+      ])
+      // Tab from the label jumps to the final tabstop and ends the session
+      await session.nextPlaceholder()
+      expect(session.isActive).toBe(false)
+    })
   })
 
   describe('nested snippet', () => {

--- a/src/snippets/session.ts
+++ b/src/snippets/session.ts
@@ -19,7 +19,7 @@ import { filterSortEdits, reduceTextEdit } from '../util/textedit'
 import window from '../window'
 import workspace from '../workspace'
 import { executePythonCode, generateContextId, getInitialPythonCode } from './eval'
-import { getPlaceholderId, Placeholder, Text, TextmateSnippet } from './parser'
+import { getPlaceholderId, Placeholder, SnippetParser, Text, TextmateSnippet } from './parser'
 import { CocSnippet, CocSnippetPlaceholder, getNextPlaceholder, getUltiSnipActionCodes } from "./snippet"
 import { SnippetString } from './string'
 import { toSnippetString, UltiSnippetContext, wordsSource } from './util'
@@ -71,6 +71,90 @@ export class SnippetSession {
     if (edits.length === 1) return await this.start(toSnippetString(edits[0].snippet), edits[0].range, false)
     const textDocument = this.document.textDocument
     const textEdits = filterSortEdits(textDocument, edits.map(e => TextEdit.replace(e.range, toSnippetString(e.snippet))))
+    const sharedFinals = this.getSharedEditableFinals(textEdits.map(o => o.newText))
+    if (sharedFinals.size === 0) return await this.insertNestedSnippetEdits(textEdits)
+    const len = textEdits.length
+    // Merge all edits into a single snippet so placeholders share one
+    // session. Each edit keeps its local tabstop namespace, except repeated
+    // editable final tabstops used by assists like rust-analyzer "Add Label",
+    // which intentionally mirror across edits.
+    let combined = ''
+    const snippets = textEdits.map(o => new SnippetParser().parse(o.newText))
+    let nextIndex = 1
+    for (const snippet of snippets) {
+      const localIndexes = new Set<number>()
+      snippet.walk(m => {
+        if (m instanceof Placeholder && m.index > 0) localIndexes.add(m.index)
+        return true
+      })
+      const indexMap = new Map<number, number>()
+      for (const index of Array.from(localIndexes).sort((a, b) => a - b)) {
+        indexMap.set(index, nextIndex++)
+      }
+      snippet.walk(m => {
+        if (m instanceof Placeholder && m.index > 0) m.index = indexMap.get(m.index)
+        return true
+      })
+    }
+    const sharedIndexMap = new Map<string, number>()
+    let needsFinalTabstop = false
+    for (const snippet of snippets) {
+      const localFinalMap = new Map<string, number>()
+      snippet.walk(m => {
+        if (m instanceof Placeholder && m.index === 0 && m.children.length > 0) {
+          needsFinalTabstop = true
+          const key = this.getEditableFinalKey(m)
+          let index = sharedFinals.has(key) ? sharedIndexMap.get(key) : localFinalMap.get(key)
+          if (index == null) {
+            index = nextIndex++
+            if (sharedFinals.has(key)) {
+              sharedIndexMap.set(key, index)
+            } else {
+              localFinalMap.set(key, index)
+            }
+          }
+          m.index = index
+        }
+        return true
+      })
+    }
+    for (let i = 0; i < len; i++) {
+      combined += snippets[i].toTextmateString()
+      if (i !== len - 1) {
+        let r = Range.create(textEdits[i].range.end, textEdits[i + 1].range.start)
+        combined += SnippetParser.escape(textDocument.getText(r))
+      }
+    }
+    if (needsFinalTabstop) combined += '$0'
+    this.deactivate()
+    let range = Range.create(textEdits[0].range.start, textEdits[len - 1].range.end)
+    return await this.start(combined, range, false)
+  }
+
+  private getEditableFinalKey(placeholder: Placeholder): string {
+    return placeholder.toTextmateString()
+  }
+
+  private getSharedEditableFinals(snippets: string[]): Set<string> {
+    const counts = new Map<string, number>()
+    for (const text of snippets) {
+      const keys = new Set<string>()
+      const snippet = new SnippetParser().parse(text)
+      snippet.walk(m => {
+        if (m instanceof Placeholder && m.index === 0 && m.children.length > 0) {
+          keys.add(this.getEditableFinalKey(m))
+        }
+        return true
+      })
+      for (const key of keys) {
+        counts.set(key, (counts.get(key) ?? 0) + 1)
+      }
+    }
+    return new Set(Array.from(counts.entries()).filter(([, count]) => count > 1).map(([key]) => key))
+  }
+
+  private async insertNestedSnippetEdits(textEdits: TextEdit[]): Promise<boolean> {
+    const textDocument = this.document.textDocument
     const len = textEdits.length
     const snip = new TextmateSnippet()
     for (let i = 0; i < len; i++) {


### PR DESCRIPTION
rust-analyzer assists such as "Add Label" emit multiple SnippetTextEdits
that reuse the same editable final tabstop (${0:'l}) at every site so the
inserted labels stay linked. coc previously applied each edit as its own
nested snippet, which prevented those labels from mirroring (editing one
did not update the others).

Detect editable final tabstops (${0:...} with a default value) that repeat
across edits and merge all edits into a single snippet, escaping the
document text between them. Each edit keeps its own local tabstop
namespace; only the shared editable finals collapse onto one index so they
mirror, and a fresh $0 is appended as the real final stop so selecting the
label keeps the session active and Tab navigation works. Edits without such
shared finals keep the original independent nested-snippet behavior.

Closes #5485

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
