### PR TITLE
fix(events): separate WinClosed and BufWinLeave

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -320,10 +320,11 @@ class Events {
         break
       }
       case EventName.BufWinLeave:
-      case EventName.WinClosed: {
+        this.clearVisibleTimer(args[1])
+        break
+      case EventName.WinClosed:
         this.clearVisibleTimer(args[0])
         break
-      }
       case EventName.ModeChanged: {
         this._mode = args[0].new_mode
         break


### PR DESCRIPTION
BufWinLeave sends `[bufnr, winid]`, WinClosed sends `[winid]`, the switch refactor handled both with `args[0]`. Handle the events separately.

Co-authored-by: Codex <noreply@openai.com>
