### PR TITLE
fix(language-client): make dot matching default

### DIFF
--- a/history.md
+++ b/history.md
@@ -2,6 +2,10 @@
 
 Notable changes of coc.nvim:
 
+## 2026-08-03
+
+- File operation glob patterns now match dotfiles and dot-prefixed directories by default.
+
 ## 2026-08-02
 
 - `watchFile` now watches the parent directory of the target file, so changes

--- a/src/__tests__/client/dynamic.test.ts
+++ b/src/__tests__/client/dynamic.test.ts
@@ -428,7 +428,7 @@ describe('DynamicFeature', () => {
         }
       }, ['*'])
       await createFeature.send({ files: [URI.file(os.tmpdir()), URI.file(__filename)] })
-      await helper.waitValue(() => n, 1)
+      await helper.waitValue(() => n, 2)
       await client.stop()
     })
   })

--- a/src/language-client/fileOperations.ts
+++ b/src/language-client/fileOperations.ts
@@ -190,13 +190,12 @@ abstract class FileOperationFeature<I, E extends EventWithFiles<I>>
   }
 
   public static asMinimatchOptions(options: FileOperationPatternOptions | undefined): MinimatchOptions | undefined {
-    if (options === undefined) {
-      return undefined
+    // The spec doesn't state that dot files don't match, so make matching those the default.
+    const result: MinimatchOptions = { dot: true }
+    if (options?.ignoreCase === true) {
+      result.nocase = true
     }
-    if (options.ignoreCase === true) {
-      return { nocase: true }
-    }
-    return undefined
+    return result
   }
 }
 


### PR DESCRIPTION
https://github.com/microsoft/vscode-languageserver-node/pull/1221
