### PR TITLE
fix(completion): refresh language sources after backspace

### DIFF
--- a/src/__tests__/completion/language.test.ts
+++ b/src/__tests__/completion/language.test.ts
@@ -1,5 +1,5 @@
 import { Neovim } from '../../neovim'
-import { CancellationToken, Disposable } from 'vscode-languageserver-protocol'
+import { CancellationToken, CompletionTriggerKind, Disposable } from 'vscode-languageserver-protocol'
 import { CompletionItem, CompletionItemKind, CompletionList, InsertReplaceEdit, InsertTextFormat, InsertTextMode, Position, Range, TextEdit } from 'vscode-languageserver-types'
 import commandManager from '../../commands'
 import completion from '../../completion'
@@ -630,6 +630,31 @@ describe('language source', () => {
         let items = await helper.items()
         return items.length
       }, 1)
+    })
+
+    it('should refresh language source after backspace clears input', async () => {
+      let requests: [string, CompletionTriggerKind][] = []
+      let provider: CompletionItemProvider = {
+        provideCompletionItems: async (_doc, _pos, _token, context): Promise<CompletionList> => {
+          let option = (context as any).option
+          requests.push([option.input, context.triggerKind])
+          return {
+            isIncomplete: option.input.length === 0,
+            items: option.input.length > 0 ? [{ label: 'foo' }] : [{ label: 'foo' }, { label: 'bar' }]
+          }
+        }
+      }
+      disposables.push(languages.registerCompletionItemProvider('backspace', 'B', null, provider))
+      await nvim.setLine('#include <f')
+      await nvim.input('A')
+      nvim.call('coc#start', { source: 'backspace' }, true)
+      await helper.waitPopup()
+      await nvim.input('<backspace>')
+      await helper.waitValue(async () => {
+        let items = await helper.items()
+        return items.length
+      }, 2)
+      expect(requests).toContainEqual(['', CompletionTriggerKind.Invoked])
     })
   })
 

--- a/src/completion/complete.ts
+++ b/src/completion/complete.ts
@@ -11,6 +11,7 @@ import { clamp } from '../util/numbers'
 import { CancellationToken, CancellationTokenSource, Disposable, Emitter, Event } from '../util/protocol'
 import { characterIndex } from '../util/string'
 import workspace from '../workspace'
+import LanguageSource from './source-language'
 import { CompleteConfig, CompleteItem, CompleteOption, DurationCompleteItem, InsertMode, ISource, SortMethod } from './types'
 import { Converter, ConvertOption, getPriority, useAscii } from './util'
 import { WordDistance } from './wordDistance'
@@ -112,18 +113,16 @@ export default class Complete {
     return this.sources.includes(source)
   }
 
-  private get hasInComplete(): boolean {
-    for (let result of this.results.values()) {
-      if (result.isIncomplete) return true
-    }
-    return false
-  }
-
   public getIncompleteSources(): ISource[] {
     return this.sources.filter(s => {
       let res = this.results.get(s.name)
       return res && res.isIncomplete === true
     })
+  }
+
+  public getBackspaceSources(): ISource[] {
+    let sources = this.sources.filter(s => this.results.has(s.name))
+    return sources.some(s => this.results.get(s.name)?.isIncomplete === true || s instanceof LanguageSource) ? sources : []
   }
 
   public async doComplete(): Promise<boolean> {
@@ -204,6 +203,9 @@ export default class Complete {
     let { asciiMatch } = this
     const insertMode = this.config.insertMode
     const sourceName = source.name
+    if (opt.triggerForInComplete && this.results.get(sourceName)?.isIncomplete !== true) {
+      opt.triggerForInComplete = false
+    }
     let added = false
     this.completingSources.add(sourceName)
     try {
@@ -258,7 +260,7 @@ export default class Complete {
     return added
   }
 
-  public async completeInComplete(resumeInput: string): Promise<undefined> {
+  public async completeInComplete(resumeInput: string, sources = this.getIncompleteSources()): Promise<undefined> {
     let { document } = this
     this.cancelInComplete()
     let tokenSource = this.createTokenSource(true)
@@ -274,7 +276,6 @@ export default class Complete {
       triggerForInComplete: true
     })
     this.cid++
-    const sources = this.getIncompleteSources()
     await this.completeSources(sources, tokenSource, this.cid)
   }
 
@@ -333,10 +334,11 @@ export default class Complete {
     return this.limitCompleteItems(arr.slice(0, maxItemCount))
   }
 
-  public async filterResults(input: string): Promise<DurationCompleteItem[] | undefined> {
-    if (input !== this.option.input && this.hasInComplete) {
+  public async filterResults(input: string, backspace = false): Promise<DurationCompleteItem[] | undefined> {
+    let sources = backspace ? this.getBackspaceSources() : this.getIncompleteSources()
+    if (input !== this.option.input && sources.length > 0) {
       this.fireRefresh(30)
-      void this.completeInComplete(input)
+      void this.completeInComplete(input, sources)
       return undefined
     }
     clearTimeout(this.timer)

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -248,6 +248,7 @@ export class Completion implements Disposable {
     if (info.pre.length >= this.pretext.length) return false
     if (this.staticConfig.filterOnBackspace === false) return true
     if (getResumeInput(option, info.pre) !== '') return false
+    if (this.complete?.getBackspaceSources().length) return false
     let triggerSources = this.getTriggerSources(doc, info.pre)
     return !triggerSources.some(source => this.complete?.hasSource(source))
   }
@@ -287,7 +288,7 @@ export class Completion implements Disposable {
     this.clearTriggerTimer()
     let pretext = this.pretext = info.pre
     if (!info.insertChar) {
-      if (this.complete) await this.filterResults()
+      if (this.complete) await this.filterResults(info)
       return
     }
     // check commit
@@ -456,7 +457,7 @@ export class Completion implements Disposable {
       this.cancelAndClose()
       return
     }
-    let items = await complete.filterResults(search)
+    let items = await complete.filterResults(search, info != null && !info.insertChar && search === '')
     // cancelled or have inserted text
     if (items === undefined || !this.option) return
     let doc = workspace.getDocument(option.bufnr)


### PR DESCRIPTION
Refresh active completion sources when backspace clears the input and a language source is active. Preserve the correct LSP trigger kind for complete and incomplete responses.

Closes https://github.com/neoclide/coc.nvim/issues/5697

Co-authored-by: Codex <noreply@openai.com>
