### PR TITLE
fix(completion): restart completion after clearing input

### DIFF
--- a/src/__tests__/completion/basic.test.ts
+++ b/src/__tests__/completion/basic.test.ts
@@ -938,6 +938,41 @@ describe('completion', () => {
       await helper.waitValue(() => completion.activeItems.length, 2)
     })
 
+    it('should start new completion after backspace clears input', async () => {
+      let calls: string[] = []
+      let name = crypto.randomUUID()
+      disposables.push(sources.createSource({
+        name,
+        doComplete: opt => {
+          calls.push(opt.input)
+          return { items: [{ word: opt.input == 'f' ? 'foo' : 'bar' }] }
+        }
+      }))
+      await nvim.setLine('foo bar -f')
+      await nvim.input('A')
+      triggerCompletion(name)
+      await helper.waitPopup()
+
+      await nvim.exec(`
+        noa call setline('.', 'foo bar -')
+        noa call cursor(1, 10)
+      `)
+      let changedtick = await nvim.eval('b:changedtick')
+      await events.fire('TextChangedI', [events.bufnr, {
+        lnum: 1,
+        col: 10,
+        changedtick,
+        line: 'foo bar -'
+      }])
+      expect(completion.isActivated).toBe(false)
+
+      await nvim.input('b')
+      await helper.waitValue(() => calls.includes('b'), true)
+      await helper.waitValue(() => completion.activeItems.some(item => item.word == 'bar'), true)
+      expect(await helper.visible('bar')).toBe(true)
+      expect(calls).toEqual(['f', 'b'])
+    })
+
     it('should respect commit character', async () => {
       helper.updateConfiguration('suggest.acceptSuggestionOnCommitCharacter', true)
       let source: ISource = {

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -271,7 +271,8 @@ export class Completion implements Disposable {
         await this.triggerCompletion(doc, info)
         return
       }
-      if (shouldStop(bufnr, info, option) || (filterOnBackspace === false && info.pre.length < this.pretext.length)) {
+      let hasBackspace = info.pre.length < this.pretext.length
+      if (shouldStop(bufnr, info, option) || (hasBackspace && (filterOnBackspace === false || getResumeInput(option, info.pre) === ''))) {
         this.cancelAndClose()
         return
       }


### PR DESCRIPTION
End the stale completion session when backspace clears the current input, so the next character starts a fresh completion request. Add a regression test for typing f, deleting it, and then typing b.

Closes #5697 

Co-authored-by: Codex <noreply@openai.com>
