### PR TITLE
fix(ui): fix the setup of scratch buffer for extensions 

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -201,6 +201,7 @@
       "type": "array",
       "default": [],
       "description": "Features disabled for this language server.",
+      "uniqueItems": true,
       "items": {
         "type": "string",
         "enum": [

--- a/src/__tests__/modules/extensionModules.test.ts
+++ b/src/__tests__/modules/extensionModules.test.ts
@@ -392,6 +392,9 @@ describe('InstallBuffer', () => {
     disposables.push(buf)
     events.requesting = true
     await buf.start(['a', 'b', 'c'])
+    // scratch buffer should carry a meaningful name (#5061)
+    const bufname = await nvim.call('bufname', ['%']) as string
+    expect(bufname).toBe('[Coc Extensions]')
     let wins = await nvim.windows
     expect(wins.length).toBe(1)
     global.__TEST__ = true

--- a/src/extension/ui.ts
+++ b/src/extension/ui.ts
@@ -215,13 +215,12 @@ export class InstallBuffer implements InstallUI {
     // `[scratch]`; reusing the named buffer also avoids leaking a new buffer
     // on every show (#5061)
     let name = '[Coc Extensions]'
-    let setup = 'buftype=nofile bufhidden=wipe nobuflisted'
     if (isSync) {
-      nvim.command(`edit +setl\\ ${setup} ${name}`, true)
+      nvim.command(`edit ${name}`, true)
     } else if (this.settings.updateUIInTab) {
-      nvim.command(`tabnew +setl\\ ${setup} ${name}`, true)
+      nvim.command(`tabnew ${name}`, true)
     } else {
-      nvim.command(`vs +setl\\ ${setup} ${name}`, true)
+      nvim.command(`vs ${name}`, true)
     }
     nvim.call('bufnr', ['%'], true)
     nvim.command('setl buftype=nofile bufhidden=wipe noswapfile nobuflisted wrap undolevels=-1', true)


### PR DESCRIPTION
The `setup` is not escaped, and there is already `setl ...` below

Improve schema by the way