### PR TITLE
Replace strip-ansi with util.stripVTControlCharacters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "marked": "^10.0.0",
         "minimatch": "^10.2.5",
         "semver": "^7.8.1",
-        "strip-ansi": "^7.2.0",
         "tar": "^7.5.13",
         "tslib": "^2.8.1",
         "unidecode": "^1.1.0",
@@ -3010,33 +3009,6 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/strip-ansi/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "marked": "^10.0.0",
     "minimatch": "^10.2.5",
     "semver": "^7.8.1",
-    "strip-ansi": "^7.2.0",
     "tar": "^7.5.13",
     "tslib": "^2.8.1",
     "unidecode": "^1.1.0",

--- a/src/util/node.ts
+++ b/src/util/node.ts
@@ -11,9 +11,8 @@ import type OS from 'os'
 import type PATH from 'path'
 import type READLINE from 'readline'
 import type SEMVER from 'semver'
-import type STRIPANSI from 'strip-ansi'
 import type UNIDECODE from 'unidecode'
-import { inspect, promisify } from 'util'
+import { inspect, promisify, stripVTControlCharacters } from 'util'
 import type VM from 'vm'
 import type WHICH from 'which'
 
@@ -22,7 +21,7 @@ export const path = require('path') as typeof PATH
 export const os = require('os') as typeof OS
 export const crypto = require('crypto') as typeof CRYPTO
 export const styles = require('ansi-styles').default as typeof STYLES
-export const stripAnsi = require('strip-ansi').default as typeof STRIPANSI
+export const stripAnsi = stripVTControlCharacters
 export const debounce = require('debounce').default as typeof DEBOUNCE
 export const readline = require('readline') as typeof READLINE
 export const child_process = require('child_process') as typeof CHILD_PROCESS


### PR DESCRIPTION
## Why

`strip-ansi` is an external dependency whose job is now covered by Node's built-in `util.stripVTControlCharacters` (available since Node 16.11, and this project already requires Node >= 20.19). Dropping it removes `strip-ansi` plus its bundled `ansi-regex` from the dependency tree and the build output.

## Approach

`stripAnsi` in `src/util/node.ts` is re-pointed to `util.stripVTControlCharacters` and kept under the same exported name, so the four call sites (`markdown`, `list/manager`, `model/resolver`, `handler/workspace`) need no changes. The dependency is removed from `package.json` and the lockfile.

The two functions are behaviorally equivalent for all common ANSI sequences: SGR colors (16/256/truecolor in semicolon form), bold, cursor moves, line/screen clears, OSC hyperlinks/titles (BEL and ST terminated), and the 8-bit `\u009B` CSI introducer. Verified across ~190 structured cases with zero diffs.

## Note for reviewers

There is one edge difference: colon-separated SGR sub-parameters (ISO 8613-6 / ITU T.416, e.g. `\u001b[38:5:200m` or `\u001b[4:3m`). `strip-ansi@7` strips these; Node's built-in regex (all current versions, 20 through 26) leaves a small residue like `:5:200m`. This colon form is rarely emitted by the tools coc.nvim ingests, and the affected call sites (list labels, content display) degrade gracefully, so the trade-off is acceptable.

`npm run lint:typecheck`, `npm run lint`, and the rolldown build all pass.