### PR TITLE
fix(pum): avoid completion confirmation race

### DIFF
--- a/autoload/coc/pum.vim
+++ b/autoload/coc/pum.vim
@@ -50,26 +50,25 @@ function! coc#pum#close(...) abort
   if coc#pum#visible()
     let inserted = 0
     let kind = get(a:, 1, '')
+    let request = !get(a:, 2, 0)
     if kind ==# 'cancel'
       let input = getwinvar(s:pum_winid, 'input', '')
       let s:pum_index = -1
-      let inserted = s:insert_word(input, 1)
+      let inserted = s:insert_word(input, 1, request ? kind : v:null)
       call s:on_pum_change(0)
     elseif kind ==# 'confirm'
       let words = getwinvar(s:pum_winid, 'words', [])
       if s:pum_index >= 0
         let word = get(words, s:pum_index, '')
-        let inserted = s:insert_word(word, 1)
+        let inserted = s:insert_word(word, 1, request ? kind : v:null)
         " have to restore here, so that TextChangedI can trigger indent.
         call s:restore_indentkeys()
       endif
     endif
     call s:close_pum()
-    if !get(a:, 2, 0)
+    if request
       " Needed to wait TextChangedI fired
-      if inserted
-        call timer_start(0, {-> coc#rpc#request('stopCompletion', [kind])})
-      else
+      if !inserted
         call coc#rpc#request('stopCompletion', [kind])
       endif
     endif
@@ -117,15 +116,18 @@ endfunction
 
 function! coc#pum#_insert() abort
   if coc#pum#visible()
+    let inserted = 0
     if s:pum_index >= 0
       let words = getwinvar(s:pum_winid, 'words', [])
       let word = get(words, s:pum_index, '')
-      call s:insert_word(word, 1)
+      let inserted = s:insert_word(word, 1, '')
       call s:restore_indentkeys()
     endif
     doautocmd <nomodeline> TextChangedI
     call s:close_pum()
-    call timer_start(0, {-> coc#rpc#request('stopCompletion', [''])})
+    if !inserted
+      call timer_start(0, {-> coc#rpc#request('stopCompletion', [''])})
+    endif
   endif
   return ''
 endfunction
@@ -317,7 +319,7 @@ function! s:get_index(next) abort
   return index
 endfunction
 
-function! s:insert_word(word, finish) abort
+function! s:insert_word(word, finish, ...) abort
   if s:start_col != -1 && mode() ==# 'i'
     " Not insert same characters
     let inserted = strpart(getline('.'), s:start_col, col('.') - 1)
@@ -331,7 +333,11 @@ function! s:insert_word(word, finish) abort
       let saved_completeopt = &completeopt
       noa set completeopt=noinsert,noselect
       noa call complete(s:start_col + 1, [{ 'empty': v:true, 'word': a:word }])
-      noa call feedkeys("\<C-n>\<C-x>\<C-z>", 'in')
+      let keys = "\<C-n>\<C-x>\<C-z>"
+      if a:finish && a:0 && a:1 isnot v:null
+        let keys = keys . "\<Cmd>call timer_start(0, {-> coc#rpc#request('stopCompletion', [".string(a:1)."])})\<CR>"
+      endif
+      noa call feedkeys(keys, 'in')
       call timer_start(0, { -> execute('noa set completeopt='.saved_completeopt)})
       return 1
     endif

--- a/src/__tests__/vim.test.ts
+++ b/src/__tests__/vim.test.ts
@@ -105,6 +105,32 @@ describe('vim api', () => {
     await nvim.command('silent! %bwipeout!')
   })
 
+  it('should synchronize document before completion done', async () => {
+    const sources = require('../completion/sources').default
+    let line: string
+    let name = crypto.randomUUID()
+    let disposable = sources.createSource({
+      name,
+      doComplete: (): Promise<CompleteResult<ExtendedCompleteItem>> => Promise.resolve({ items: [{ word: 'foo' }] }),
+      onCompleteDone: (_item, opt) => {
+        line = helper.workspace.getDocument(opt.bufnr).getline(0)
+      }
+    })
+    await nvim.setLine('')
+    await nvim.input('i')
+    nvim.call('coc#start', { source: name }, true)
+    try {
+      await helper.waitPopup()
+      await nvim.call('coc#pum#select', [0, 1, 1])
+      await helper.waitValue(() => line, 'foo')
+    } finally {
+      await nvim.input('<esc>')
+      await helper.waitFor('mode', [], 'n')
+      disposable.dispose()
+      await nvim.command('silent! %bwipeout!')
+    }
+  })
+
   it('should place popup menu after concealed text on current line', async () => {
     // Regression for #5582: Vim's popup 'cursor' column anchor ignores concealed
     // text, so the menu must be positioned with the conceal-aware screen column.


### PR DESCRIPTION
Defer stopCompletion until candidate insertion and text synchronization finish, and add a Vim regression test ensuring onCompleteDone sees the latest document.

Co-authored-by: Codex <noreply@openai.com>
