### PR TITLE
fix(handler): should return the attached document

### DIFF
--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -207,8 +207,8 @@ export default class Handler implements HandlerDelegate {
   public async getCurrentState(): Promise<CurrentState> {
     let { nvim } = this
     let [bufnr, [line, character], winid, mode] = await nvim.eval("[bufnr('%'),coc#cursor#position(),win_getid(),mode()]") as [number, [number, number], number, string]
-    let doc = await workspace.document
-    workspace.getAttachedDocument(bufnr)
+    await workspace.document
+    let doc = workspace.getAttachedDocument(bufnr)
     return {
       doc,
       mode,


### PR DESCRIPTION
1. kept lazy document initialization
2. resolve and return the attached one using the bufnr from the the original editor snapshot
