### PR TITLE
fix(completion): handle backspace for trigger sources

### DIFF
--- a/src/__tests__/completion/basic.test.ts
+++ b/src/__tests__/completion/basic.test.ts
@@ -816,6 +816,41 @@ describe('completion', () => {
       expect(items[0].word).toBe('foo')
     }, 10000)
 
+    it('should keep trigger completion after backspace clears input', async () => {
+      let source: ISource = {
+        priority: 0,
+        enable: true,
+        name: 'source',
+        sourceType: SourceType.Service,
+        triggerCharacters: ['.'],
+        doComplete: () => Promise.resolve({ items: [{ word: 'foo' }, { word: 'bar' }] })
+      }
+      disposables.push(sources.addSource(source))
+      await nvim.input('i.')
+      await helper.waitPopup()
+      await nvim.input('f')
+      await helper.waitValue(() => completion.activeItems.length, 1)
+      await nvim.input('<backspace>')
+      await helper.waitValue(() => completion.activeItems.length, 2)
+      expect(await pumvisible()).toBe(true)
+    }, 10000)
+
+    it('should stop completion when trigger source is not active', async () => {
+      await nvim.setLine('x.f')
+      await nvim.input('A')
+      let name = await create(['foo'], false)
+      disposables.push(sources.addSource({
+        name: crypto.randomUUID(),
+        enable: true,
+        triggerCharacters: ['.'],
+        doComplete: async () => ({ items: [{ word: 'trigger' }] })
+      }))
+      triggerCompletion(name)
+      await helper.waitPopup()
+      await nvim.input('<backspace>')
+      await helper.waitValue(() => completion.isActivated, false)
+    }, 10000)
+
     it('should filter slow source', async () => {
       disposables.push(sources.addSource({
         name: 'fast',

--- a/src/completion/complete.ts
+++ b/src/completion/complete.ts
@@ -108,6 +108,10 @@ export default class Complete {
     return this.results.size === 0
   }
 
+  public hasSource(source: ISource): boolean {
+    return this.sources.includes(source)
+  }
+
   private get hasInComplete(): boolean {
     for (let result of this.results.values()) {
       if (result.isIncomplete) return true

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -244,12 +244,19 @@ export class Completion implements Disposable {
     return true
   }
 
+  private shouldStopOnBackspace(doc: Document, info: InsertChange, option: CompleteOption): boolean {
+    if (info.pre.length >= this.pretext.length) return false
+    if (this.staticConfig.filterOnBackspace === false) return true
+    if (getResumeInput(option, info.pre) !== '') return false
+    let triggerSources = this.getTriggerSources(doc, info.pre)
+    return !triggerSources.some(source => this.complete?.hasSource(source))
+  }
+
   private async onTextChangedI(bufnr: number, info: InsertChange): Promise<void> {
     const doc = workspace.getDocument(bufnr)
     if (!doc || !doc.attached) return
     this._debounced.clear()
     const { option, staticConfig } = this
-    const filterOnBackspace = this.staticConfig.filterOnBackspace
     if (option != null) {
       // detect item word insert
       if (!info.insertChar) {
@@ -271,8 +278,7 @@ export class Completion implements Disposable {
         await this.triggerCompletion(doc, info)
         return
       }
-      let hasBackspace = info.pre.length < this.pretext.length
-      if (shouldStop(bufnr, info, option) || (hasBackspace && (filterOnBackspace === false || getResumeInput(option, info.pre) === ''))) {
+      if (shouldStop(bufnr, info, option) || this.shouldStopOnBackspace(doc, info, option)) {
         this.cancelAndClose()
         return
       }


### PR DESCRIPTION
Keep trigger-character completion active when backspace clears the query, but only when the current session contains the matching source. Close stale manual completion sessions and cover both paths with regression tests.

Closes https://github.com/neoclide/coc.nvim/issues/5697

Co-authored-by: Codex <noreply@openai.com>
