### PR TITLE
fix(document): synchronization when applying edits

### DIFF
--- a/src/handler/linkedEditing.ts
+++ b/src/handler/linkedEditing.ts
@@ -100,15 +100,16 @@ export default class LinkedEditingHandler {
     ranges.forEach(r => r.applyChange(change))
     let edits = ranges.filter(r => r !== textRange).map(o => o.textEdit)
     // logger.debug('edits:', JSON.stringify(edits, null, 2))
-    this.changing = true
-    await doc.applyEdits(edits, true, true)
-    this.changing = false
     if (delta != 0) {
       for (let r of ranges) {
-        let n = getBeforeCount(r, this.ranges, textRange)
+        let n = getBeforeCount(r, ranges, textRange)
         r.move(n * delta)
       }
     }
+    this.changing = true
+    await doc.applyEdits(edits, true, true)
+    this.changing = false
+    if (this.ranges !== ranges) return
     this.doHighlights()
   }
 

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -382,8 +382,8 @@ export default class Document {
       ], true)
     }
     this._applying = true
-    void this.nvim.resumeNotification(true, true)
     this.lines = newLines
+    await this.nvim.resumeNotification(true)
     await waitNextTick()
     fireLinesChanged(bufnr)
     let textEdit = edits.length == 1 ? edits[0] : mergeTextEdits(edits, lines, newLines)


### PR DESCRIPTION
await pending Neovim notifications before continuing, ensuring formatting edits complete before subsequent operations such as saving the buffer. Preserve the existing line-state update order to avoid losing concurrent user input.

Closes https://github.com/neoclide/coc.nvim/issues/5698

Co-authored-by: Codex <noreply@openai.com>
