### PR TITLE
Replace uuid package with global crypto.randomUUID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "tslib": "^2.8.1",
         "unidecode": "^1.1.0",
         "unzip-stream": "^0.3.4",
-        "uuid": "^14.0.0",
         "vscode-languageserver-protocol": "^3.18.0",
         "vscode-languageserver-textdocument": "^1.0.12",
         "vscode-languageserver-types": "^3.18.0",
@@ -3257,19 +3256,6 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "tslib": "^2.8.1",
     "unidecode": "^1.1.0",
     "unzip-stream": "^0.3.4",
-    "uuid": "^14.0.0",
     "vscode-languageserver-protocol": "^3.18.0",
     "vscode-languageserver-textdocument": "^1.0.12",
     "vscode-languageserver-types": "^3.18.0",

--- a/src/__tests__/client/diagnostics.test.ts
+++ b/src/__tests__/client/diagnostics.test.ts
@@ -1,7 +1,6 @@
 import { Neovim } from '../../neovim'
 import os from 'os'
 import path from 'path'
-import { v4 as uuid } from 'uuid'
 import { CancellationToken, DocumentDiagnosticRequest, Position, TextEdit } from 'vscode-languageserver-protocol'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { URI } from 'vscode-uri'
@@ -253,9 +252,9 @@ describe('DiagnosticFeature', () => {
   })
 
   it('should pull diagnostic on save', async () => {
-    let doc = await workspace.loadFile(getUri(uuid() + 'filtered'), 'edit')
+    let doc = await workspace.loadFile(getUri(crypto.randomUUID() + 'filtered'), 'edit')
     await doc.applyEdits([TextEdit.insert(Position.create(0, 0), 'foo')])
-    doc = await workspace.loadFile(getUri(uuid() + 'save'), 'tabe')
+    doc = await workspace.loadFile(getUri(crypto.randomUUID() + 'save'), 'tabe')
     let client = await createServer(true, false, {}, opt => {
       opt.diagnosticPullOptions = {
         onSave: true,

--- a/src/__tests__/client/features.test.ts
+++ b/src/__tests__/client/features.test.ts
@@ -1,6 +1,5 @@
 import * as assert from 'assert'
 import path from 'path'
-import { v4 as uuidv4 } from 'uuid'
 import { ApplyWorkspaceEditParams, CallHierarchyIncomingCall, CallHierarchyItem, CallHierarchyOutgoingCall, CallHierarchyPrepareRequest, CancellationToken, CancellationTokenSource, CodeAction, CodeActionRequest, CodeLensRequest, Color, ColorInformation, ColorPresentation, CompletionItem, CompletionRequest, CompletionTriggerKind, ConfigurationRequest, DeclarationRequest, DefinitionRequest, DidChangeConfigurationNotification, DidChangeTextDocumentNotification, DidChangeWatchedFilesNotification, DidCloseTextDocumentNotification, DidCreateFilesNotification, DidDeleteFilesNotification, DidOpenTextDocumentNotification, DidRenameFilesNotification, DidSaveTextDocumentNotification, Disposable, DocumentColorRequest, DocumentDiagnosticReport, DocumentDiagnosticReportKind, DocumentDiagnosticRequest, DocumentFormattingRequest, DocumentHighlight, DocumentHighlightKind, DocumentHighlightRequest, DocumentLink, DocumentLinkRequest, DocumentOnTypeFormattingRequest, DocumentRangeFormattingRequest, DocumentSelector, DocumentSymbolRequest, ErrorCodes, FoldingRange, FoldingRangeRequest, FullDocumentDiagnosticReport, Hover, HoverRequest, ImplementationRequest, InlayHintKind, InlayHintLabelPart, InlayHintRequest, InlineCompletionItem, InlineCompletionRequest, InlineValueEvaluatableExpression, InlineValueRequest, InlineValueText, InlineValueVariableLookup, LinkedEditingRangeRequest, Location, NotificationType0, ParameterInformation, Position, ProgressToken, ProtocolRequestType, Range, ReferencesRequest, RenameRequest, ResponseError, SelectionRange, SelectionRangeRequest, SemanticTokensRegistrationType, SignatureHelpRequest, SignatureHelpTriggerKind, SignatureInformation, TextDocumentContentRequest, TextDocumentEdit, TextDocumentSyncKind, TextEdit, TypeDefinitionRequest, TypeHierarchyPrepareRequest, WillCreateFilesRequest, WillDeleteFilesRequest, WillRenameFilesRequest, WillSaveTextDocumentNotification, WillSaveTextDocumentWaitUntilRequest, WorkDoneProgressBegin, WorkDoneProgressCreateRequest, WorkDoneProgressEnd, WorkDoneProgressReport, WorkspaceEdit, WorkspaceSymbolRequest } from 'vscode-languageserver-protocol'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { URI } from 'vscode-uri'
@@ -1383,7 +1382,7 @@ describe('Client integration', () => {
     let feature = client.getFeature(InlayHintRequest.method) as InlayHintsFeature
     const providerData = feature.getProvider(document)
     expect(feature.getProvider(TextDocument.create('term:///1', 'foo', 1, '\n'))).toBeUndefined()
-    feature.register({ id: uuidv4(), registerOptions: { documentSelector: null } })
+    feature.register({ id: crypto.randomUUID(), registerOptions: { documentSelector: null } })
     let res = feature.getRegistration([], { id: '1', workDoneProgress: '' } as any)
     expect(res).toEqual([undefined, undefined])
     isDefined(providerData)

--- a/src/__tests__/client/integration.test.ts
+++ b/src/__tests__/client/integration.test.ts
@@ -3,7 +3,6 @@ import cp, { ChildProcess } from 'child_process'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { v4 as uuid } from 'uuid'
 import { CancellationToken, DidCreateFilesNotification, Disposable, ErrorCodes, InlayHintRequest, LSPErrorCodes, MessageType, ResponseError, Trace, WorkDoneProgress } from 'vscode-languageserver-protocol'
 import { IPCMessageReader, IPCMessageWriter } from 'vscode-languageserver-protocol/node'
 import { MarkupKind, Range } from 'vscode-languageserver-types'
@@ -392,7 +391,7 @@ describe('Client events', () => {
     await helper.waitValue(() => {
       return times >= 3
     }, true)
-    let filename = path.join(os.tmpdir(), uuid())
+    let filename = path.join(os.tmpdir(), crypto.randomUUID())
     let uri = URI.file(filename)
     fs.writeFileSync(filename, 'foo', 'utf8')
     let spy = vi.spyOn(workspace, 'openResource').mockImplementation(() => {

--- a/src/__tests__/client/textSynchronization.test.ts
+++ b/src/__tests__/client/textSynchronization.test.ts
@@ -2,7 +2,6 @@ import { Neovim } from '../../neovim'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { v4 as uuidv4 } from 'uuid'
 import { DidChangeTextDocumentNotification, DidCloseTextDocumentNotification, DidOpenTextDocumentNotification, DocumentSelector, Position, Range, TextDocumentSaveReason, TextEdit, WillSaveTextDocumentNotification, WillSaveTextDocumentWaitUntilRequest } from 'vscode-languageserver-protocol'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { URI } from 'vscode-uri'
@@ -62,7 +61,7 @@ describe('TextDocumentSynchronization', () => {
       let client = createClient(undefined)
       await client.start()
       let feature = client.getFeature(DidOpenTextDocumentNotification.method)
-      feature.register({ id: uuidv4(), registerOptions: { documentSelector: null } })
+      feature.register({ id: crypto.randomUUID(), registerOptions: { documentSelector: null } })
       let res = await client.sendRequest('getLastOpen')
       expect(res).toBe(null)
       let docs = feature.openDocuments
@@ -100,7 +99,7 @@ describe('TextDocumentSynchronization', () => {
       let doc = await workspace.loadFile(uri.toString())
       expect(doc.languageId).toBe('javascript')
       let feature = client.getFeature(DidOpenTextDocumentNotification.method)
-      feature.register({ id: uuidv4(), registerOptions: { documentSelector: [{ language: 'javascript' }] } })
+      feature.register({ id: crypto.randomUUID(), registerOptions: { documentSelector: [{ language: 'javascript' }] } })
       let res = await client.sendRequest('getLastOpen') as any
       expect(res.uri).toBe(doc.uri)
       expect(called).toBe(true)
@@ -174,7 +173,7 @@ describe('TextDocumentSynchronization', () => {
       })
       await client.start()
       let openFeature = client.getFeature(DidOpenTextDocumentNotification.method)
-      let id = uuidv4()
+      let id = crypto.randomUUID()
       let options = { id, registerOptions: { documentSelector: [{ language: 'vim' }] } }
       openFeature.register(options)
       let feature = client.getFeature(DidCloseTextDocumentNotification.method)
@@ -229,7 +228,7 @@ describe('TextDocumentSynchronization', () => {
       feature.onNotificationSent(() => {
         called = true
       })
-      let doc = await helper.createDocument(`${uuidv4()}.vim`)
+      let doc = await helper.createDocument(`${crypto.randomUUID()}.vim`)
       await helper.waitValue(() => {
         return client.isSynced(doc.uri)
       }, true)
@@ -293,7 +292,7 @@ describe('TextDocumentSynchronization', () => {
         }
       })
       await client.start()
-      let fsPath = path.join(os.tmpdir(), `${uuidv4()}.vim`)
+      let fsPath = path.join(os.tmpdir(), `${crypto.randomUUID()}.vim`)
       let uri = URI.file(fsPath)
       await workspace.openResource(uri.toString())
       let doc = await workspace.document
@@ -317,7 +316,7 @@ describe('TextDocumentSynchronization', () => {
       let client = createClient([{ scheme: 'lsptest' }])
       await client.start()
       await client.sendNotification('registerDocumentSync')
-      let fsPath = path.join(os.tmpdir(), `${uuidv4()}-foo.vim`)
+      let fsPath = path.join(os.tmpdir(), `${crypto.randomUUID()}-foo.vim`)
       let uri = URI.file(fsPath)
       await workspace.openResource(uri.toString())
       let doc = await workspace.document
@@ -348,7 +347,7 @@ describe('TextDocumentSynchronization', () => {
       })
       await client.start()
       await client.sendNotification('registerDocumentSync')
-      let fsPath = path.join(os.tmpdir(), `${uuidv4()}-error.vim`)
+      let fsPath = path.join(os.tmpdir(), `${crypto.randomUUID()}-error.vim`)
       let uri = URI.file(fsPath)
       await helper.waitValue(() => {
         let feature = client.getFeature(DidOpenTextDocumentNotification.method)
@@ -394,7 +393,7 @@ describe('TextDocumentSynchronization', () => {
         }
       })
       await client.start()
-      let fsPath = path.join(os.tmpdir(), `${uuidv4()}.vim`)
+      let fsPath = path.join(os.tmpdir(), `${crypto.randomUUID()}.vim`)
       let uri = URI.file(fsPath)
       await workspace.openResource(uri.toString())
       let doc = await workspace.document

--- a/src/__tests__/completion/basic.test.ts
+++ b/src/__tests__/completion/basic.test.ts
@@ -1,5 +1,4 @@
 import { Neovim } from '../../neovim'
-import { v4 as uuidv4 } from 'uuid'
 import { CancellationToken, Disposable, Position, TextEdit } from 'vscode-languageserver-protocol'
 import commands from '../../commands'
 import completion, { Completion } from '../../completion'
@@ -38,7 +37,7 @@ async function pumvisible(): Promise<boolean> {
 }
 
 async function create(items: string[] | VimCompleteItem[], trigger = true, conf?: Partial<SourceConfig>): Promise<string> {
-  let name = uuidv4()
+  let name = crypto.randomUUID()
   disposables.push(sources.createSource({
     ...(conf ?? {}),
     name,

--- a/src/__tests__/configuration/configurations.test.ts
+++ b/src/__tests__/configuration/configurations.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { v1 as uuid } from 'uuid'
 import { Disposable } from 'vscode-languageserver-protocol'
 import { URI } from 'vscode-uri'
 import Configurations, { folderSettingsSchemaId, userSettingsSchemaId } from '../../configuration'
@@ -33,7 +32,7 @@ afterEach(() => {
 })
 
 function generateTmpDir(): string {
-  return path.join(os.tmpdir(), uuid())
+  return path.join(os.tmpdir(), crypto.randomUUID())
 }
 
 describe('FolderConfigutions', () => {
@@ -101,7 +100,7 @@ describe('Configurations', () => {
 
   describe('watchFile', () => {
     it('should watch user config file', async () => {
-      let userConfigFile = path.join(os.tmpdir(), `settings-${uuid()}.json`)
+      let userConfigFile = path.join(os.tmpdir(), `settings-${crypto.randomUUID()}.json`)
       fs.writeFileSync(userConfigFile, '{"foo.bar": true}', { encoding: 'utf8' })
       let conf = new Configurations(userConfigFile, undefined, false)
       disposables.push(conf)
@@ -275,7 +274,7 @@ describe('Configurations', () => {
     })
 
     it('should handle errors', () => {
-      let tmpFile = path.join(os.tmpdir(), uuid())
+      let tmpFile = path.join(os.tmpdir(), crypto.randomUUID())
       fs.writeFileSync(tmpFile, '{"x":', 'utf8')
       let conf = new Configurations(tmpFile)
       disposables.push(conf)
@@ -412,7 +411,7 @@ describe('Configurations', () => {
     })
 
     it('should create config file for workspace folder', async () => {
-      let folder = path.join(os.tmpdir(), `test-workspace-folder-${uuid()}`)
+      let folder = path.join(os.tmpdir(), `test-workspace-folder-${crypto.randomUUID()}`)
       let conf = new Configurations(undefined, {
         modifyConfiguration: async () => {},
         getWorkspaceFolder: () => {

--- a/src/__tests__/core/documents.test.ts
+++ b/src/__tests__/core/documents.test.ts
@@ -2,7 +2,6 @@ import { Neovim } from '../../neovim'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { v4 as uuid } from 'uuid'
 import { Disposable } from 'vscode-languageserver-protocol'
 import { LocationLink, Position, Range, TextEdit } from 'vscode-languageserver-types'
 import { URI } from 'vscode-uri'
@@ -156,7 +155,7 @@ describe('documents', () => {
   it('should check buffer rename on save', async () => {
     let doc = await workspace.document
     let bufnr = doc.bufnr
-    let name = `${uuid()}.vim`
+    let name = `${crypto.randomUUID()}.vim`
     let tmpfile = path.join(os.tmpdir(), name)
     await nvim.command(`write ${tmpfile}`)
     doc = workspace.getDocument(bufnr)

--- a/src/__tests__/core/fileSystemWatcher.test.ts
+++ b/src/__tests__/core/fileSystemWatcher.test.ts
@@ -2,7 +2,6 @@ import bser from 'bser'
 import net from 'net'
 import os from 'os'
 import path from 'path'
-import { v4 as uuid } from 'uuid'
 import { Disposable } from 'vscode-languageserver-protocol'
 import { URI } from 'vscode-uri'
 import Configurations from '../../configuration/index'
@@ -18,7 +17,7 @@ import helper from '../helper'
 let server: net.Server
 let client: net.Socket
 const cwd = path.resolve(__dirname, '../../..')
-const sockPath = path.join(os.tmpdir(), `watchman-fake-${uuid()}`)
+const sockPath = path.join(os.tmpdir(), `watchman-fake-${crypto.randomUUID()}`)
 process.env.WATCHMAN_SOCK = sockPath
 
 let workspaceFolder: WorkspaceFolderController

--- a/src/__tests__/core/files.test.ts
+++ b/src/__tests__/core/files.test.ts
@@ -2,7 +2,6 @@ import { Buffer, Neovim } from '../../neovim'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { v4 as uuid } from 'uuid'
 import { CancellationTokenSource, Disposable } from 'vscode-languageserver-protocol'
 import { CreateFile, DeleteFile, Position, Range, RenameFile, SnippetTextEdit, StringValue, TextDocumentEdit, TextEdit, VersionedTextDocumentIdentifier, WorkspaceEdit } from 'vscode-languageserver-types'
 import { URI } from 'vscode-uri'
@@ -284,7 +283,7 @@ describe('applyEdits()', () => {
         }
       }, 0)
     }, null, disposables)
-    let file = path.join(os.tmpdir(), uuid())
+    let file = path.join(os.tmpdir(), crypto.randomUUID())
     await workspace.createFile(file, { overwrite: true })
     expect(err).toBeDefined()
     fs.rmSync(file, { force: true })
@@ -354,7 +353,7 @@ describe('applyEdits()', () => {
   it('should support changes with edit and rename', async () => {
     let fsPath = await createTmpFile('test')
     let doc = await helper.createDocument(fsPath)
-    let newFile = path.join(os.tmpdir(), `coc-${process.pid}/new-${uuid()}`)
+    let newFile = path.join(os.tmpdir(), `coc-${process.pid}/new-${crypto.randomUUID()}`)
     let newUri = URI.file(newFile).toString()
     let edit: WorkspaceEdit = {
       documentChanges: [
@@ -397,7 +396,7 @@ describe('applyEdits()', () => {
   })
 
   it('should support edit new file with CreateFile', async () => {
-    let file = path.join(os.tmpdir(), uuid())
+    let file = path.join(os.tmpdir(), crypto.randomUUID())
     let uri = URI.file(file).toString()
     let workspaceEdit: WorkspaceEdit = {
       documentChanges: [
@@ -417,7 +416,7 @@ describe('applyEdits()', () => {
   })
 
   it('should undo and redo workspace edit', async () => {
-    const folder = path.join(os.tmpdir(), uuid())
+    const folder = path.join(os.tmpdir(), crypto.randomUUID())
     const pathone = path.join(folder, 'a')
     const pathtwo = path.join(folder, 'b')
     await workspace.files.createFile(pathone, { overwrite: true })
@@ -446,7 +445,7 @@ describe('applyEdits()', () => {
 
   it('should should support annotations', async () => {
     async function assertEdit(confirm: boolean, description: string | undefined): Promise<void> {
-      let doc = await helper.createDocument(uuid())
+      let doc = await helper.createDocument(crypto.randomUUID())
       let edit: WorkspaceEdit = {
         documentChanges: [
           {
@@ -525,9 +524,9 @@ describe('getOriginalLine', () => {
     it('should render with changes', async () => {
       let fsPath = await createTmpFile('foo\n1\n2\nbar')
       let doc = await helper.createDocument(fsPath)
-      let newFile = path.join(os.tmpdir(), `coc-${process.pid}/new-${uuid()}`)
+      let newFile = path.join(os.tmpdir(), `coc-${process.pid}/new-${crypto.randomUUID()}`)
       let newUri = URI.file(newFile).toString()
-      let createFile = path.join(os.tmpdir(), `coc-${process.pid}/create-${uuid()}`)
+      let createFile = path.join(os.tmpdir(), `coc-${process.pid}/create-${crypto.randomUUID()}`)
       let deleteFile = await createTmpFile('delete')
       disposables.push(Disposable.create(() => {
         if (fs.existsSync(newFile)) fs.unlinkSync(newFile)
@@ -571,7 +570,7 @@ describe('getOriginalLine', () => {
     })
 
     it('should render annotation label', async () => {
-      let filepath = path.join(__dirname, uuid())
+      let filepath = path.join(__dirname, crypto.randomUUID())
       disposables.push(Disposable.create(() => {
         if (fs.existsSync(filepath)) {
           fs.unlinkSync(filepath)
@@ -628,7 +627,7 @@ describe('getOriginalLine', () => {
 
   describe('createFile()', () => {
     it('should create and revert parent folder', async () => {
-      const folder = path.join(os.tmpdir(), uuid())
+      const folder = path.join(os.tmpdir(), crypto.randomUUID())
       const filepath = path.join(folder, 'a/b/bar')
       disposables.push(Disposable.create(() => {
         fs.rmSync(folder, { recursive: true, force: true })
@@ -668,7 +667,7 @@ describe('getOriginalLine', () => {
     })
 
     it('should revert file create', async () => {
-      let filepath = path.join(os.tmpdir(), uuid())
+      let filepath = path.join(os.tmpdir(), crypto.randomUUID())
       disposables.push(Disposable.create(() => {
         if (fs.existsSync(filepath)) fs.unlinkSync(filepath)
       }))
@@ -736,7 +735,7 @@ describe('getOriginalLine', () => {
       let doc = await helper.createDocument(file)
       await nvim.setLine('bar')
       await doc.patchChange()
-      let newFile = path.join(os.tmpdir(), `coc-${process.pid}/new-${uuid()}`)
+      let newFile = path.join(os.tmpdir(), `coc-${process.pid}/new-${crypto.randomUUID()}`)
       disposables.push(Disposable.create(() => {
         if (fs.existsSync(newFile)) fs.unlinkSync(newFile)
       }))
@@ -750,8 +749,8 @@ describe('getOriginalLine', () => {
     })
 
     it('should overwrite if file exists', async () => {
-      let filepath = path.join(os.tmpdir(), uuid())
-      let newPath = path.join(os.tmpdir(), uuid())
+      let filepath = path.join(os.tmpdir(), crypto.randomUUID())
+      let newPath = path.join(os.tmpdir(), crypto.randomUUID())
       await workspace.createFile(filepath)
       await workspace.createFile(newPath)
       await workspace.renameFile(filepath, newPath, { overwrite: true })
@@ -761,8 +760,8 @@ describe('getOriginalLine', () => {
     })
 
     it('should rename buffer in directory and revert', async () => {
-      let folder = path.join(os.tmpdir(), uuid())
-      let newFolder = path.join(os.tmpdir(), uuid())
+      let folder = path.join(os.tmpdir(), crypto.randomUUID())
+      let newFolder = path.join(os.tmpdir(), crypto.randomUUID())
       fs.mkdirSync(folder)
       disposables.push(Disposable.create(() => {
         fs.rmSync(folder, { recursive: true, force: true })
@@ -830,7 +829,7 @@ describe('getOriginalLine', () => {
     })
 
     it('should delete and recover folder', async () => {
-      let folder = path.join(os.tmpdir(), uuid())
+      let folder = path.join(os.tmpdir(), crypto.randomUUID())
       disposables.push(Disposable.create(() => {
         if (fs.existsSync(folder)) fs.rmdirSync(folder)
       }))
@@ -847,7 +846,7 @@ describe('getOriginalLine', () => {
     })
 
     it('should delete and recover folder recursive', async () => {
-      let folder = path.join(os.tmpdir(), uuid())
+      let folder = path.join(os.tmpdir(), crypto.randomUUID())
       disposables.push(Disposable.create(() => {
         fs.rmSync(folder, { recursive: true, force: true })
       }))

--- a/src/__tests__/core/funcs.test.ts
+++ b/src/__tests__/core/funcs.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { v4 as uuid } from 'uuid'
 import which from 'which'
 import Configurations from '../../configuration/index'
 import * as funcs from '../../core/funcs'
@@ -36,7 +35,7 @@ describe('Resolver()', () => {
 
   it('should resolve npm module', async () => {
     let r = new Resolver()
-    let folder = path.join(os.tmpdir(), uuid())
+    let folder = path.join(os.tmpdir(), crypto.randomUUID())
     Object.assign(r, {
       _npmFolder: folder,
       _yarnFolder: __dirname,

--- a/src/__tests__/core/terminals.test.ts
+++ b/src/__tests__/core/terminals.test.ts
@@ -1,7 +1,6 @@
 import { Neovim } from '../../neovim'
 import os from 'os'
 import path from 'path'
-import { v4 as uuid } from 'uuid'
 import which from 'which'
 import Terminals from '../../core/terminals'
 import { TerminalModel } from '../../model/terminal'
@@ -29,7 +28,7 @@ afterAll(async () => {
 describe('create terminal', () => {
   it('should use cleaned env', async () => {
     let terminal = await terminals.createTerminal(nvim, {
-      name: `test-${uuid()}`,
+      name: `test-${crypto.randomUUID()}`,
       shellPath: which.sync('bash'),
       strictEnv: true
     })
@@ -43,7 +42,7 @@ describe('create terminal', () => {
 
   it('should use custom shell command', async () => {
     let terminal = await terminals.createTerminal(nvim, {
-      name: `test-${uuid()}`,
+      name: `test-${crypto.randomUUID()}`,
       shellPath: which.sync('bash')
     })
     let bufnr = terminal.bufnr
@@ -54,7 +53,7 @@ describe('create terminal', () => {
   it('should use custom cwd', async () => {
     let basename = path.basename(os.tmpdir())
     let terminal = await terminals.createTerminal(nvim, {
-      name: `test-${uuid()}`,
+      name: `test-${crypto.randomUUID()}`,
       cwd: os.tmpdir()
     })
     let bufnr = terminal.bufnr
@@ -68,7 +67,7 @@ describe('create terminal', () => {
       exitStatus = terminal.exitStatus
     })
     let terminal = await terminals.createTerminal(nvim, {
-      name: `test-${uuid()}`,
+      name: `test-${crypto.randomUUID()}`,
       shellPath: which.sync('bash'),
       strictEnv: true
     })
@@ -91,7 +90,7 @@ describe('create terminal', () => {
 
   it('should not throw when show & hide disposed terminal', async () => {
     let terminal = await terminals.createTerminal(nvim, {
-      name: `test-${uuid()}`,
+      name: `test-${crypto.randomUUID()}`,
       shellPath: which.sync('bash')
     })
     terminal.dispose()
@@ -101,7 +100,7 @@ describe('create terminal', () => {
 
   it('should show terminal on current window', async () => {
     let terminal = await terminals.createTerminal(nvim, {
-      name: `test-${uuid()}`,
+      name: `test-${crypto.randomUUID()}`,
       shellPath: which.sync('bash')
     })
     let winid = await nvim.call('bufwinid', [terminal.bufnr])
@@ -112,7 +111,7 @@ describe('create terminal', () => {
 
   it('should show terminal that shown', async () => {
     let terminal = await terminals.createTerminal(nvim, {
-      name: `test-${uuid()}`,
+      name: `test-${crypto.randomUUID()}`,
       shellPath: which.sync('bash')
     })
     let res = await terminal.show(true)
@@ -121,7 +120,7 @@ describe('create terminal', () => {
 
   it('should show hidden terminal', async () => {
     let terminal = await terminals.createTerminal(nvim, {
-      name: `test-${uuid()}`,
+      name: `test-${crypto.randomUUID()}`,
       shellPath: which.sync('bash')
     })
     await terminal.hide()
@@ -130,7 +129,7 @@ describe('create terminal', () => {
 
   it('should create terminal', async () => {
     let terminal = await window.createTerminal({
-      name: `test-${uuid()}`,
+      name: `test-${crypto.randomUUID()}`,
     })
     expect(terminal).toBeDefined()
     expect(terminal.processId).toBeDefined()

--- a/src/__tests__/handler/workspace.test.ts
+++ b/src/__tests__/handler/workspace.test.ts
@@ -6,7 +6,6 @@ vi.mock('v8', async importOriginal => {
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { v4 as uuid } from 'uuid'
 import { Disposable, Location, Range } from 'vscode-languageserver-protocol'
 import { URI } from 'vscode-uri'
 import commands from '../../commands'
@@ -150,7 +149,7 @@ describe('Workspace handler', () => {
     })
 
     it('should rename file', async () => {
-      let dir = path.join(os.tmpdir(), uuid())
+      let dir = path.join(os.tmpdir(), crypto.randomUUID())
       fs.mkdirSync(dir, { recursive: true })
       let fsPath = path.join(dir, 'x')
       let newPath = path.join(dir, 'b')
@@ -176,7 +175,7 @@ describe('Workspace handler', () => {
     })
 
     it('should not rename when reject overwrite', async () => {
-      let dir = path.join(os.tmpdir(), uuid())
+      let dir = path.join(os.tmpdir(), crypto.randomUUID())
       fs.mkdirSync(dir, { recursive: true })
       let fsPath = path.join(dir, 'x')
       let newPath = path.join(dir, 'b')

--- a/src/__tests__/helper.ts
+++ b/src/__tests__/helper.ts
@@ -7,7 +7,6 @@ import net, { Server } from 'net'
 import os from 'os'
 import path from 'path'
 import util from 'util'
-import { v4 as uuid } from 'uuid'
 import { Disposable } from 'vscode-languageserver-protocol'
 import attach from '../attach'
 import type { Completion } from '../completion'
@@ -130,7 +129,7 @@ export class Helper extends EventEmitter {
     return new Promise((resolve, reject) => {
       if (!isWindows) {
         // not work on old version vim.
-        const socket = path.join(os.tmpdir(), `coc-test-${uuid()}.sock`)
+        const socket = path.join(os.tmpdir(), `coc-test-${crypto.randomUUID()}.sock`)
         server.listen(socket, () => {
           resolve(socket)
         })
@@ -239,7 +238,7 @@ export class Helper extends EventEmitter {
 
   public async edit(file?: string): Promise<Buffer> {
     if (!file || !path.isAbsolute(file)) {
-      file = path.join(__dirname, file ? file : `${uuid()}`)
+      file = path.join(__dirname, file ? file : `${crypto.randomUUID()}`)
     }
     let escaped = await this.nvim.call('fnameescape', file) as string
     await this.nvim.command(`edit ${escaped}`)
@@ -383,7 +382,7 @@ export async function createTmpFile(content: string, disposables?: Disposable[])
   if (!fs.existsSync(tmpFolder)) {
     fs.mkdirSync(tmpFolder)
   }
-  let fsPath = path.join(tmpFolder, uuid())
+  let fsPath = path.join(tmpFolder, crypto.randomUUID())
   await util.promisify(fs.writeFile)(fsPath, content, 'utf8')
   if (disposables) {
     disposables.push(Disposable.create(() => {

--- a/src/__tests__/list/history.test.ts
+++ b/src/__tests__/list/history.test.ts
@@ -3,10 +3,9 @@ import { DataBase } from '../../list/db'
 import os from 'os'
 import fs from 'fs'
 import path from 'path'
-import { v4 as uuid } from 'uuid'
 
 function createTmpDir(): string {
-  let dir = path.join(os.tmpdir(), uuid())
+  let dir = path.join(os.tmpdir(), crypto.randomUUID())
   fs.mkdirSync(dir, { recursive: true })
   return dir
 }

--- a/src/__tests__/list/sources.test.ts
+++ b/src/__tests__/list/sources.test.ts
@@ -1,7 +1,6 @@
 import { Neovim } from '../../neovim'
 import fs from 'fs'
 import os from 'os'
-import { v4 as uuid } from 'uuid'
 import { CancellationToken, Diagnostic, DiagnosticSeverity, Disposable, DocumentLink, Emitter, Location, Position, Range, SymbolInformation, SymbolKind, SymbolTag, TextEdit } from 'vscode-languageserver-protocol'
 import { URI } from 'vscode-uri'
 import diagnosticManager, { DiagnosticItem } from '../../diagnostic/manager'
@@ -585,7 +584,7 @@ describe('list sources', () => {
 
   describe('extensions', () => {
     it('should load extensions source', async () => {
-      let folder = path.join(os.tmpdir(), uuid())
+      let folder = path.join(os.tmpdir(), crypto.randomUUID())
       fs.mkdirSync(path.join(folder, 'foo'), { recursive: true })
       fs.mkdirSync(path.join(folder, 'bar'), { recursive: true })
       let infos: ExtensionInfo[] = []
@@ -657,7 +656,7 @@ describe('list sources', () => {
   describe('folders', () => {
     it('should load folders source', async () => {
       await helper.createDocument(__filename)
-      let uid = uuid()
+      let uid = crypto.randomUUID()
       let source = new FolderList()
       const doAction = async (name: string, item: any) => {
         let action = source.actions.find(o => o.name == name)

--- a/src/__tests__/modules/extensionInstaller.test.ts
+++ b/src/__tests__/modules/extensionInstaller.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { v4 as uuid } from 'uuid'
 import { getDependencies, getExtensionDependencies, Info, Installer, isNpmCommand, isYarn, registryUrl } from '../../extension/installer'
 import { remove } from '../../util/fs'
 
@@ -319,7 +318,7 @@ describe('Installer', () => {
     })
 
     it('should throw and remove folder when download failed', async () => {
-      tmpfolder = path.join(os.tmpdir(), uuid())
+      tmpfolder = path.join(os.tmpdir(), crypto.randomUUID())
       let installer = new Installer(tmpfolder, 'npm', 'coc-omni')
       let folder: string
       let option: any
@@ -341,7 +340,7 @@ describe('Installer', () => {
     })
 
     it('should revert folder when download failed', async () => {
-      tmpfolder = path.join(os.tmpdir(), uuid())
+      tmpfolder = path.join(os.tmpdir(), crypto.randomUUID())
       let installer = new Installer(tmpfolder, 'npm', 'coc-omni')
       let f = path.join(tmpfolder, 'coc-omni')
       fs.mkdirSync(f, { recursive: true })
@@ -360,7 +359,7 @@ describe('Installer', () => {
     })
 
     it('should install new extension', async () => {
-      tmpfolder = path.join(os.tmpdir(), uuid())
+      tmpfolder = path.join(os.tmpdir(), crypto.randomUUID())
       let installer = new Installer(tmpfolder, 'npm', 'coc-omni')
       let f = path.join(tmpfolder, 'coc-omni')
       let spy = vi.spyOn(installer, 'download').mockImplementation((_url, option) => {
@@ -381,7 +380,7 @@ describe('Installer', () => {
     })
 
     it('should install new version', async () => {
-      tmpfolder = path.join(os.tmpdir(), uuid())
+      tmpfolder = path.join(os.tmpdir(), crypto.randomUUID())
       let installer = new Installer(tmpfolder, 'npm', 'coc-omni')
       let f = path.join(tmpfolder, 'coc-omni')
       fs.mkdirSync(f, { recursive: true })
@@ -405,7 +404,7 @@ describe('Installer', () => {
 
     it('should install dependencies', async () => {
       let npm = path.resolve(__dirname, '../npm')
-      tmpfolder = path.join(os.tmpdir(), uuid())
+      tmpfolder = path.join(os.tmpdir(), crypto.randomUUID())
       fs.mkdirSync(tmpfolder)
       let installer = new Installer(tmpfolder, npm, 'coc-omni')
       let called = false
@@ -418,7 +417,7 @@ describe('Installer', () => {
 
     it('should reject on install error', async () => {
       let npm = path.resolve(__dirname, '../npm')
-      tmpfolder = path.join(os.tmpdir(), uuid())
+      tmpfolder = path.join(os.tmpdir(), crypto.randomUUID())
       fs.mkdirSync(tmpfolder)
       let installer = new Installer(tmpfolder, npm, 'coc-omni')
       let spy = vi.spyOn(installer, 'getInstallArguments').mockImplementation(() => {

--- a/src/__tests__/modules/extensionManager.test.ts
+++ b/src/__tests__/modules/extensionManager.test.ts
@@ -2,7 +2,6 @@ import { Neovim } from '../../neovim'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { v4 as uuid } from 'uuid'
 import { Disposable } from 'vscode-languageserver-protocol'
 import events from '../../events'
 import { API, checkCommand, checkFileSystem, checkLanguageId, Extension, ExtensionManager, ExtensionType, getActivationEvents, getEvents, getOnCommandList, toWorkspaceContainsPatterns } from '../../extension/manager'
@@ -35,7 +34,7 @@ afterAll(async () => {
 })
 
 function createFolder(): string {
-  let folder = path.join(os.tmpdir(), uuid())
+  let folder = path.join(os.tmpdir(), crypto.randomUUID())
   fs.mkdirSync(folder, { recursive: true })
   return folder
 }
@@ -195,7 +194,7 @@ describe('ExtensionManager', () => {
 
   describe('activationEvents', () => {
     async function createExtension(manager: ExtensionManager, ...events: string[]): Promise<Extension<API>> {
-      let id = uuid()
+      let id = crypto.randomUUID()
       let isActive = false
       let packageJSON = {
         name: id,
@@ -776,7 +775,7 @@ describe('ExtensionManager', () => {
 
     it('should watch single file extension', async () => {
       let dir = createFolder()
-      let id = uuid()
+      let id = crypto.randomUUID()
       let filepath = path.join(dir, `${id}.js`)
       fs.writeFileSync(filepath, `exports.activate = () => {return {file: "${filepath}"}};exports.deactivate = () => {}`, 'utf8')
       let manager = create(dir)
@@ -883,7 +882,7 @@ describe('ExtensionManager', () => {
       tmpfolder = createFolder()
       let manager = create(tmpfolder, false)
       await expect(manager.load('file_not_exists', false)).rejects.toThrow(Error)
-      let id = uuid()
+      let id = crypto.randomUUID()
       let filpath = path.join(os.tmpdir(), id)
       fs.writeFileSync(filpath, '', 'utf8')
       await manager.toggleExtension(`single-${id}`)

--- a/src/__tests__/modules/extensionModules.test.ts
+++ b/src/__tests__/modules/extensionModules.test.ts
@@ -3,7 +3,6 @@ import { Neovim } from '../../neovim'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { v4 as uuid } from 'uuid'
 import { Disposable } from 'vscode-languageserver-protocol'
 import { URI } from 'vscode-uri'
 import events from '../../events'
@@ -30,7 +29,7 @@ afterAll(async () => {
 })
 
 function createFolder(): string {
-  let folder = path.join(os.tmpdir(), uuid())
+  let folder = path.join(os.tmpdir(), crypto.randomUUID())
   fs.mkdirSync(folder, { recursive: true })
   disposables.push(Disposable.create(() => {
     fs.rmSync(folder, { recursive: true, force: true })
@@ -83,7 +82,7 @@ describe('utils', () => {
   describe('validExtensionFolder()', () => {
     it('should check validExtensionFolder', async () => {
       expect(validExtensionFolder(__dirname, '')).toBe(false)
-      let folder = path.join(os.tmpdir(), uuid())
+      let folder = path.join(os.tmpdir(), crypto.randomUUID())
       fs.mkdirSync(folder)
       disposables.push(Disposable.create(() => {
         fs.rmSync(folder, { recursive: true, force: true })
@@ -122,7 +121,7 @@ describe('utils', () => {
     })
 
     it('should remove unexpted file', async () => {
-      let root = path.join(os.tmpdir(), uuid())
+      let root = path.join(os.tmpdir(), crypto.randomUUID())
       fs.writeFileSync(root, '')
       let res = checkExtensionRoot(root)
       expect(res).toBe(true)
@@ -134,7 +133,7 @@ describe('utils', () => {
 
   describe('loadExtensionJson()', () => {
     function testErrors(data: any, version: string, count, createJs = false): any {
-      let folder = path.join(os.tmpdir(), uuid())
+      let folder = path.join(os.tmpdir(), crypto.randomUUID())
       fs.mkdirSync(folder)
       disposables.push(Disposable.create(() => {
         fs.rmSync(folder, { recursive: true, force: true })
@@ -181,7 +180,7 @@ describe('ExtensionStat', () => {
   }
 
   function create(): [ExtensionStat, string] {
-    let folder = path.join(os.tmpdir(), uuid())
+    let folder = path.join(os.tmpdir(), crypto.randomUUID())
     fs.mkdirSync(folder)
     disposables.push(Disposable.create(() => {
       fs.rmSync(folder, { force: true, recursive: true })
@@ -193,7 +192,7 @@ describe('ExtensionStat', () => {
     let spy = vi.spyOn(ExtensionStat.prototype, 'migrate' as any).mockImplementation(() => {
       throw new Error('my error')
     })
-    let folder = path.join(os.tmpdir(), uuid())
+    let folder = path.join(os.tmpdir(), crypto.randomUUID())
     fs.mkdirSync(folder)
     let stat = new ExtensionStat(folder)
     spy.mockRestore()
@@ -201,7 +200,7 @@ describe('ExtensionStat', () => {
   })
 
   it('should add local extension', async () => {
-    let folder = path.join(os.tmpdir(), uuid())
+    let folder = path.join(os.tmpdir(), crypto.randomUUID())
     let stat = new ExtensionStat(folder)
     stat.addLocalExtension('name', folder)
     expect(stat.getFolder('name')).toBe(folder)

--- a/src/__tests__/modules/extensions.test.ts
+++ b/src/__tests__/modules/extensions.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { v4 as uuid } from 'uuid'
 import { URI } from 'vscode-uri'
 import which from 'which'
 import commands from '../../commands'
@@ -90,7 +89,7 @@ describe('extensions', () => {
   it('should add global extensions', async () => {
     extensions.states.addExtension('foo', '0.0.1')
     extensions.states.addExtension('bar', '0.0.1')
-    extensions.modulesFolder = path.join(os.tmpdir(), uuid())
+    extensions.modulesFolder = path.join(os.tmpdir(), crypto.randomUUID())
     let folder = path.join(extensions.modulesFolder, 'foo')
     writeJson(path.join(folder, 'package.json'), { name: 'foo', engines: { coc: '>=0.0.1' } })
     fs.writeFileSync(path.join(folder, 'index.js'), '')
@@ -122,11 +121,11 @@ describe('extensions', () => {
   })
 
   it('should load extension stats from runtimepath', () => {
-    let f1 = path.join(os.tmpdir(), uuid())
+    let f1 = path.join(os.tmpdir(), crypto.randomUUID())
     fs.mkdirSync(f1)
     writeJson(path.join(f1, 'package.json'), { name: 'name', engines: { coc: '>=0.0.1' } })
     fs.writeFileSync(path.join(f1, 'index.js'), '')
-    let f2 = path.join(os.tmpdir(), uuid())
+    let f2 = path.join(os.tmpdir(), crypto.randomUUID())
     fs.mkdirSync(f2)
     writeJson(path.join(f2, 'package.json'), { name: 'folder', engines: { coc: '>=0.0.1' } })
     fs.writeFileSync(path.join(f2, 'index.js'), '')
@@ -213,7 +212,7 @@ describe('extensions', () => {
       return {
         on: () => {},
         update: () => {
-          return Promise.resolve(path.join(os.tmpdir(), uuid()))
+          return Promise.resolve(path.join(os.tmpdir(), crypto.randomUUID()))
         }
       } as any
     })
@@ -320,7 +319,7 @@ describe('extensions', () => {
 
   it('should checkRecommendation', async () => {
     await extensions.checkRecommendation({ name: 'tmp', uri: URI.file(__dirname).toString() })
-    tmpfolder = path.join(os.tmpdir(), uuid())
+    tmpfolder = path.join(os.tmpdir(), crypto.randomUUID())
     let folder = path.join(tmpfolder, '.vim')
     fs.mkdirSync(folder, { recursive: true })
 

--- a/src/__tests__/modules/fetch.test.ts
+++ b/src/__tests__/modules/fetch.test.ts
@@ -5,7 +5,6 @@ import path from 'path'
 import semver from 'semver'
 import { URL } from 'url'
 import { promisify } from 'util'
-import { v4 as uuid } from 'uuid'
 import { CancellationTokenSource } from 'vscode-languageserver-protocol'
 import download, { getEtag, getExtname } from '../../model/download'
 import fetch, { getAgent, getDataType, getRequestModule, getSystemProxyURI, getText, request, resolveRequestOptions, toPort, toURL } from '../../model/fetch'
@@ -238,7 +237,7 @@ describe('utils', () => {
   })
 
   it('should resolve request options #1', async () => {
-    let file = path.join(os.tmpdir(), `${uuid()}/ca`)
+    let file = path.join(os.tmpdir(), `${crypto.randomUUID()}/ca`)
     fs.mkdirSync(path.dirname(file))
     fs.writeFileSync(file, 'ca', 'utf8')
     helper.updateConfiguration('http.proxyAuthorization', 'authorization')
@@ -395,7 +394,7 @@ describe('fetch', () => {
 
 describe('download', () => {
   let binary_file: string
-  let tempdir = path.join(os.tmpdir(), uuid())
+  let tempdir = path.join(os.tmpdir(), crypto.randomUUID())
 
   beforeAll(async () => {
     binary_file = path.join(os.tmpdir(), 'binary_file')

--- a/src/__tests__/modules/fs.test.ts
+++ b/src/__tests__/modules/fs.test.ts
@@ -1,5 +1,4 @@
 import { findUp, isDirectory, findMatch, watchFile, writeJson, loadJson, normalizeFilePath, checkFolder, getFileType, isGitIgnored, readFileLine, readFileLines, fileStartsWith, writeFile, remove, renameAsync, isParentFolder, parentDirs, inDirectory, getFileLineCount, sameFile, lineToLocation, resolveRoot, statAsync, FileType } from '../../util/fs'
-import { v4 as uuid } from 'uuid'
 import path from 'path'
 import fs from 'fs'
 import os from 'os'
@@ -31,7 +30,7 @@ describe('fs', () => {
   })
 
   it('should watch file', async () => {
-    let filepath = path.join(os.tmpdir(), uuid())
+    let filepath = path.join(os.tmpdir(), crypto.randomUUID())
     fs.writeFileSync(filepath, 'file', 'utf8')
     let called = false
     let disposable = watchFile(filepath, () => {
@@ -64,7 +63,7 @@ describe('fs', () => {
     })
 
     it('should loadJson with bad format', async () => {
-      let file = path.join(os.tmpdir(), uuid())
+      let file = path.join(os.tmpdir(), crypto.randomUUID())
       fs.writeFileSync(file, 'foo', 'utf8')
       expect(loadJson(file)).toEqual({})
     })
@@ -72,13 +71,13 @@ describe('fs', () => {
 
   describe('writeJson()', () => {
     it('should writeJson file', async () => {
-      let file = path.join(os.tmpdir(), uuid())
+      let file = path.join(os.tmpdir(), crypto.randomUUID())
       writeJson(file, { x: 1 })
       expect(loadJson(file)).toEqual({ x: 1 })
     })
 
     it('should create file with folder', async () => {
-      let file = path.join(os.tmpdir(), uuid(), 'foo', 'bar')
+      let file = path.join(os.tmpdir(), crypto.randomUUID(), 'foo', 'bar')
       writeJson(file, { foo: '1' })
       expect(loadJson(file)).toEqual({ foo: '1' })
     })
@@ -97,7 +96,7 @@ describe('fs', () => {
     })
 
     it('should get location', async () => {
-      let file = path.join(os.tmpdir(), uuid())
+      let file = path.join(os.tmpdir(), crypto.randomUUID())
       fs.writeFileSync(file, '\nfoo\n', 'utf8')
       let res = await lineToLocation(file, 'foo', 'foo')
       expect(res.range).toEqual(Range.create(1, 0, 1, 3))
@@ -106,8 +105,8 @@ describe('fs', () => {
 
   describe('remove()', () => {
     it('should remove files', async () => {
-      await remove(path.join(os.tmpdir(), uuid()))
-      let p = path.join(os.tmpdir(), uuid())
+      await remove(path.join(os.tmpdir(), crypto.randomUUID()))
+      let p = path.join(os.tmpdir(), crypto.randomUUID())
       fs.writeFileSync(p, 'data', 'utf8')
       await remove(p)
       let exists = fs.existsSync(p)
@@ -119,13 +118,13 @@ describe('fs', () => {
       let spy = vi.spyOn(fs, 'rm').mockImplementation(() => {
         throw new Error('my error')
       })
-      let p = path.join(os.tmpdir(), uuid())
+      let p = path.join(os.tmpdir(), crypto.randomUUID())
       await remove(p)
       spy.mockRestore()
     })
 
     it('should remove folder', async () => {
-      let f = path.join(os.tmpdir(), uuid())
+      let f = path.join(os.tmpdir(), crypto.randomUUID())
       let p = path.join(f, 'a/b/c')
       fs.mkdirSync(p, { recursive: true })
       await remove(f)
@@ -140,7 +139,7 @@ describe('fs', () => {
       expect(res).toBe(FileType.Directory)
       res = await getFileType(__filename)
       expect(res).toBe(FileType.File)
-      let newPath = path.join(os.tmpdir(), uuid())
+      let newPath = path.join(os.tmpdir(), crypto.randomUUID())
       fs.symlinkSync(__filename, newPath)
       res = await getFileType(newPath)
       expect(res).toBe(FileType.SymbolicLink)
@@ -184,7 +183,7 @@ describe('fs', () => {
 
   describe('renameAsync()', () => {
     it('should rename file', async () => {
-      let id = uuid()
+      let id = crypto.randomUUID()
       let filepath = path.join(os.tmpdir(), id)
       await writeFile(filepath, id)
       let dest = path.join(os.tmpdir(), 'bar')
@@ -273,7 +272,7 @@ describe('fs', () => {
 
     it('should be ignored', async () => {
       let res = await isGitIgnored('')
-      let uid = uuid()
+      let uid = crypto.randomUUID()
       expect(res).toBe(false)
       res = await isGitIgnored(path.join(os.tmpdir(), uid))
       expect(res).toBe(false)

--- a/src/__tests__/modules/logger.test.ts
+++ b/src/__tests__/modules/logger.test.ts
@@ -3,7 +3,6 @@ import { createLogger, logger, getTimestamp, resolveLogFilepath, emptyFile } fro
 import path from 'path'
 import fs from 'fs'
 import os from 'os'
-import { v4 as uuid } from 'uuid'
 
 let filepath: string
 afterEach(() => {
@@ -58,7 +57,7 @@ describe('FileLogger', () => {
   })
 
   it('should create logger', async () => {
-    filepath = path.join(os.tmpdir(), uuid())
+    filepath = path.join(os.tmpdir(), crypto.randomUUID())
     let fileLogger = new FileLogger(filepath, LogLevel.Trace, {
       color: false,
       depth: 2,
@@ -83,7 +82,7 @@ describe('FileLogger', () => {
   })
 
   it('should switch to console', () => {
-    filepath = path.join(os.tmpdir(), uuid())
+    filepath = path.join(os.tmpdir(), crypto.randomUUID())
     let fileLogger = new FileLogger(filepath, LogLevel.Trace, {})
     let logger = fileLogger.createLogger('scope')
     fileLogger.switchConsole()
@@ -104,7 +103,7 @@ describe('FileLogger', () => {
   })
 
   it('should enable color', async () => {
-    filepath = path.join(os.tmpdir(), uuid())
+    filepath = path.join(os.tmpdir(), crypto.randomUUID())
     let fileLogger = new FileLogger(filepath, LogLevel.Trace, {
       color: true
     })
@@ -116,14 +115,14 @@ describe('FileLogger', () => {
   })
 
   it('should change level', () => {
-    filepath = path.join(os.tmpdir(), uuid())
+    filepath = path.join(os.tmpdir(), crypto.randomUUID())
     let fileLogger = new FileLogger(filepath, LogLevel.Off, {})
     fileLogger.setLevel(LogLevel.Debug)
     fileLogger.setLevel(LogLevel.Debug)
   })
 
   it('should work with off level', async () => {
-    filepath = path.join(os.tmpdir(), uuid())
+    filepath = path.join(os.tmpdir(), crypto.randomUUID())
     let fileLogger = new FileLogger(filepath, LogLevel.Off, {
       color: false,
       depth: 2,
@@ -144,7 +143,7 @@ describe('FileLogger', () => {
   })
 
   it('should work without formatter', async () => {
-    filepath = path.join(os.tmpdir(), uuid())
+    filepath = path.join(os.tmpdir(), crypto.randomUUID())
     let fileLogger = new FileLogger(filepath, LogLevel.Trace, {
       userFormatters: false
     })
@@ -157,7 +156,7 @@ describe('FileLogger', () => {
   })
 
   it('should use backup file', async () => {
-    filepath = path.join(os.tmpdir(), uuid())
+    filepath = path.join(os.tmpdir(), crypto.randomUUID())
     let fileLogger = new FileLogger(filepath, LogLevel.Trace, {
       userFormatters: true
     })
@@ -175,7 +174,7 @@ describe('FileLogger', () => {
   })
 
   it('should not throw on error', async () => {
-    filepath = path.join(os.tmpdir(), uuid())
+    filepath = path.join(os.tmpdir(), crypto.randomUUID())
     let fileLogger = new FileLogger(filepath, LogLevel.Trace, {
       userFormatters: false
     })
@@ -213,7 +212,7 @@ describe('FileLogger', () => {
 
   it('should empty file', async () => {
     emptyFile('/file_not_exists')
-    filepath = path.join(os.tmpdir(), uuid())
+    filepath = path.join(os.tmpdir(), crypto.randomUUID())
     fs.writeFileSync(filepath, 'data', 'utf8')
     emptyFile(filepath)
     let content = fs.readFileSync(filepath, 'utf8')

--- a/src/__tests__/modules/services.test.ts
+++ b/src/__tests__/modules/services.test.ts
@@ -3,7 +3,6 @@ import fs from 'fs'
 import net from 'net'
 import os from 'os'
 import path from 'path'
-import { v4 as uuid } from 'uuid'
 import { Disposable } from 'vscode-languageserver-protocol'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { URI } from 'vscode-uri'
@@ -69,7 +68,7 @@ describe('services', () => {
     })
 
     it('should use languageserver config from workspace folder', async () => {
-      let folder = path.join(os.tmpdir(), uuid())
+      let folder = path.join(os.tmpdir(), crypto.randomUUID())
       fs.mkdirSync(path.join(folder, '.vim'), { recursive: true })
       let configFile = path.join(folder, '.vim/coc-settings.json')
       fs.writeFileSync(configFile, '{"languageserver": {"foo": {"command":"bar", "filetypes": ["vim"]}, "bar": {}}}')

--- a/src/__tests__/modules/util.test.ts
+++ b/src/__tests__/modules/util.test.ts
@@ -4,7 +4,6 @@ import cp, { spawn } from 'child_process'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { v4 as uuid } from 'uuid'
 import vm from 'vm'
 import { AnnotatedTextEdit, CancellationToken, CancellationTokenSource, ChangeAnnotation, Color, Position, Range, SymbolKind, TextDocumentEdit, TextEdit, WorkspaceEdit } from 'vscode-languageserver-protocol'
 import { ConfigurationScope } from '../../configuration/types'
@@ -349,7 +348,7 @@ describe('textedit', () => {
   it('should get all annotation ids for confirm', () => {
     let doc = { uri: 'test:///1', version: null }
     let changes: DocumentChange[] = []
-    let ids = [uuid(), uuid(), uuid()]
+    let ids = [crypto.randomUUID(), crypto.randomUUID(), crypto.randomUUID()]
     changes.push({
       textDocument: doc,
       edits: [
@@ -377,7 +376,7 @@ describe('textedit', () => {
   it('should create filtered changes', () => {
     let doc = { uri: 'test:///1', version: null }
     let changes: DocumentChange[] = []
-    let ids = [uuid(), uuid(), uuid()]
+    let ids = [crypto.randomUUID(), crypto.randomUUID(), crypto.randomUUID()]
     changes.push({
       textDocument: doc,
       edits: [
@@ -419,7 +418,7 @@ describe('textedit', () => {
   })
 
   it('should check edit is denied', () => {
-    let ids = [uuid(), uuid()]
+    let ids = [crypto.randomUUID(), crypto.randomUUID()]
     let edits = [
       AnnotatedTextEdit.insert(Position.create(0, 0), 'foo', ids[0]),
       AnnotatedTextEdit.insert(Position.create(1, 0), 'bar', ids[1]),

--- a/src/__tests__/modules/workspace.test.ts
+++ b/src/__tests__/modules/workspace.test.ts
@@ -2,7 +2,6 @@ import { Neovim } from '../../neovim'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { v4 as uuid } from 'uuid'
 import { Disposable } from 'vscode-languageserver-protocol'
 import { Location, Position, Range, TextEdit } from 'vscode-languageserver-types'
 import { URI } from 'vscode-uri'
@@ -382,7 +381,7 @@ describe('workspace utility', () => {
   })
 
   it('should not findUp from file in other directory', async () => {
-    await nvim.command(`edit ${path.join(os.tmpdir(), uuid())}`)
+    await nvim.command(`edit ${path.join(os.tmpdir(), crypto.randomUUID())}`)
     let filepath = await workspace.findUp('tsconfig.json')
     expect(filepath).toBeNull()
   })

--- a/src/__tests__/vim.test.ts
+++ b/src/__tests__/vim.test.ts
@@ -6,7 +6,6 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import util from 'util'
-import { v4 as uuid } from 'uuid'
 import { Position, Range, TextEdit, type Disposable } from 'vscode-languageserver-protocol'
 import type { CompleteResult, ExtendedCompleteItem } from '../completion/types'
 import events from '../events'
@@ -46,7 +45,7 @@ async function createTmpFile(content: string, disposables?: Disposable[]): Promi
   if (!fs.existsSync(tmpFolder)) {
     fs.mkdirSync(tmpFolder)
   }
-  let fsPath = path.join(tmpFolder, uuid())
+  let fsPath = path.join(tmpFolder, crypto.randomUUID())
   await util.promisify(fs.writeFile)(fsPath, content, 'utf8')
   if (disposables) {
     disposables.push({

--- a/src/core/watchman.ts
+++ b/src/core/watchman.ts
@@ -1,6 +1,5 @@
 'use strict'
 import type { Client } from 'fb-watchman'
-import { v1 as uuidv1 } from 'uuid'
 import { createLogger } from '../logger'
 import { OutputChannel } from '../types'
 import { minimatch, path } from '../util/node'
@@ -94,7 +93,7 @@ export default class Watchman {
       sub.relative_root = relative_path
       root = path.join(watch, relative_path)
     }
-    let uid = uuidv1()
+    let uid = crypto.randomUUID()
     let { subscribe } = await this.command(['subscribe', watch, uid, sub])
     this.subscription = subscribe
     this.appendOutput(`subscribing events in ${root}`)

--- a/src/extension/installer.ts
+++ b/src/extension/installer.ts
@@ -1,6 +1,5 @@
 'use strict'
 import { EventEmitter } from 'events'
-import { v4 as uuid } from 'uuid'
 import { createLogger } from '../logger'
 import download, { DownloadOptions } from '../model/download'
 import fetch, { FetchOptions } from '../model/fetch'
@@ -272,7 +271,7 @@ export class Installer extends EventEmitter implements IInstaller {
     installing.add(info.name)
 
     let key = info.name.replace(/\//g, '_')
-    let downloadFolder = path.join(this.root, `${key}-${uuid()}`)
+    let downloadFolder = path.join(this.root, `${key}-${crypto.randomUUID()}`)
     let url = info['dist.tarball']
     this.log(`Downloading from ${url}`)
     let etagAlgorithm = url.startsWith('https://registry.npmjs.org') ? 'md5' : undefined

--- a/src/handler/workspace.ts
+++ b/src/handler/workspace.ts
@@ -1,6 +1,5 @@
 'use strict'
 import { Neovim } from '../neovim'
-import { v4 as uuid } from 'uuid'
 import { writeHeapSnapshot } from 'v8'
 import { Location } from 'vscode-languageserver-types'
 import { URI } from 'vscode-uri'
@@ -104,7 +103,7 @@ export default class WorkspaceHandler {
     commands.register({
       id: 'workspace.writeHeapSnapshot',
       execute: async () => {
-        let filepath = path.join(os.homedir(), `${uuid()}-${process.pid}.heapsnapshot`)
+        let filepath = path.join(os.homedir(), `${crypto.randomUUID()}-${process.pid}.heapsnapshot`)
         writeHeapSnapshot(filepath)
         void window.showInformationMessage(`Create heapdump at: ${filepath}`)
         return filepath

--- a/src/language-client/client.ts
+++ b/src/language-client/client.ts
@@ -64,7 +64,6 @@ import { Delayer } from './utils/async'
 import * as c2p from './utils/codeConverter'
 import { CloseAction, CloseHandlerResult, DefaultErrorHandler, ErrorAction, ErrorHandler, ErrorHandlerResult, InitializationFailedHandler, toCloseHandlerResult } from './utils/errorHandler'
 import { ConsoleLogger, NullLogger } from './utils/logger'
-import * as UUID from './utils/uuid'
 import { $WorkspaceOptions, WorkspaceFolderMiddleware, WorkspaceFoldersFeature } from './workspaceFolders'
 import { WorkspaceProviderFeature, WorkspaceSymbolFeature, WorkspaceSymbolMiddleware } from './workspaceSymbol'
 
@@ -1131,7 +1130,7 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
     }
     this.fillInitializeParams(initParams)
     if (progressOnInitialization) {
-      const token: ProgressToken = UUID.generateUuid()
+      const token: ProgressToken = crypto.randomUUID()
       initParams.workDoneToken = token
       connection.id = this._id
       const part = new ProgressPart(connection, token)

--- a/src/language-client/codeAction.ts
+++ b/src/language-client/codeAction.ts
@@ -8,7 +8,6 @@ import { CodeActionProvider, ProviderResult } from '../provider'
 import { CodeActionRequest, CodeActionResolveRequest, ExecuteCommandRequest } from '../util/protocol'
 import { ExecuteCommandMiddleware, ExecuteCommandSignature } from './executeCommand'
 import { ensure, FeatureClient, TextDocumentLanguageFeature } from './features'
-import * as UUID from './utils/uuid'
 
 export interface ProvideCodeActionsSignature {
   (
@@ -83,7 +82,7 @@ export class CodeActionFeature extends TextDocumentLanguageFeature<boolean | Cod
     }
 
     this.register({
-      id: UUID.generateUuid(),
+      id: crypto.randomUUID(),
       registerOptions: options
     })
   }

--- a/src/language-client/codeLens.ts
+++ b/src/language-client/codeLens.ts
@@ -5,7 +5,6 @@ import languages from '../languages'
 import { CodeLensProvider, ProviderResult } from '../provider'
 import { CodeLensRefreshRequest, CodeLensRequest, CodeLensResolveRequest, Emitter } from '../util/protocol'
 import { ensure, FeatureClient, TextDocumentLanguageFeature } from './features'
-import * as UUID from './utils/uuid'
 
 export interface ProvideCodeLensesSignature {
   (this: void, document: TextDocument, token: CancellationToken): ProviderResult<CodeLens[]>
@@ -45,7 +44,7 @@ export class CodeLensFeature extends TextDocumentLanguageFeature<CodeLensOptions
     })
     const options = this.getRegistrationOptions(documentSelector, capabilities.codeLensProvider)
     if (!options) return
-    this.register({ id: UUID.generateUuid(), registerOptions: options })
+    this.register({ id: crypto.randomUUID(), registerOptions: options })
   }
 
   protected registerLanguageProvider(options: CodeLensRegistrationOptions): [Disposable, CodeLensProviderShape] {

--- a/src/language-client/completion.ts
+++ b/src/language-client/completion.ts
@@ -7,7 +7,6 @@ import { CompletionItemProvider, ProviderResult } from '../provider'
 import { CompletionRequest, CompletionResolveRequest, Disposable } from '../util/protocol'
 import workspace from '../workspace'
 import { ensure, FeatureClient, TextDocumentLanguageFeature } from './features'
-import * as UUID from './utils/uuid'
 
 const SupportedCompletionItemKinds: CompletionItemKind[] = [
   CompletionItemKind.Text,
@@ -110,7 +109,7 @@ export class CompletionItemFeature extends TextDocumentLanguageFeature<Completio
     const options = this.getRegistrationOptions(documentSelector, capabilities.completionProvider)
     if (!options) return
     this.register({
-      id: UUID.generateUuid(),
+      id: crypto.randomUUID(),
       registerOptions: options
     })
   }

--- a/src/language-client/configuration.ts
+++ b/src/language-client/configuration.ts
@@ -11,7 +11,6 @@ import {
 } from '../util/protocol'
 import workspace from '../workspace'
 import { DynamicFeature, ensure, FeatureClient, FeatureState, RegistrationData, StaticFeature } from './features'
-import * as UUID from './utils/uuid'
 
 export interface ConfigurationMiddleware {
   configuration?: ConfigurationRequest.MiddlewareSignature
@@ -139,7 +138,7 @@ export class SyncConfigurationFeature implements DynamicFeature<DidChangeConfigu
   public initialize(): void {
     let section = defaultValue(this._client.clientOptions.synchronize, {}).configurationSection
     if (section !== undefined) {
-      let id = this.configuredUID = UUID.generateUuid()
+      let id = this.configuredUID = crypto.randomUUID()
       this.register({
         id,
         registerOptions: {

--- a/src/language-client/definition.ts
+++ b/src/language-client/definition.ts
@@ -5,7 +5,6 @@ import languages from '../languages'
 import { DefinitionProvider, ProviderResult } from '../provider'
 import { DefinitionRequest } from '../util/protocol'
 import { ensure, FeatureClient, TextDocumentLanguageFeature } from './features'
-import * as UUID from './utils/uuid'
 
 export interface ProvideDefinitionSignature {
   (
@@ -48,7 +47,7 @@ export class DefinitionFeature extends TextDocumentLanguageFeature<
       return
     }
     this.register({
-      id: UUID.generateUuid(),
+      id: crypto.randomUUID(),
       registerOptions: options
     })
   }

--- a/src/language-client/diagnostic.ts
+++ b/src/language-client/diagnostic.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import type {
   CancellationToken, ClientCapabilities, Diagnostic, DiagnosticOptions, DiagnosticRegistrationOptions, DocumentDiagnosticParams, DocumentDiagnosticReport, DocumentSelector, PreviousResultId, ServerCapabilities, WorkspaceDiagnosticParams, WorkspaceDiagnosticReport, WorkspaceDiagnosticReportPartialResult
 } from 'vscode-languageserver-protocol'
@@ -480,7 +479,7 @@ export class DiagnosticRequestor extends BaseFeature<DiagnosticProviderMiddlewar
     if (this.options.workspaceDiagnostics) {
       provider.provideWorkspaceDiagnostics = (resultIds, token, resultReporter): ProviderResult<WorkspaceDiagnosticReport> => {
         const provideWorkspaceDiagnostics: ProvideWorkspaceDiagnosticSignature = (resultIds, token, resultReporter): ProviderResult<WorkspaceDiagnosticReport> => {
-          const partialResultToken = uuid()
+          const partialResultToken = crypto.randomUUID()
           const disposable = this.client.onProgress(WorkspaceDiagnosticRequest.partialResult, partialResultToken, partialResult => {
             if (partialResult == undefined) {
               resultReporter(null)

--- a/src/language-client/documentHighlight.ts
+++ b/src/language-client/documentHighlight.ts
@@ -5,7 +5,6 @@ import languages from '../languages'
 import { DocumentHighlightProvider, ProviderResult } from '../provider'
 import { DocumentHighlightRequest } from '../util/protocol'
 import { ensure, FeatureClient, TextDocumentLanguageFeature } from './features'
-import * as UUID from './utils/uuid'
 
 export interface ProvideDocumentHighlightsSignature {
   (
@@ -49,7 +48,7 @@ export class DocumentHighlightFeature extends TextDocumentLanguageFeature<
       return
     }
     this.register({
-      id: UUID.generateUuid(),
+      id: crypto.randomUUID(),
       registerOptions: options
     })
   }

--- a/src/language-client/documentLink.ts
+++ b/src/language-client/documentLink.ts
@@ -5,7 +5,6 @@ import languages from '../languages'
 import { DocumentLinkProvider, ProviderResult } from '../provider'
 import { DocumentLinkRequest, DocumentLinkResolveRequest } from '../util/protocol'
 import { ensure, FeatureClient, TextDocumentLanguageFeature } from './features'
-import * as UUID from './utils/uuid'
 
 export interface ProvideDocumentLinksSignature {
   (this: void, document: TextDocument, token: CancellationToken): ProviderResult<DocumentLink[]>
@@ -50,7 +49,7 @@ export class DocumentLinkFeature extends TextDocumentLanguageFeature<DocumentLin
       return
     }
     this.register({
-      id: UUID.generateUuid(),
+      id: crypto.randomUUID(),
       registerOptions: options
     })
   }

--- a/src/language-client/documentSymbol.ts
+++ b/src/language-client/documentSymbol.ts
@@ -6,7 +6,6 @@ import languages from '../languages'
 import { DocumentSymbolProvider, ProviderResult } from '../provider'
 import { CancellationToken, Disposable, DocumentSymbolRequest } from '../util/protocol'
 import { ensure, FeatureClient, TextDocumentLanguageFeature } from './features'
-import * as UUID from './utils/uuid'
 
 export const SupportedSymbolKinds: SymbolKind[] = [
   SymbolKind.File,
@@ -83,7 +82,7 @@ export class DocumentSymbolFeature extends TextDocumentLanguageFeature<
       return
     }
     this.register({
-      id: UUID.generateUuid(),
+      id: crypto.randomUUID(),
       registerOptions: options
     })
   }

--- a/src/language-client/executeCommand.ts
+++ b/src/language-client/executeCommand.ts
@@ -4,7 +4,6 @@ import commands from '../commands'
 import { ProviderResult } from '../provider'
 import { CancellationToken, ExecuteCommandRequest } from '../util/protocol'
 import { BaseFeature, DynamicFeature, ensure, FeatureClient, FeatureState, RegistrationData } from './features'
-import * as UUID from './utils/uuid'
 
 export interface ExecuteCommandSignature {
   (this: void, command: string, args: any[]): ProviderResult<any>
@@ -37,7 +36,7 @@ export class ExecuteCommandFeature extends BaseFeature<ExecuteCommandMiddleware>
       return
     }
     this.register({
-      id: UUID.generateUuid(),
+      id: crypto.randomUUID(),
       registerOptions: Object.assign({}, capabilities.executeCommandProvider)
     })
   }

--- a/src/language-client/features.ts
+++ b/src/language-client/features.ts
@@ -19,7 +19,6 @@ import * as Is from '../util/is'
 import { Emitter, Event, StaticRegistrationOptions, TextDocumentRegistrationOptions, WorkDoneProgressOptions } from '../util/protocol'
 import workspace from '../workspace'
 import * as c2p from './utils/codeConverter'
-import * as UUID from './utils/uuid'
 
 export class LSPCancellationError extends CancellationError {
   public readonly data: object
@@ -551,12 +550,12 @@ export abstract class TextDocumentLanguageFeature<PO, RO extends TextDocumentReg
     if (!capability) {
       return [undefined, undefined]
     } else if (TextDocumentRegistrationOptions.is(capability)) {
-      const id = StaticRegistrationOptions.hasId(capability) ? capability.id : UUID.generateUuid()
+      const id = StaticRegistrationOptions.hasId(capability) ? capability.id : crypto.randomUUID()
       const selector = defaultValue(capability.documentSelector, documentSelector)
       return [id, Object.assign({}, capability, { documentSelector: selector })]
     } else if ((Is.boolean(capability) && capability === true) || WorkDoneProgressOptions.is(capability)) {
       const options = capability === true ? { documentSelector } : Object.assign({}, capability, { documentSelector })
-      return [UUID.generateUuid(), options as RO & { documentSelector: DocumentSelector }]
+      return [crypto.randomUUID(), options as RO & { documentSelector: DocumentSelector }]
     }
     return [undefined, undefined]
   }

--- a/src/language-client/fileOperations.ts
+++ b/src/language-client/fileOperations.ts
@@ -11,7 +11,6 @@ import {
 } from '../util/protocol'
 import workspace from '../workspace'
 import { BaseFeature, DynamicFeature, ensure, FeatureClient, FeatureState, NextSignature, RegistrationData } from './features'
-import * as UUID from './utils/uuid'
 
 function access<T, K extends keyof T>(target: T, key: K): T[K] {
   return target[key]
@@ -93,7 +92,7 @@ abstract class FileOperationFeature<I, E extends EventWithFiles<I>>
     if (capability?.filters !== undefined) {
       try {
         this.register({
-          id: UUID.generateUuid(),
+          id: crypto.randomUUID(),
           registerOptions: { filters: capability.filters },
         })
       } catch (e) {

--- a/src/language-client/fileSystemWatcher.ts
+++ b/src/language-client/fileSystemWatcher.ts
@@ -11,7 +11,6 @@ import * as Is from '../util/is'
 import { DidChangeWatchedFilesNotification, FileChangeType, RelativePattern, WatchKind } from '../util/protocol'
 import workspace from '../workspace'
 import { DynamicFeature, ensure, FeatureClient, FeatureState, RegistrationData } from './features'
-import * as UUID from './utils/uuid'
 
 export interface DidChangeWatchedFileSignature {
   (this: void, event: FileEvent): void
@@ -70,7 +69,7 @@ export class FileSystemWatcherFeature implements DynamicFeature<DidChangeWatched
         !fileSystemWatcher.ignoreDeleteEvents,
         disposables)
     }
-    this._watchers.set(UUID.generateUuid(), disposables)
+    this._watchers.set(crypto.randomUUID(), disposables)
   }
 
   public register(data: RegistrationData<DidChangeWatchedFilesRegistrationOptions>): void {

--- a/src/language-client/formatting.ts
+++ b/src/language-client/formatting.ts
@@ -7,7 +7,6 @@ import {
   DocumentFormattingRequest, DocumentOnTypeFormattingRequest, DocumentRangeFormattingRequest
 } from '../util/protocol'
 import { FeatureClient, TextDocumentLanguageFeature, ensure } from './features'
-import * as UUID from './utils/uuid'
 
 export interface ProvideDocumentFormattingEditsSignature {
   (
@@ -94,7 +93,7 @@ export class DocumentFormattingFeature extends TextDocumentLanguageFeature<
       return
     }
     this.register({
-      id: UUID.generateUuid(),
+      id: crypto.randomUUID(),
       registerOptions: options
     })
   }
@@ -149,7 +148,7 @@ export class DocumentRangeFormattingFeature extends TextDocumentLanguageFeature<
       return
     }
     this.register({
-      id: UUID.generateUuid(),
+      id: crypto.randomUUID(),
       registerOptions: options
     })
   }
@@ -200,7 +199,7 @@ export class DocumentOnTypeFormattingFeature extends TextDocumentLanguageFeature
       return
     }
     this.register({
-      id: UUID.generateUuid(),
+      id: crypto.randomUUID(),
       registerOptions: options
     })
   }

--- a/src/language-client/hover.ts
+++ b/src/language-client/hover.ts
@@ -5,7 +5,6 @@ import languages from '../languages'
 import { HoverProvider, ProviderResult } from '../provider'
 import { HoverRequest } from '../util/protocol'
 import { ensure, FeatureClient, TextDocumentLanguageFeature } from './features'
-import * as UUID from './utils/uuid'
 
 export interface ProvideHoverSignature {
   (
@@ -51,7 +50,7 @@ export class HoverFeature extends TextDocumentLanguageFeature<
       return
     }
     this.register({
-      id: UUID.generateUuid(),
+      id: crypto.randomUUID(),
       registerOptions: options
     })
   }

--- a/src/language-client/inlineCompletion.ts
+++ b/src/language-client/inlineCompletion.ts
@@ -21,7 +21,6 @@ import {
   FeatureClient,
   TextDocumentLanguageFeature
 } from './features'
-import * as UUID from './utils/uuid'
 
 export interface ProvideInlineCompletionItemsSignature {
   (this: void, document: TextDocument, position: Position, context: InlineCompletionContext, token: CancellationToken): ProviderResult<InlineCompletionItem[] | InlineCompletionList>
@@ -53,7 +52,7 @@ export class InlineCompletionItemFeature extends TextDocumentLanguageFeature<boo
     }
 
     this.register({
-      id: UUID.generateUuid(),
+      id: crypto.randomUUID(),
       registerOptions: options
     })
   }

--- a/src/language-client/reference.ts
+++ b/src/language-client/reference.ts
@@ -5,7 +5,6 @@ import languages from '../languages'
 import { ProviderResult, ReferenceProvider } from '../provider'
 import { ReferencesRequest } from '../util/protocol'
 import { ensure, FeatureClient, TextDocumentLanguageFeature } from './features'
-import * as UUID from './utils/uuid'
 
 export interface ProvideReferencesSignature {
   (
@@ -51,7 +50,7 @@ export class ReferencesFeature extends TextDocumentLanguageFeature<
       return
     }
     this.register({
-      id: UUID.generateUuid(),
+      id: crypto.randomUUID(),
       registerOptions: options
     })
   }

--- a/src/language-client/rename.ts
+++ b/src/language-client/rename.ts
@@ -7,7 +7,6 @@ import { ProviderResult, RenameProvider } from '../provider'
 import * as Is from '../util/is'
 import { PrepareRenameRequest, PrepareSupportDefaultBehavior, RenameRequest } from '../util/protocol'
 import { ensure, FeatureClient, TextDocumentLanguageFeature } from './features'
-import * as UUID from './utils/uuid'
 
 interface DefaultBehavior {
   defaultBehavior: boolean
@@ -69,7 +68,7 @@ export class RenameFeature extends TextDocumentLanguageFeature<boolean | RenameO
       options.prepareProvider = false
     }
     this.register({
-      id: UUID.generateUuid(),
+      id: crypto.randomUUID(),
       registerOptions: options
     })
   }

--- a/src/language-client/signatureHelp.ts
+++ b/src/language-client/signatureHelp.ts
@@ -5,7 +5,6 @@ import languages from '../languages'
 import { ProviderResult, SignatureHelpProvider } from '../provider'
 import { SignatureHelpRequest } from '../util/protocol'
 import { ensure, FeatureClient, TextDocumentLanguageFeature } from './features'
-import * as UUID from './utils/uuid'
 
 export interface ProvideSignatureHelpSignature {
   (
@@ -54,7 +53,7 @@ export class SignatureHelpFeature extends TextDocumentLanguageFeature<SignatureH
     if (!options) return
 
     this.register({
-      id: UUID.generateUuid(),
+      id: crypto.randomUUID(),
       registerOptions: options
     })
   }

--- a/src/language-client/textDocumentContent.ts
+++ b/src/language-client/textDocumentContent.ts
@@ -5,7 +5,6 @@ import { defaultValue, disposeAll } from '../util'
 import { toArray } from '../util/array'
 import workspace from '../workspace'
 import { ensure, type DynamicFeature, type FeatureClient, type FeatureState, type RegistrationData } from './features'
-import * as UUID from './utils/uuid'
 
 export interface ProvideTextDocumentContentSignature {
   (this: void, uri: URI, token: CancellationToken): ProviderResult<string>
@@ -67,7 +66,7 @@ export class TextDocumentContentFeature implements DynamicFeature<TextDocumentCo
 
     const capability = defaultValue(defaultValue(capabilities, {}).workspace, {}).textDocumentContent
     if (capability) {
-      const id = StaticRegistrationOptions.hasId(capability) ? capability.id : UUID.generateUuid()
+      const id = StaticRegistrationOptions.hasId(capability) ? capability.id : crypto.randomUUID()
       this.register({
         id,
         registerOptions: capability

--- a/src/language-client/textSynchronization.ts
+++ b/src/language-client/textSynchronization.ts
@@ -7,7 +7,6 @@ import { defaultValue, disposeAll } from '../util'
 import { CancellationToken, DidChangeTextDocumentNotification, DidCloseTextDocumentNotification, DidOpenTextDocumentNotification, DidSaveTextDocumentNotification, Disposable, Emitter, Event, TextDocumentSyncKind, WillSaveTextDocumentNotification, WillSaveTextDocumentWaitUntilRequest } from '../util/protocol'
 import workspace from '../workspace'
 import { DynamicDocumentFeature, DynamicFeature, ensure, FeatureClient, NextSignature, NotificationSendEvent, NotifyingFeature, RegistrationData, TextDocumentEventFeature, TextDocumentSendFeature } from './features'
-import * as UUID from './utils/uuid'
 
 export interface TextDocumentSynchronizationMiddleware {
   didOpen?: NextSignature<TextDocument, Promise<void>>
@@ -92,7 +91,7 @@ export class DidOpenTextDocumentFeature extends TextDocumentEventFeature<DidOpen
     let textDocumentSyncOptions = (capabilities as ResolvedTextDocumentSyncCapabilities).resolvedTextDocumentSync
     if (documentSelector && textDocumentSyncOptions && textDocumentSyncOptions.openClose) {
       this.register({
-        id: UUID.generateUuid(),
+        id: crypto.randomUUID(),
         registerOptions: { documentSelector }
       })
     }
@@ -205,7 +204,7 @@ export class DidCloseTextDocumentFeature extends TextDocumentEventFeature<DidClo
       textDocumentSyncOptions.openClose
     ) {
       this.register({
-        id: UUID.generateUuid(),
+        id: crypto.randomUUID(),
         registerOptions: { documentSelector }
       })
     }
@@ -275,7 +274,7 @@ export class DidChangeTextDocumentFeature extends DynamicDocumentFeature<TextDoc
       textDocumentSyncOptions.change !== TextDocumentSyncKind.None
     ) {
       this.register({
-        id: UUID.generateUuid(),
+        id: crypto.randomUUID(),
         registerOptions: Object.assign(
           {},
           { documentSelector },
@@ -400,7 +399,7 @@ export class WillSaveFeature extends TextDocumentEventFeature<WillSaveTextDocume
       textDocumentSyncOptions.willSave
     ) {
       this.register({
-        id: UUID.generateUuid(),
+        id: crypto.randomUUID(),
         registerOptions: { documentSelector }
       })
     }
@@ -441,7 +440,7 @@ export class WillSaveWaitUntilFeature extends DynamicDocumentFeature<TextDocumen
       textDocumentSyncOptions.willSaveWaitUntil
     ) {
       this.register({
-        id: UUID.generateUuid(),
+        id: crypto.randomUUID(),
         registerOptions: { documentSelector }
       })
     }
@@ -524,7 +523,7 @@ export class DidSaveTextDocumentFeature extends TextDocumentEventFeature<DidSave
         ? { includeText: false }
         : { includeText: !!textDocumentSyncOptions.save.includeText }
       this.register({
-        id: UUID.generateUuid(),
+        id: crypto.randomUUID(),
         registerOptions: Object.assign({}, { documentSelector }, saveOptions)
       })
     }

--- a/src/language-client/utils/uuid.ts
+++ b/src/language-client/utils/uuid.ts
@@ -1,6 +1,0 @@
-'use strict'
-import { v4 as uuidv4 } from 'uuid'
-
-export function generateUuid(): string {
-  return uuidv4()
-}

--- a/src/language-client/workspaceFolders.ts
+++ b/src/language-client/workspaceFolders.ts
@@ -7,7 +7,6 @@ import { sameFile } from '../util/fs'
 import { DidChangeWorkspaceFoldersNotification, WorkspaceFoldersRequest } from '../util/protocol'
 import workspace from '../workspace'
 import { DynamicFeature, FeatureClient, FeatureState, NextSignature, RegistrationData } from './features'
-import * as UUID from './utils/uuid'
 
 function access<T, K extends keyof T>(target: T | undefined, key: K): T[K] | undefined {
   if (target === void 0) {
@@ -98,7 +97,7 @@ export class WorkspaceFoldersFeature implements DynamicFeature<void> {
     if (typeof value === 'string') {
       id = value
     } else if (value) {
-      id = UUID.generateUuid()
+      id = crypto.randomUUID()
     }
     if (id) {
       this.register({ id, registerOptions: undefined })

--- a/src/language-client/workspaceSymbol.ts
+++ b/src/language-client/workspaceSymbol.ts
@@ -5,7 +5,6 @@ import { ProviderResult, WorkspaceSymbolProvider } from "../provider"
 import { WorkspaceSymbolRequest, WorkspaceSymbolResolveRequest } from '../util/protocol'
 import { SupportedSymbolKinds, SupportedSymbolTags } from './documentSymbol'
 import { BaseFeature, DynamicFeature, ensure, FeatureClient, FeatureState, RegistrationData } from './features'
-import * as UUID from './utils/uuid'
 
 export interface ProvideWorkspaceSymbolsSignature {
   (this: void, query: string, token: CancellationToken): ProviderResult<SymbolInformation[]>
@@ -102,7 +101,7 @@ export class WorkspaceSymbolFeature extends WorkspaceFeature<WorkspaceSymbolRegi
       return
     }
     this.register({
-      id: UUID.generateUuid(),
+      id: crypto.randomUUID(),
       registerOptions: capabilities.workspaceSymbolProvider === true ? { workDoneProgress: false } : capabilities.workspaceSymbolProvider
     })
   }

--- a/src/model/download.ts
+++ b/src/model/download.ts
@@ -1,6 +1,5 @@
 'use strict'
 import http, { IncomingHttpHeaders, IncomingMessage } from 'http'
-import { v1 as uuidv1 } from 'uuid'
 import { createLogger } from '../logger'
 import { crypto, fs, path } from '../util/node'
 import { CancellationToken } from '../util/protocol'
@@ -127,7 +126,7 @@ export default function download(urlInput: string | URL, options: DownloadOption
           const unzip = require('unzip-stream')
           stream = res.pipe(unzip.Extract({ path: dest }))
         } else {
-          dest = path.join(dest, `${uuidv1()}${extname}`)
+          dest = path.join(dest, `${crypto.randomUUID()}${extname}`)
           stream = res.pipe(fs.createWriteStream(dest))
         }
         stream.on('finish', () => {

--- a/src/model/status.ts
+++ b/src/model/status.ts
@@ -1,6 +1,5 @@
 'use strict'
 import { Neovim } from '../neovim'
-import { v1 as uuidv1 } from 'uuid'
 import type { Disposable } from '../util/protocol'
 
 export const frames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
@@ -42,7 +41,7 @@ export default class StatusLine implements Disposable {
   }
 
   public createStatusBarItem(priority: number, isProgress = false): StatusBarItem {
-    let uid = uuidv1()
+    let uid = crypto.randomUUID()
 
     let item: StatusBarItem = {
       text: '',

--- a/src/provider/callHierarchyManager.ts
+++ b/src/provider/callHierarchyManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { CallHierarchyIncomingCall, CallHierarchyItem, CallHierarchyOutgoingCall, Position } from 'vscode-languageserver-types'
 import { CancellationToken, Disposable } from '../util/protocol'
 import { TextDocument } from 'vscode-languageserver-textdocument'
@@ -10,7 +9,7 @@ export default class CallHierarchyManager extends Manager<CallHierarchyProvider>
 
   public register(selector: DocumentSelector, provider: CallHierarchyProvider): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider
     })

--- a/src/provider/codeActionManager.ts
+++ b/src/provider/codeActionManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { CodeAction, CodeActionContext, CodeActionKind, Command, Range } from 'vscode-languageserver-types'
 import { isFalsyOrEmpty } from '../util/array'
@@ -35,7 +34,7 @@ export function checkAction(only: CodeActionKind[] | undefined, action: CodeActi
 export default class CodeActionManager extends Manager<CodeActionProvider, ProviderMeta> {
   public register(selector: DocumentSelector, provider: CodeActionProvider, clientId: string | undefined, codeActionKinds?: CodeActionKind[]): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider,
       kinds: codeActionKinds,

--- a/src/provider/codeLensManager.ts
+++ b/src/provider/codeLensManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { CancellationToken, Disposable } from '../util/protocol'
 import type { CodeLens } from 'vscode-languageserver-types'
 import { TextDocument } from 'vscode-languageserver-textdocument'
@@ -16,7 +15,7 @@ export default class CodeLensManager extends Manager<CodeLensProvider> {
 
   public register(selector: DocumentSelector, provider: CodeLensProvider): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider
     })

--- a/src/provider/declarationManager.ts
+++ b/src/provider/declarationManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { Position } from 'vscode-languageserver-types'
 import { LocationWithTarget } from '../types'
@@ -11,7 +10,7 @@ export default class DeclarationManager extends Manager<DeclarationProvider> {
 
   public register(selector: DocumentSelector, provider: DeclarationProvider): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider
     })

--- a/src/provider/definitionManager.ts
+++ b/src/provider/definitionManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { DefinitionLink, LocationLink, Position } from 'vscode-languageserver-types'
 import { LocationWithTarget } from '../types'
@@ -11,7 +10,7 @@ export default class DefinitionManager extends Manager<DefinitionProvider> {
 
   public register(selector: DocumentSelector, provider: DefinitionProvider): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider
     })

--- a/src/provider/documentColorManager.ts
+++ b/src/provider/documentColorManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { ColorInformation, ColorPresentation } from 'vscode-languageserver-types'
 import { equals } from '../util/object'
@@ -15,7 +14,7 @@ export default class DocumentColorManager extends Manager<DocumentColorProvider>
 
   public register(selector: DocumentSelector, provider: DocumentColorProvider): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider
     })

--- a/src/provider/documentHighlightManager.ts
+++ b/src/provider/documentHighlightManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { DocumentHighlight, Position } from 'vscode-languageserver-types'
 import { CancellationToken, Disposable } from '../util/protocol'
@@ -10,7 +9,7 @@ export default class DocumentHighlightManager extends Manager<DocumentHighlightP
 
   public register(selector: DocumentSelector, provider: DocumentHighlightProvider): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider
     })

--- a/src/provider/documentLinkManager.ts
+++ b/src/provider/documentLinkManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { DocumentLink, Range } from 'vscode-languageserver-types'
 import { omit } from '../util/lodash'
@@ -19,7 +18,7 @@ export default class DocumentLinkManager extends Manager<DocumentLinkProvider> {
 
   public register(selector: DocumentSelector, provider: DocumentLinkProvider): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider
     })

--- a/src/provider/documentSymbolManager.ts
+++ b/src/provider/documentSymbolManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { DocumentSymbol, SymbolInformation, SymbolTag } from 'vscode-languageserver-types'
 import { isFalsyOrEmpty, toArray } from '../util/array'
@@ -12,7 +11,7 @@ import Manager from './manager'
 export default class DocumentSymbolManager extends Manager<DocumentSymbolProvider> {
   public register(selector: DocumentSelector, provider: DocumentSymbolProvider): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider
     })

--- a/src/provider/foldingRangeManager.ts
+++ b/src/provider/foldingRangeManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { FoldingRange } from 'vscode-languageserver-types'
 import { CancellationToken, Disposable } from '../util/protocol'
@@ -10,7 +9,7 @@ export default class FoldingRangeManager extends Manager<FoldingRangeProvider>  
 
   public register(selector: DocumentSelector, provider: FoldingRangeProvider): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider
     })

--- a/src/provider/formatManager.ts
+++ b/src/provider/formatManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { FormattingOptions, TextEdit } from 'vscode-languageserver-types'
 import { CancellationToken, Disposable } from '../util/protocol'
@@ -11,7 +10,7 @@ export default class FormatManager extends Manager<DocumentFormattingEditProvide
 
   public register(selector: DocumentSelector, provider: DocumentFormattingEditProvider, priority: number): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       priority,
       provider

--- a/src/provider/formatRangeManager.ts
+++ b/src/provider/formatRangeManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { FormattingOptions, Range, TextEdit } from 'vscode-languageserver-types'
 import { CancellationToken, Disposable } from '../util/protocol'
@@ -12,7 +11,7 @@ export default class FormatRangeManager extends Manager<DocumentRangeFormattingE
     provider: DocumentRangeFormattingEditProvider,
     priority: number): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider,
       priority

--- a/src/provider/hoverManager.ts
+++ b/src/provider/hoverManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { Hover, Position } from 'vscode-languageserver-types'
 import { isHover } from '../util/is'
@@ -12,7 +11,7 @@ export default class HoverManager extends Manager<HoverProvider> {
 
   public register(selector: DocumentSelector, provider: HoverProvider): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider
     })

--- a/src/provider/implementationManager.ts
+++ b/src/provider/implementationManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { Position } from 'vscode-languageserver-types'
 import { LocationWithTarget } from '../types'
@@ -11,7 +10,7 @@ export default class ImplementationManager extends Manager<ImplementationProvide
 
   public register(selector: DocumentSelector, provider: ImplementationProvider): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider
     })

--- a/src/provider/inlayHintManager.ts
+++ b/src/provider/inlayHintManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { InlayHint, Position, Range } from 'vscode-languageserver-types'
 import { createLogger } from '../logger'
@@ -18,7 +17,7 @@ export default class InlayHintManger extends Manager<InlayHintsProvider> {
 
   public register(selector: DocumentSelector, provider: InlayHintsProvider): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider
     })

--- a/src/provider/inlineCompletionItemManager.ts
+++ b/src/provider/inlineCompletionItemManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { InlineCompletionContext, InlineCompletionItem, Position } from 'vscode-languageserver-types'
 import { toArray } from '../util/array'
@@ -16,7 +15,7 @@ export interface ExtendedInlineContext extends InlineCompletionContext {
 export default class InlineCompletionItemManager extends Manager<InlineCompletionItemProvider> {
   public register(selector: DocumentSelector, provider: InlineCompletionItemProvider): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider
     })

--- a/src/provider/inlineValueManager.ts
+++ b/src/provider/inlineValueManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { InlineValue, InlineValueContext, Range } from 'vscode-languageserver-types'
 import { equals } from '../util/object'
@@ -11,7 +10,7 @@ export default class InlineValueManager extends Manager<InlineValuesProvider> {
 
   public register(selector: DocumentSelector, provider: InlineValuesProvider): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider
     })

--- a/src/provider/linkedEditingRangeManager.ts
+++ b/src/provider/linkedEditingRangeManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import type { CancellationToken, Disposable, DocumentSelector, LinkedEditingRanges } from 'vscode-languageserver-protocol'
 import type { TextDocument } from 'vscode-languageserver-textdocument'
 import type { Position } from 'vscode-languageserver-types'
@@ -11,7 +10,7 @@ const logger = createLogger('linkedEditingManager')
 export default class LinkedEditingRangeManager extends Manager<LinkedEditingRangeProvider> {
   public register(selector: DocumentSelector, provider: LinkedEditingRangeProvider): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider
     })

--- a/src/provider/onTypeFormatManager.ts
+++ b/src/provider/onTypeFormatManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { Position, TextEdit } from 'vscode-languageserver-types'
 import { CancellationToken, Disposable } from '../util/protocol'
@@ -15,7 +14,7 @@ export default class OnTypeFormatManager extends Manager<OnTypeFormattingEditPro
 
   public register(selector: DocumentSelector, provider: OnTypeFormattingEditProvider, triggerCharacters: string[] | undefined): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider,
       triggerCharacters: triggerCharacters ?? []

--- a/src/provider/referenceManager.ts
+++ b/src/provider/referenceManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import type { CancellationToken, Disposable, DocumentSelector, Position, ReferenceContext } from 'vscode-languageserver-protocol'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { LocationWithTarget } from '../types'
@@ -10,7 +9,7 @@ export default class ReferenceManager extends Manager<ReferenceProvider>  {
 
   public register(selector: DocumentSelector, provider: ReferenceProvider): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider
     })

--- a/src/provider/renameManager.ts
+++ b/src/provider/renameManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { Position, Range, WorkspaceEdit } from 'vscode-languageserver-types'
 import type { CancellationToken, Disposable } from '../util/protocol'
@@ -10,7 +9,7 @@ export default class RenameManager extends Manager<RenameProvider> {
 
   public register(selector: DocumentSelector, provider: RenameProvider): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider
     })

--- a/src/provider/selectionRangeManager.ts
+++ b/src/provider/selectionRangeManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { Position, SelectionRange } from 'vscode-languageserver-types'
 import { equals } from '../util/object'
@@ -12,7 +11,7 @@ export default class SelectionRangeManager extends Manager<SelectionRangeProvide
 
   public register(selector: DocumentSelector, provider: SelectionRangeProvider): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider
     })

--- a/src/provider/semanticTokensManager.ts
+++ b/src/provider/semanticTokensManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { SemanticTokens, SemanticTokensDelta, SemanticTokensLegend } from 'vscode-languageserver-types'
 import type { CancellationToken, Disposable } from '../util/protocol'
@@ -14,7 +13,7 @@ export default class SemanticTokensManager extends Manager<DocumentSemanticToken
 
   public register(selector: DocumentSelector, provider: DocumentSemanticTokensProvider, legend: SemanticTokensLegend): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider,
       legend,

--- a/src/provider/semanticTokensRangeManager.ts
+++ b/src/provider/semanticTokensRangeManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { Range, SemanticTokens, SemanticTokensLegend } from 'vscode-languageserver-types'
 import type { CancellationToken, Disposable } from '../util/protocol'
@@ -13,7 +12,7 @@ interface ProviderMeta {
 export default class SemanticTokensRangeManager extends Manager<DocumentRangeSemanticTokensProvider, ProviderMeta> {
   public register(selector: DocumentSelector, provider: DocumentRangeSemanticTokensProvider, legend: SemanticTokensLegend): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       legend,
       provider

--- a/src/provider/signatureManager.ts
+++ b/src/provider/signatureManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import type { SignatureHelpContext } from 'vscode-languageserver-protocol'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { Position, SignatureHelp } from 'vscode-languageserver-types'
@@ -18,7 +17,7 @@ export default class SignatureManager extends Manager<SignatureHelpProvider, Pro
     triggerCharacters = isFalsyOrEmpty(triggerCharacters) ? [] : triggerCharacters
     let characters = triggerCharacters.reduce((p, c) => p.concat(c.length == 1 ? [c] : c.split(/\s*/g)), [] as string[])
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider,
       triggerCharacters: characters

--- a/src/provider/typeDefinitionManager.ts
+++ b/src/provider/typeDefinitionManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { Position } from 'vscode-languageserver-types'
 import { LocationWithTarget } from '../types'
@@ -11,7 +10,7 @@ export default class TypeDefinitionManager extends Manager<TypeDefinitionProvide
 
   public register(selector: DocumentSelector, provider: TypeDefinitionProvider): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider
     })

--- a/src/provider/typeHierarchyManager.ts
+++ b/src/provider/typeHierarchyManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { Position, TypeHierarchyItem } from 'vscode-languageserver-types'
 import { omit } from '../util/lodash'
@@ -17,7 +16,7 @@ export default class TypeHierarchyManager extends Manager<TypeHierarchyProvider>
 
   public register(selector: DocumentSelector, provider: TypeHierarchyProvider): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector,
       provider
     })

--- a/src/provider/workspaceSymbolsManager.ts
+++ b/src/provider/workspaceSymbolsManager.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { WorkspaceSymbol } from 'vscode-languageserver-types'
 import type { CancellationToken, Disposable } from '../util/protocol'
 import { WorkspaceSymbolProvider } from './index'
@@ -12,7 +11,7 @@ interface WorkspaceSymbolWithSource extends WorkspaceSymbol {
 export default class WorkspaceSymbolManager extends Manager<WorkspaceSymbolProvider> {
   public register(provider: WorkspaceSymbolProvider): Disposable {
     return this.addProvider({
-      id: uuid(),
+      id: crypto.randomUUID(),
       selector: [{ language: '*' }],
       provider
     })

--- a/src/snippets/variableResolve.ts
+++ b/src/snippets/variableResolve.ts
@@ -1,6 +1,5 @@
 'use strict'
 import { Neovim } from '../neovim'
-import { v4 as uuid } from 'uuid'
 import { URI } from 'vscode-uri'
 import WorkspaceFolderController from '../core/workspaceFolder'
 import { path } from '../util/node'
@@ -120,7 +119,7 @@ export class SnippetVariableResolver implements VariableResolver {
       return Math.random().toString(16).slice(-6)
     }
     if (name === 'UUID') {
-      return uuid()
+      return crypto.randomUUID()
     }
     if (['RELATIVE_FILEPATH', 'WORKSPACE_NAME', 'WORKSPACE_FOLDER'].includes(name)) {
       let filepath = await nvim.call('coc#util#get_fullpath') as string

--- a/src/tree/BasicDataProvider.ts
+++ b/src/tree/BasicDataProvider.ts
@@ -1,5 +1,4 @@
 'use strict'
-import { v4 as uuid } from 'uuid'
 import { CancellationToken, Disposable, Emitter, Event } from '../util/protocol'
 import { MarkupContent } from 'vscode-languageserver-types'
 import commandsManager from '../commands'
@@ -68,7 +67,7 @@ export default class BasicDataProvider<T extends TreeNode> implements TreeDataPr
   public resolveActions: (item: TreeItem, element: T) => ProviderResult<TreeItemAction<T>[]>
   // data is shared with TreeView
   constructor(private opts: ProviderOptions<T>) {
-    this.invokeCommand = `_invoke_${uuid()}`
+    this.invokeCommand = `_invoke_${crypto.randomUUID()}`
     this.disposables.push(commandsManager.registerCommand(this.invokeCommand, async (node: T) => {
       await opts.handleClick(node)
     }, null, true))


### PR DESCRIPTION
## Why

The `uuid` package is an extra dependency for something Node now provides natively. Since coc.nvim targets Node >= 20.19.0, the built-in global `crypto.randomUUID()` covers every use case in the codebase, so we can drop the dependency entirely.

## What changed

- Removed the `uuid` dependency from `package.json` (and the lockfile).
- Replaced all `v4 as uuid` usages with `crypto.randomUUID()` across providers, handlers, tree, snippets, installer, and tests.
- Replaced the three `v1 as uuidv1` usages (`status.ts`, `watchman.ts`, `download.ts`) with `crypto.randomUUID()`. These sites only need a unique string and do not rely on v1's time-ordering, so v4 is equivalent for them.
- Inlined the `language-client` wrapper: every `UUID.generateUuid()` call now uses `crypto.randomUUID()` directly, and `src/language-client/utils/uuid.ts` is removed.

All call sites use the Node global `crypto`, so no import is needed (per discussion, we intentionally keep the global form rather than importing from `util/node`).

## Notes for reviewers

- The only behavioral change is v1 -> v4 in the three spots above; none of them depend on time-ordered IDs.
- `crypto.randomUUID()` always produces a v4 (random) UUID, which matches what the vast majority of call sites already used.

## Verification

- `npm run lint:typecheck` (tsc) passes
- `npm run lint` (eslint) passes
- `npm run build` (rolldown) succeeds