### PR TITLE
fix(completion): retry vim source after input changes

### DIFF
--- a/src/__tests__/completion/basic.test.ts
+++ b/src/__tests__/completion/basic.test.ts
@@ -647,6 +647,77 @@ describe('completion', () => {
       clearTimeout(timer)
     }, 10000)
 
+    it('should close pum after pending retry is cancelled by results', async () => {
+      helper.updateConfiguration('suggest.autoTrigger', 'trigger')
+      let resolveInitial: (result: CompleteResult<ExtendedCompleteItem>) => void
+      let resolveIncomplete: (result: CompleteResult<ExtendedCompleteItem>) => void
+      let startedResolve: () => void
+      let started = new Promise<void>(resolve => {
+        startedResolve = resolve
+      })
+      let incompleteStartedResolve: () => void
+      let incompleteStarted = new Promise<void>(resolve => {
+        incompleteStartedResolve = resolve
+      })
+      let name = crypto.randomUUID()
+      disposables.push(sources.createSource({
+        name,
+        doComplete: (opt: CompleteOption) => {
+          if (opt.triggerForInComplete) {
+            return new Promise<CompleteResult<ExtendedCompleteItem>>(resolve => {
+              resolveIncomplete = resolve
+              incompleteStartedResolve()
+            })
+          }
+          return new Promise<CompleteResult<ExtendedCompleteItem>>(resolve => {
+            resolveInitial = resolve
+            startedResolve()
+          })
+        }
+      }))
+      await nvim.input('if')
+      nvim.call('coc#start', { source: name }, true)
+      await started
+      let textChanged = events.race(['TextChangedI'])
+      let input = nvim.input('o')
+      await textChanged
+      resolveInitial({ isIncomplete: true, items: [{ word: 'foo' }] })
+      await input
+      await incompleteStarted
+      await helper.waitPopup()
+
+      resolveIncomplete({ items: [] })
+      await helper.waitValue(pumvisible, false)
+    })
+
+    it('should clear pending retry before trigger returns early', async () => {
+      helper.updateConfiguration('suggest.autoTrigger', 'trigger')
+      let resolveComplete: (result: CompleteResult<ExtendedCompleteItem>) => void
+      let startedResolve: () => void
+      let started = new Promise<void>(resolve => {
+        startedResolve = resolve
+      })
+      let name = crypto.randomUUID()
+      disposables.push(sources.createSource({
+        name,
+        doComplete: () => new Promise<CompleteResult<ExtendedCompleteItem>>(resolve => {
+          resolveComplete = resolve
+          startedResolve()
+        })
+      }))
+      let shouldTrigger = vi.spyOn(completion, 'shouldTrigger')
+      disposables.push(Disposable.create(() => shouldTrigger.mockRestore()))
+      await nvim.input('i')
+      nvim.call('coc#start', { source: name }, true)
+      await started
+
+      await nvim.input('f')
+      await helper.waitValue(() => shouldTrigger.mock.calls.length > 0, true)
+      resolveComplete({ items: [] })
+
+      await helper.waitValue(() => completion.isActivated, false)
+    })
+
     it('should stop if no filtered items', async () => {
       await create(['foo', 'bar'], true)
       expect(completion.isActivated).toBe(true)

--- a/src/__tests__/completion/sources.test.ts
+++ b/src/__tests__/completion/sources.test.ts
@@ -224,6 +224,29 @@ endfunction `
     await Promise.resolve(ext.deactivate())
   })
 
+  it('should retry vim source after input becomes eligible', async () => {
+    let content = `
+function! coc#source#issue5539#init() abort
+  return {'filetypes': ['mediawiki']}
+endfunction
+function! coc#source#issue5539#should_complete(opt) abort
+  return strpart(a:opt.line, 0, a:opt.colnr - 1) =~# '\\[\\[\\k\\{2,}$'
+endfunction
+function! coc#source#issue5539#complete(opt, cb) abort
+  call a:cb(['Microsoft Windows'])
+endfunction `
+    let filepath = createSourceFile('issue5539', content)
+    await sources.createVimSourceExtension(filepath)
+    await nvim.command('setfiletype mediawiki')
+    await helper.wait(30)
+
+    await nvim.input('i')
+    for (let character of '[[Mi') await nvim.input(character)
+    await helper.waitPopup()
+
+    expect(helper.completion.activeItems.some(item => item.word == 'Microsoft Windows')).toBe(true)
+  })
+
   it('should not run by check complete', async () => {
     let opt = await nvim.call('coc#util#get_complete_option') as CompleteOption
     let source = new VimSource({

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -47,6 +47,11 @@ export class Completion implements Disposable {
     return workspace.nvim
   }
 
+  private clearTriggerTimer(): void {
+    clearTimeout(this.triggerTimer)
+    this.triggerTimer = null
+  }
+
   public init(): void {
     this.loadConfiguration()
     workspace.onDidChangeConfiguration(this.loadConfiguration, this, this.disposables)
@@ -68,7 +73,7 @@ export class Completion implements Disposable {
     }, null, this.disposables)
     events.on('CursorMovedI', this._debounced, this, this.disposables)
     events.on('CursorMovedI', () => {
-      clearTimeout(this.triggerTimer)
+      this.clearTriggerTimer()
     }, null, this.disposables)
     events.on('InsertEnter', this.onInsertEnter, this, this.disposables)
     events.on('TextChangedI', this.onTextChangedI, this, this.disposables)
@@ -189,7 +194,7 @@ export class Completion implements Disposable {
   }
 
   public async startCompletion(opt?: { source?: string, col?: number }): Promise<void> {
-    clearTimeout(this.triggerTimer)
+    this.clearTriggerTimer()
     let sourceList: ISource[]
     if (Is.string(opt.source)) {
       sourceList = toArray(sources.getSource(opt.source))
@@ -218,11 +223,12 @@ export class Completion implements Disposable {
     events.completing = true
     void events.fire('CompleteStart', [option])
     complete.onDidRefresh(async () => {
-      clearTimeout(this.triggerTimer)
       if (complete.isEmpty) {
-        this.cancelAndClose()
+        // Keep the pending retry when input changed while sources were completing.
+        if (this.triggerTimer == null) this.cancelAndClose()
         return
       }
+      this.clearTriggerTimer()
       await this.filterResults()
     })
     let shouldStop = await complete.doComplete()
@@ -271,7 +277,7 @@ export class Completion implements Disposable {
       }
     }
     if (info.pre === this.pretext) return
-    clearTimeout(this.triggerTimer)
+    this.clearTriggerTimer()
     let pretext = this.pretext = info.pre
     if (!info.insertChar) {
       if (this.complete) await this.filterResults()
@@ -315,6 +321,7 @@ export class Completion implements Disposable {
     if (this.complete.isEmpty) {
       // triggering without results
       this.triggerTimer = setTimeout(async () => {
+        this.triggerTimer = null
         await this.triggerCompletion(doc, info)
       }, TRIGGER_TIMEOUT)
       return
@@ -379,7 +386,7 @@ export class Completion implements Disposable {
   }
 
   public cancelAndClose(close = true): void {
-    clearTimeout(this.triggerTimer)
+    this.clearTriggerTimer()
     if (!this.complete) return
     const { linenr, bufnr } = this.complete.option
     this._onFinish(CompleteFinishKind.Normal, close)
@@ -471,8 +478,7 @@ export class Completion implements Disposable {
       this.complete = null
     }
     if (this.triggerTimer != null) {
-      clearTimeout(this.triggerTimer)
-      this.triggerTimer = null
+      this.clearTriggerTimer()
     }
     this.pretext = undefined
     this.activeItems = []


### PR DESCRIPTION
## Summary

- preserve a pending completion retry when an asynchronous source returns no results for stale input
- add a Vim source regression test for a completion prefix that becomes eligible during rapid typing

Closes #5539

## Tests

- TMPDIR=/tmp npm test -- src/__tests__/completion/sources.test.ts src/__tests__/completion/basic.test.ts
- npm run lint:typecheck
- ESLint on the modified files