### PR TITLE
fix(pum): position menu on concealed lines

### DIFF
--- a/autoload/coc/pum.vim
+++ b/autoload/coc/pum.vim
@@ -369,14 +369,13 @@ function! coc#pum#create(lines, opt, config) abort
   if empty(config)
     return
   endif
-  let s:reversed = get(a:config, 'reverse', 0) && config['row'] < 0
+  let s:reversed = get(a:config, 'reverse', 0) && config['above']
   let s:virtual_text = get(a:opt, 'virtualText', v:false)
   let s:pum_size = len(a:lines)
   let s:pum_index = a:opt['index']
   let lnum = s:index_to_lnum(s:pum_index)
   call extend(config, {
         \ 'lines': s:reversed ? reverse(copy(a:lines)) : a:lines,
-        \ 'relative': 'cursor',
         \ 'nopad': 1,
         \ 'cursorline': 1,
         \ 'index': lnum - 1,
@@ -399,7 +398,7 @@ function! coc#pum#create(lines, opt, config) abort
   let s:pum_winid = result[0]
   let s:pum_bufnr = result[1]
   let s:start_col = a:opt['startcol']
-  call setwinvar(s:pum_winid, 'above', config['row'] < 0)
+  call setwinvar(s:pum_winid, 'above', config['above'])
   let firstline = s:get_firstline(lnum, s:pum_size, config['height'])
   if s:is_vim
     call popup_setoptions(s:pum_winid, { 'firstline': firstline })
@@ -462,6 +461,29 @@ function! s:index_to_lnum(index) abort
   return max([1, a:index + 1])
 endfunction
 
+function! s:displaywidth(text, col) abort
+  if !s:is_vim || &conceallevel == 0
+    return strdisplaywidth(a:text, a:col)
+  endif
+  let width = 0
+  let byte = a:col
+  let concealed = 0
+  for ch in split(a:text, '\zs')
+    let info = synconcealed(line('.'), byte + 1)
+    if info[0]
+      if !concealed
+        let width += empty(info[1]) ? (&conceallevel == 1 ? 1 : 0) : strdisplaywidth(info[1])
+      endif
+      let concealed = 1
+    else
+      let width += strdisplaywidth(ch, a:col + width)
+      let concealed = 0
+    endif
+    let byte += strlen(ch)
+  endfor
+  return width
+endfunction
+
 function! s:get_pum_dimension(lines, col, config) abort
   let linecount = len(a:lines)
   let [lineIdx, colIdx] = coc#cursor#screen_pos()
@@ -486,10 +508,20 @@ function! s:get_pum_dimension(lines, col, config) abort
   if height <= 0
     return v:null
   endif
-  " should use strdiplaywidth here
   let text = strpart(getline('.'), a:col, col('.') - 1 - a:col)
-  let col = - strdisplaywidth(text, a:col) - 1
-  let row = showTop ? - height : 1
+  let textwidth = s:displaywidth(text, a:col)
+  let col = - textwidth - 1
+  if s:is_vim
+    let info = getwininfo(win_getid())[0]
+    let textleft = info['wincol'] - 1 + info['textoff']
+    let startcol = colIdx - textleft - textwidth
+    " Wrapped input can start on an earlier screen row; keep nowrap clamped.
+    let textwidth_avail = info['width'] - info['textoff']
+    if &wrap && startcol < 0 && textwidth_avail > 0
+      let startcol = (startcol % textwidth_avail + textwidth_avail) % textwidth_avail
+    endif
+    let col = textleft + startcol - 1 - colIdx
+  endif
   let delta = colIdx + col
   if width > pumwidth && delta + width > columns
     let width = max([columns - delta, pumwidth])
@@ -499,9 +531,22 @@ function! s:get_pum_dimension(lines, col, config) abort
   elseif delta + width > columns
     let col = max([-colIdx, col - (delta + width - columns)])
   endif
+  " Vim's popup cursor anchor ignores concealed text, so use editor coordinates.
+  if s:is_vim
+    return {
+          \ 'row': showTop ? lineIdx - height - bh : lineIdx + 1,
+          \ 'col': colIdx + col,
+          \ 'relative': 'editor',
+          \ 'above': showTop,
+          \ 'width': width,
+          \ 'height': height
+          \ }
+  endif
   return {
-        \ 'row': row,
+        \ 'row': showTop ? - height : 1,
         \ 'col': col,
+        \ 'relative': 'cursor',
+        \ 'above': showTop,
         \ 'width': width,
         \ 'height': height
         \ }

--- a/src/__tests__/completion/basic.test.ts
+++ b/src/__tests__/completion/basic.test.ts
@@ -1601,4 +1601,35 @@ describe('completion', () => {
       }, false)
     }, 10000)
   })
+
+  describe('pum position', () => {
+    it('should place popup menu after concealed text on current line', async () => {
+      // Regression for #5582: concealed text before the input shifts the visible
+      // screen column. The pum must align with the conceal-aware screen position,
+      // not the byte/virtual column.
+      await helper.edit()
+      await nvim.command('syntax match CocConceal /conceal/ conceal')
+      await nvim.command('setl conceallevel=2 concealcursor=i')
+      await nvim.setLine('conceal ')
+      await nvim.input('A')
+      let name = await create(['conceal', 'conclude'], false)
+      await nvim.input('conc')
+      await helper.visible('conclude', name)
+      let win: any
+      await helper.waitValue(async () => {
+        win = await helper.getFloat('pum')
+        return win != null
+      }, true)
+      let pos = await nvim.call('nvim_win_get_position', [win.id]) as [number, number]
+      let wincol = await nvim.call('wincol') as number
+      let virtcol = await nvim.call('virtcol', ['.']) as number
+      // "conceal" is hidden, so the cursor screen column is far smaller than the
+      // virtual column; the pum must follow the conceal-aware column.
+      expect(wincol).toBeLessThan(virtcol)
+      // Aligned just left of the conceal-aware cursor column, well away from the
+      // virtual position that would place it after the hidden "conceal ".
+      expect(pos[1]).toBeLessThan(wincol)
+      expect(pos[1]).toBeLessThan(virtcol - byteLength('conc'))
+    })
+  })
 })

--- a/src/__tests__/vim.test.ts
+++ b/src/__tests__/vim.test.ts
@@ -105,6 +105,169 @@ describe('vim api', () => {
     await nvim.command('silent! %bwipeout!')
   })
 
+  it('should place popup menu after concealed text on current line', async () => {
+    // Regression for #5582: Vim's popup 'cursor' column anchor ignores concealed
+    // text, so the menu must be positioned with the conceal-aware screen column.
+    const sources = require('../completion/sources').default
+    let name = crypto.randomUUID()
+    let disposable = sources.createSource({
+      name,
+      doComplete: (_opt): Promise<CompleteResult<ExtendedCompleteItem>> => Promise.resolve({
+        items: [{ word: 'conceal' }, { word: 'conclude' }]
+      })
+    })
+    await nvim.command('syntax match CocConceal /conceal/ conceal')
+    await nvim.command('setl conceallevel=2 concealcursor=i')
+    await nvim.call('setline', [1, 'conceal '])
+    await nvim.input('A')
+    await nvim.input('conc')
+    nvim.call('coc#start', { source: name }, true)
+    try {
+      await helper.waitPopup()
+      let id = 0
+      await helper.waitValue(async () => {
+        id = await nvim.call('coc#pum#winid', []) as number
+        return id > 0
+      }, true)
+      let pos = await nvim.call('popup_getpos', [id]) as { col: number }
+      let wincol = await nvim.call('wincol') as number
+      let virtcol = await nvim.call('virtcol', ['.']) as number
+      // "conceal" is hidden, so the conceal-aware cursor column is far smaller than
+      // the virtual column; the menu must follow the conceal-aware column and not
+      // land after the hidden text.
+      expect(wincol).toBeLessThan(virtcol)
+      expect(pos.col).toBeLessThanOrEqual(wincol)
+    } finally {
+      await nvim.call('coc#pum#close', ['cancel'])
+      await nvim.input('<esc>')
+      await helper.waitFor('mode', [], 'n')
+      disposable.dispose()
+      await nvim.command('silent! %bwipeout!')
+    }
+  })
+
+  it('should place popup menu by word start when input wraps on concealed line', async () => {
+    // Regression for #5582 (wrap case): with 'wrap', the typed input can span
+    // multiple display rows. A flat column subtraction underflows below 0 and the
+    // menu was clamped to the left screen edge, while the word visibly starts near
+    // the right edge on an upper row. The menu must anchor under the word start.
+    const sources = require('../completion/sources').default
+    let name = crypto.randomUUID()
+    let disposable = sources.createSource({
+      name,
+      doComplete: (_opt): Promise<CompleteResult<ExtendedCompleteItem>> => Promise.resolve({
+        items: [{ word: 'conceal' }, { word: 'conclude' }]
+      })
+    })
+    let columns = await nvim.eval('&columns') as number
+    await nvim.command('set columns=40')
+    await nvim.command('setl wrap')
+    await nvim.command('syntax match CocConceal /conceal/ conceal')
+    await nvim.command('setl conceallevel=2 concealcursor=i')
+    await nvim.call('setline', [1, Array(151).join('.')])
+    await nvim.input('Iconceal')
+    await nvim.input('<esc>')
+    await nvim.input('Aconcea')
+    nvim.call('coc#start', { source: name }, true)
+    try {
+      await helper.waitPopup()
+      let id = 0
+      await helper.waitValue(async () => {
+        id = await nvim.call('coc#pum#winid', []) as number
+        return id > 0
+      }, true)
+      let pos = await nvim.call('popup_getpos', [id]) as { col: number }
+      // The word start is on the right half of the screen on an upper wrap row,
+      // so the menu must be anchored there, not clamped to the left edge (col 1).
+      expect(pos.col).toBeGreaterThan(20)
+    } finally {
+      await nvim.call('coc#pum#close', ['cancel'])
+      await nvim.input('<esc>')
+      await helper.waitFor('mode', [], 'n')
+      await nvim.command(`set columns=${columns}`)
+      disposable.dispose()
+      await nvim.command('silent! %bwipeout!')
+    }
+  })
+
+  it('should keep popup menu at word start when typed input becomes concealed', async () => {
+    const sources = require('../completion/sources').default
+    let name = crypto.randomUUID()
+    let disposable = sources.createSource({
+      name,
+      doComplete: (_opt): Promise<CompleteResult<ExtendedCompleteItem>> => Promise.resolve({
+        items: [{ word: 'concealer' }, { word: 'concealment' }]
+      })
+    })
+    let columns = await nvim.eval('&columns') as number
+    await nvim.command('set columns=80')
+    await nvim.command('setl wrap')
+    await nvim.command('syntax match CocConceal /conceal/ conceal')
+    await nvim.command('setl conceallevel=2 concealcursor=i')
+    await nvim.input('150a.')
+    await nvim.input('<esc>')
+    await helper.waitFor('mode', [], 'n')
+    await nvim.input('A')
+    await nvim.input('concea')
+    nvim.call('coc#start', { source: name }, true)
+    try {
+      await helper.waitPopup()
+      let id = 0
+      await helper.waitValue(async () => {
+        id = await nvim.call('coc#pum#winid', []) as number
+        return id > 0
+      }, true)
+      let before = await nvim.call('popup_getpos', [id]) as { col: number }
+      await nvim.input('l')
+      await helper.waitFor('getline', ['.'], '.'.repeat(150) + 'conceal')
+      let after = await nvim.call('popup_getpos', [id]) as { col: number }
+      expect(after.col).toBe(before.col)
+    } finally {
+      await nvim.call('coc#pum#close', ['cancel'])
+      await nvim.input('<esc>')
+      await helper.waitFor('mode', [], 'n')
+      await nvim.command(`set columns=${columns}`)
+      disposable.dispose()
+      await nvim.command('silent! %bwipeout!')
+    }
+  })
+
+  it('should keep popup menu at word start after another concealed word', async () => {
+    const sources = require('../completion/sources').default
+    let name = crypto.randomUUID()
+    let disposable = sources.createSource({
+      name,
+      doComplete: (_opt): Promise<CompleteResult<ExtendedCompleteItem>> => Promise.resolve({
+        items: [{ word: 'concealer' }, { word: 'concealment' }]
+      })
+    })
+    await nvim.command('syntax match CocConceal /conceal/ conceal')
+    await nvim.command('setl conceallevel=2 concealcursor=i')
+    await nvim.input('Iconceal concea')
+    nvim.call('coc#start', { source: name }, true)
+    try {
+      await helper.waitPopup()
+      let id = 0
+      await helper.waitValue(async () => {
+        id = await nvim.call('coc#pum#winid', []) as number
+        return id > 0
+      }, true)
+      let before = await nvim.call('popup_getpos', [id]) as { col: number }
+      await nvim.input('l')
+      await helper.waitFor('getline', ['.'], 'conceal conceal')
+      let after = await nvim.call('popup_getpos', [id]) as { col: number }
+      expect(after.col).toBe(before.col)
+      let virtcol = await nvim.call('virtcol', ['.']) as number
+      expect(after.col).toBeLessThan(virtcol - 'conceal'.length)
+    } finally {
+      await nvim.call('coc#pum#close', ['cancel'])
+      await nvim.input('<esc>')
+      await helper.waitFor('mode', [], 'n')
+      disposable.dispose()
+      await nvim.command('silent! %bwipeout!')
+    }
+  })
+
   it('should echo message by callTimer', async () => {
     const ui = require('../core/ui')
     ui.echoMessages(nvim, 'message', 'more', 'more')


### PR DESCRIPTION
Use editor-relative coordinates for Vim popups so concealed text does not shift the completion menu. Keep wrapped input anchored to the visible word start and add regression coverage for Vim and Neovim.

Closes #5582

Fixed  by Codex