### PR TITLE
feat(next-edit): add generic next edit support

### DIFF
--- a/autoload/coc/nextedit.vim
+++ b/autoload/coc/nextedit.vim
@@ -1,0 +1,44 @@
+scriptencoding utf-8
+let s:ns = coc#highlight#create_namespace('nextEdit')
+
+function! coc#nextedit#available() abort
+  return get(b:, 'coc_next_edit_state', 0) != 0
+endfunction
+
+function! coc#nextedit#visible() abort
+  return get(b:, 'coc_next_edit_state', 0) == 2
+endfunction
+
+function! coc#nextedit#trigger(...) abort
+  call CocActionAsync('nextEditTrigger', get(a:, 1, {}))
+  return ''
+endfunction
+
+function! coc#nextedit#accept() abort
+  if coc#nextedit#available()
+    call CocActionAsync('nextEditAccept')
+  endif
+  return ''
+endfunction
+
+function! coc#nextedit#cancel() abort
+  call coc#nextedit#clear()
+  call CocActionAsync('nextEditCancel')
+  return ''
+endfunction
+
+function! coc#nextedit#next() abort
+  call CocActionAsync('nextEditNext')
+  return ''
+endfunction
+
+function! coc#nextedit#prev() abort
+  call CocActionAsync('nextEditPrev')
+  return ''
+endfunction
+
+function! coc#nextedit#clear(...) abort
+  let l:bufnr = get(a:, 1, bufnr('%'))
+  call coc#compat#call('buf_clear_namespace', [l:bufnr, s:ns, 0, -1])
+  call setbufvar(l:bufnr, 'coc_next_edit_state', 0)
+endfunction

--- a/data/schema.json
+++ b/data/schema.json
@@ -2387,6 +2387,20 @@
       "scope": "language-overridable",
       "description": "Wait time in milliseconds between text change and triggering inline completion."
     },
+    "nextEdit.autoTrigger": {
+      "type": "boolean",
+      "default": true,
+      "scope": "language-overridable",
+      "description": "Automatically request generic next edits after text changes."
+    },
+    "nextEdit.triggerWait": {
+      "type": "integer",
+      "default": 150,
+      "minimum": 0,
+      "maximum": 2000,
+      "scope": "language-overridable",
+      "description": "Wait time in milliseconds before requesting a next edit."
+    },
     "tree.closedIcon": {
       "type": "string",
       "scope": "application",

--- a/doc/coc-config.txt
+++ b/doc/coc-config.txt
@@ -24,6 +24,7 @@ LSP features
 	Completion 				|coc-config-suggest|
 	Sources 				|coc-config-sources|
 	Inline completion 			|coc-config-inlineSuggest|
+	Next edit 				|coc-config-nextEdit|
 	Cursors 				|coc-config-cursors|
 	Diagnostics 				|coc-config-diagnostic|
 	Document highlight 			|coc-config-documentHighlight|
@@ -2335,6 +2336,22 @@ INLINE COMPLETION
 	completion.
 
 	Scope: `language-overridable`, default: `10`
+
+------------------------------------------------------------------------------
+NEXT EDIT
+							*coc-config-nextEdit*
+
+"nextEdit.autoTrigger"					*coc-config-nextEdit-autoTrigger*
+
+	Automatically request generic next edits after text changes.
+
+	Scope: `language-overridable`, default: `true`
+
+"nextEdit.triggerWait"					*coc-config-nextEdit-triggerWait*
+
+	Wait time in milliseconds before requesting a next edit.
+
+	Scope: `language-overridable`, default: `150`
 
 ------------------------------------------------------------------------------
 TYPEHIERARCHY

--- a/doc/coc.txt
+++ b/doc/coc.txt
@@ -19,6 +19,7 @@ LSP features 					|coc-lsp|
   Hover 					|coc-hover|
   Completion					|coc-completion|
   Inline completion				|coc-inlineCompletion|
+  Next edit					|coc-next-edit|
   Diagnostics 					|coc-diagnostics|
   Pull diagnostics 				|coc-pullDiagnostics|
   Locations 					|coc-locations|
@@ -764,6 +765,32 @@ disable inline completion triggering completely.
 Related Highlight groups:
 	|CocInlineVirtualText| for virtual text highlight.
 	|CocInlineAnnotation| for annotation highlight.
+
+------------------------------------------------------------------------------
+NEXT EDIT							*coc-next-edit*
+
+Extensions can register a generic `NextEditProvider` with
+`languages.registerNextEditProvider()`. Providers return versioned insertion,
+replacement, or deletion candidates. Candidates are previewed without changing
+the buffer; accepting an off-cursor candidate first jumps to it, and accepting
+again applies it. A visible inline completion always has priority.
+
+Functions: ~
+
+  • Trigger: |coc#nextedit#trigger()|.
+  • Check availability: |coc#nextedit#available()|.
+  • Check preview visibility: |coc#nextedit#visible()|.
+  • Accept: |coc#nextedit#accept()|.
+  • Cancel: |coc#nextedit#cancel()|.
+  • Next/previous candidate: |coc#nextedit#next()| and |coc#nextedit#prev()|.
+
+No default mapping is installed. A priority-preserving Insert-mode example is: >
+	inoremap <silent><expr> <Tab>
+	      \ coc#pum#visible() ? coc#pum#next(1) :
+	      \ coc#inline#visible() ? coc#inline#accept() :
+	      \ coc#nextedit#available() ? coc#nextedit#accept() :
+	      \ "\<Tab>"
+<
 
 ------------------------------------------------------------------------------
 DIAGNOSTICS SUPPORT 					*coc-diagnostics*
@@ -2592,6 +2619,49 @@ coc#inline#prev() 					*coc#inline#prev()*
 
 	Note: this function uses |CocActionAsync()|, use it in key-mappings
 	instead of API.
+
+coc#nextedit#trigger([{option}]) 				*coc#nextedit#trigger()*
+
+	Trigger a Next Edit request for the current buffer asynchronously and
+	return `""`, so this function can be used in an `<expr>` mapping.
+
+	Parameters: ~
+		{option} Optional dictionary. The `provider` property restricts the
+		request to the named provider.
+
+coc#nextedit#available() 				*coc#nextedit#available()*
+
+	Return `1` when a Next Edit candidate is ready to jump or apply in the
+	current buffer, otherwise return `0`.
+
+coc#nextedit#visible() 				*coc#nextedit#visible()*
+
+	Return `1` when a Next Edit preview is visible in the current buffer,
+	otherwise return `0`. A ready navigation indicator is not a preview.
+
+coc#nextedit#accept() 				*coc#nextedit#accept()*
+
+	Accept the current Next Edit action asynchronously. An off-cursor or
+	cross-file candidate is first opened and previewed; a second call applies
+	the edit. Returns `""` and does nothing when no candidate is available.
+
+coc#nextedit#cancel() 				*coc#nextedit#cancel()*
+
+	Cancel the current request or preview and clear all Next Edit UI state.
+	Returns `""`.
+
+coc#nextedit#next() 				*coc#nextedit#next()*
+
+	Select the next candidate, wrapping to the first candidate. Returns `""`.
+
+coc#nextedit#prev() 				*coc#nextedit#prev()*
+
+	Select the previous candidate, wrapping to the last candidate. Returns `""`.
+
+coc#nextedit#clear([{bufnr}]) 				*coc#nextedit#clear()*
+
+	Clear Next Edit virtual text and buffer-local state. When {bufnr} is
+	omitted, clear the current buffer.
 
 							*coc#notify*
 coc#notify#close_all()					*coc#notify#close_all()*

--- a/history.md
+++ b/history.md
@@ -2,6 +2,12 @@
 
 Notable changes of coc.nvim:
 
+## 2026-08-19
+
+- Add a provider-neutral Next Edit API with versioned candidates, cancellation,
+  preview, navigation, acceptance, Vim/Neovim actions, and extension-owned
+  `handleDidShowNextEdit` callbacks.
+
 ## 2026-08-15
 
 - Upgrade extension loader:

--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -34,6 +34,11 @@ let g:did_coc_loaded = 1
 let g:coc_service_initialized = 0
 let s:root = expand('<sfile>:h:h')
 
+hi default link CocNextEditDelete DiffDelete
+hi default link CocNextEditInsert DiffAdd
+hi default link CocNextEditAnnotation MoreMsg
+hi default link CocNextEditIndicator MoreMsg
+
 function! CocTagFunc(pattern, flags, info) abort
   " tagfunc can't be set in the sandbox mode, preload the following functions
   silent! call coc#cursor#move_to()

--- a/src/__tests__/handler/inline.test.ts
+++ b/src/__tests__/handler/inline.test.ts
@@ -1131,4 +1131,10 @@ describe('Utility functions', () => {
       assert.strictEqual(result, true)
     })
   })
+
+  describe('dispose()', () => {
+    it('disposes the visibility emitter and subscriptions', () => {
+      inlineCompletion.dispose()
+    })
+  })
 })

--- a/src/__tests__/handler/nextEdit.test.ts
+++ b/src/__tests__/handler/nextEdit.test.ts
@@ -105,6 +105,20 @@ describe('NextEdit handler', () => {
     assert.strictEqual(vtextCalls[0][0][4].col, 1)
   })
 
+  it('uses the namespace cleared by the Vim next-edit layer', async t => {
+    let doc = await setup(t)
+    ;(nextEdit as any).namespace = undefined
+    let namespaces: string[] = []
+    t.mock.method(workspace.nvim, 'createNamespace', async (name: string) => { namespaces.push(name); return 1 })
+    register(doc, version => ({
+      textDocument: { uri: doc.uri, version },
+      range: Range.create(0, 0, 0, 0),
+      newText: 'X'
+    }))
+    assert.strictEqual(await nextEdit.trigger(doc.bufnr, { autoTrigger: false }), true)
+    assert.deepStrictEqual(namespaces, ['coc-nextEdit'])
+  })
+
   it('jumps before previewing an off-cursor candidate, then applies a deletion', async t => {
     let doc = await setup(t)
     register(doc, version => ({
@@ -137,6 +151,48 @@ describe('NextEdit handler', () => {
     await nextEdit.next()
     await nextEdit.prev()
     assert.strictEqual(shown, 2)
+  })
+
+  it('does not mark a superseded candidate as shown after an async render', async t => {
+    let doc = await setup(t)
+    let shown: string[] = []
+    let resolveFirst: () => void
+    let calls = 0
+    t.mock.method(workspace.nvim, 'call', ((method: string) => {
+      if (method === 'coc#vtext#add' && calls++ === 0) return new Promise<void>(resolve => { resolveFirst = resolve })
+      return Promise.resolve(1)
+    }) as any)
+    disposables.push(languages.registerNextEditProvider([{ language: '*' }], {
+      provideNextEdits: () => [
+        { textDocument: { uri: doc.uri, version: doc.version }, range: Range.create(0, 0, 0, 0), newText: 'a' },
+        { textDocument: { uri: doc.uri, version: doc.version }, range: Range.create(0, 0, 0, 0), newText: 'b' },
+      ],
+      handleDidShowNextEdit: item => { shown.push(item.newText) }
+    }))
+    let pending = nextEdit.trigger(doc.bufnr, { autoTrigger: false })
+    await shared.waitValue(() => resolveFirst != null, true)
+    await nextEdit.next()
+    resolveFirst()
+    await pending
+    assert.deepStrictEqual(shown, ['b'])
+  })
+
+  it('reloads language-scoped configuration after switching buffers', async t => {
+    await setup(t)
+    let handler = nextEdit as any
+    let original = workspace.getConfiguration
+    t.mock.method(workspace, 'getConfiguration', ((section: string, resource: any) => {
+      if (section === 'nextEdit') {
+        let disabled = resource?.languageId === 'typescript'
+        return { get: (key: string, fallback: any) => key === 'autoTrigger' ? !disabled : fallback }
+      }
+      return original.call(workspace, section, resource)
+    }) as any)
+    await workspace.nvim.command('setfiletype typescript')
+    await shared.waitValue(() => handler.config.autoTrigger, false)
+    await workspace.nvim.command('enew | setfiletype javascript')
+    await shared.waitValue(() => handler.config.autoTrigger, true)
+    assert.strictEqual(handler.config.autoTrigger, true)
   })
 
   it('rejects malformed, stale, invalid-range and no-op candidates', async t => {

--- a/src/__tests__/handler/nextEdit.test.ts
+++ b/src/__tests__/handler/nextEdit.test.ts
@@ -4,7 +4,7 @@ import commands from '../../commands'
 import languages from '../../languages'
 import type NextEdit from '../../handler/nextEdit'
 import { Disposable } from '../../util/protocol'
-import { Position, Range, TextEdit } from 'vscode-languageserver-protocol'
+import { InlineCompletionTriggerKind, Position, Range, TextEdit } from 'vscode-languageserver-protocol'
 import window from '../../window'
 import workspace from '../../workspace'
 
@@ -169,6 +169,22 @@ describe('NextEdit handler', () => {
     assert.strictEqual(await nextEdit.accept(), false)
   })
 
+  it('refuses to apply when the session is replaced during the jump', async t => {
+    let doc = await setup(t)
+    register(doc, version => ({
+      textDocument: { uri: doc.uri, version },
+      range: Range.create(1, 0, 1, 3),
+      newText: ''
+    }))
+    // Simulate a buffer switch during jumpTo invalidating the session (e.g.
+    // the target buffer closes while the request is in flight).
+    t.mock.method(workspace, 'jumpTo', async () => { nextEdit.cancel() })
+    assert.strictEqual(await nextEdit.trigger(doc.bufnr, { autoTrigger: false }), true)
+    assert.strictEqual(nextEdit.available(), true)
+    assert.strictEqual(await nextEdit.accept(), false)
+    assert.strictEqual(nextEdit.available(), false)
+  })
+
   it('normalizes newlines and executes a command after applying', async t => {
     let doc = await setup(t)
     let executed = 0
@@ -242,6 +258,21 @@ describe('NextEdit handler', () => {
     assert.strictEqual((nextEdit as any).renderedBufnrs.size, 0)
   })
 
+  it('drops a render cancelled while creating the namespace', async t => {
+    let doc = await setup(t)
+    register(doc, version => ({ textDocument: { uri: doc.uri, version }, range: Range.create(0, 0, 0, 0), newText: 'x' }))
+    ;(nextEdit as any).namespace = undefined
+    let resolveNs: (value?: unknown) => void
+    t.mock.method(workspace.nvim, 'createNamespace', () => new Promise(resolve => { resolveNs = resolve }))
+    let pending = nextEdit.trigger(doc.bufnr, { autoTrigger: false })
+    await shared.waitValue(() => resolveNs != null, true)
+    nextEdit.cancel()
+    resolveNs(1)
+    assert.strictEqual(await pending, true)
+    assert.strictEqual(nextEdit.available(), false)
+    assert.strictEqual((nextEdit as any).state, 'idle')
+  })
+
   it('keeps the accept action with inline completion', async t => {
     let doc = await setup(t)
     register(doc, version => ({ textDocument: { uri: doc.uri, version }, range: Range.create(0, 0, 0, 0), newText: 'x' }))
@@ -252,6 +283,23 @@ describe('NextEdit handler', () => {
     assert.strictEqual(await nextEdit.accept(), false)
     inline.session = undefined
     nextEdit.cancel()
+  })
+
+  it('triggers through the editor.action.triggerNextEdit command', async t => {
+    let doc = await setup(t)
+    // No provider registered yet: the command resolves to false.
+    assert.strictEqual(await commands.executeCommand('editor.action.triggerNextEdit', { autoTrigger: true }), false)
+    let kinds: number[] = []
+    disposables.push(languages.registerNextEditProvider([{ language: '*' }], {
+      provideNextEdits: (_doc, _position, option: any) => {
+        kinds.push(option.triggerKind)
+        return [{ textDocument: { uri: doc.uri, version: doc.version }, range: Range.create(0, 0, 0, 0), newText: 'x' }]
+      }
+    }))
+    // The command forces autoTrigger to false regardless of the passed option.
+    assert.strictEqual(await commands.executeCommand('editor.action.triggerNextEdit', { autoTrigger: true }), true)
+    assert.strictEqual(nextEdit.available(), true)
+    assert.deepStrictEqual(kinds, [InlineCompletionTriggerKind.Invoked])
   })
 
   it('reports final visibility state and disposes subscriptions', () => {

--- a/src/__tests__/handler/nextEdit.test.ts
+++ b/src/__tests__/handler/nextEdit.test.ts
@@ -1,0 +1,184 @@
+import { getCurrentPlugin } from '../../attach'
+import * as shared from '../sharedUtil'
+import commands from '../../commands'
+import languages from '../../languages'
+import type NextEdit from '../../handler/nextEdit'
+import { Disposable } from '../../util/protocol'
+import { Position, Range, TextEdit } from 'vscode-languageserver-protocol'
+import window from '../../window'
+import workspace from '../../workspace'
+
+let nextEdit: NextEdit
+let disposables: Disposable[] = []
+
+before(() => {
+  nextEdit = getCurrentPlugin().handler.nextEdit
+})
+
+afterEach(async t => {
+  await editorReset(t)
+  nextEdit.cancel()
+  disposables.forEach(d => d.dispose())
+  disposables = []
+})
+
+async function setup(t: any, lines = ['one', 'two']): Promise<any> {
+  shared.updateConfiguration('nextEdit.autoTrigger', false, disposables)
+  let doc = await shared.createDocument(`next-edit-${Date.now()}-${Math.random()}`)
+  await workspace.nvim.call('setline', [1, lines])
+  await doc.synchronize()
+  await workspace.nvim.call('cursor', [1, 1])
+  let originalCall = workspace.nvim.call
+  t.mock.method(workspace.nvim, 'call', ((method: string, ...args: any[]) => {
+    if (method === 'coc#vtext#add') return Promise.resolve(1)
+    return originalCall.apply(workspace.nvim, [method, ...args] as any)
+  }) as any)
+  return doc
+}
+
+function register(doc: any, create: (version: number) => any): void {
+  disposables.push(languages.registerNextEditProvider([{ language: '*' }], {
+    provideNextEdits: () => [create(doc.version)]
+  }))
+}
+
+describe('NextEdit handler', () => {
+  it('rejects unavailable, disabled and empty requests', async t => {
+    let doc = await setup(t)
+    assert.strictEqual(await nextEdit.trigger(doc.bufnr, { autoTrigger: false }), false)
+    register(doc, () => ({ textDocument: { uri: doc.uri, version: doc.version }, range: Range.create(0, 0, 0, 0), newText: '' }))
+    await doc.synchronize()
+    await workspace.nvim.createBuffer(doc.bufnr).setVar('coc_next_edit_disable', 1)
+    assert.strictEqual(await nextEdit.trigger(doc.bufnr, { autoTrigger: false }), false)
+    await workspace.nvim.createBuffer(doc.bufnr).setVar('coc_next_edit_disable', 0)
+    assert.strictEqual(await nextEdit.trigger(doc.bufnr, { autoTrigger: false }), false)
+    assert.strictEqual(nextEdit.available(), false)
+  })
+
+  it('previews an insertion and applies it exactly once', async t => {
+    let doc = await setup(t)
+    register(doc, version => ({
+      textDocument: { uri: doc.uri, version },
+      range: Range.create(0, 0, 0, 0),
+      newText: 'X'
+    }))
+    assert.strictEqual(await nextEdit.trigger(doc.bufnr, { autoTrigger: false }), true)
+    assert.strictEqual(nextEdit.available(), true)
+    assert.strictEqual(nextEdit.visible(), true)
+    let before = doc.textDocument.getText()
+    assert.strictEqual(await nextEdit.accept(), true)
+    assert.notStrictEqual(doc.textDocument.getText(), before)
+    assert.strictEqual(doc.getline(0), 'Xone')
+    assert.strictEqual(await nextEdit.accept(), false)
+  })
+
+  it('jumps before previewing an off-cursor candidate, then applies a deletion', async t => {
+    let doc = await setup(t)
+    register(doc, version => ({
+      textDocument: { uri: doc.uri, version },
+      range: Range.create(1, 0, 1, 3),
+      newText: ''
+    }))
+    assert.strictEqual(await nextEdit.trigger(doc.bufnr, { autoTrigger: false }), true)
+    assert.strictEqual(nextEdit.visible(), false)
+    assert.strictEqual(await nextEdit.accept(), true)
+    assert.strictEqual(nextEdit.visible(), true)
+    assert.strictEqual(await nextEdit.accept(), true)
+    assert.strictEqual(doc.getline(1), '')
+  })
+
+  it('switches candidates, wraps, and invokes the shown callback once', async t => {
+    let doc = await setup(t)
+    let shown = 0
+    disposables.push(languages.registerNextEditProvider([{ language: '*' }], {
+      provideNextEdits: () => [
+        { textDocument: { uri: doc.uri, version: doc.version }, range: Range.create(0, 0, 0, 0), newText: 'a' },
+        { textDocument: { uri: doc.uri, version: doc.version }, range: Range.create(0, 0, 0, 0), newText: 'b' },
+      ],
+      handleDidShowNextEdit: () => { shown++ }
+    }))
+    await nextEdit.trigger(doc.bufnr, { autoTrigger: false })
+    assert.strictEqual(shown, 1)
+    await nextEdit.next()
+    assert.strictEqual(shown, 2)
+    await nextEdit.next()
+    await nextEdit.prev()
+    assert.strictEqual(shown, 2)
+  })
+
+  it('rejects malformed, stale, invalid-range and no-op candidates', async t => {
+    let doc = await setup(t)
+    disposables.push(languages.registerNextEditProvider([{ language: '*' }], {
+      provideNextEdits: () => [
+        null as any,
+        { textDocument: { uri: doc.uri, version: 'bad' }, range: Range.create(0, 0, 0, 0), newText: 'x' },
+        { textDocument: { uri: doc.uri, version: doc.version }, range: Range.create(-1, 0, 0, 0), newText: 'x' },
+        { textDocument: { uri: doc.uri, version: doc.version - 1 }, range: Range.create(0, 0, 0, 0), newText: 'x' },
+        { textDocument: { uri: doc.uri, version: doc.version }, range: Range.create(0, 0, 0, 3), newText: 'one' },
+      ]
+    }))
+    assert.strictEqual(await nextEdit.trigger(doc.bufnr, { autoTrigger: false }), false)
+  })
+
+  it('covers direct validation guards and unattached targets', async t => {
+    let handler = nextEdit as any
+    assert.strictEqual(handler.validate({}), undefined)
+    assert.strictEqual(handler.validCandidate({}), false)
+    await nextEdit.next()
+    await nextEdit.prev()
+    let doc = await setup(t)
+    let uri = 'file:///tmp/next-edit-unattached.ts'
+    disposables.push(languages.registerNextEditProvider([{ language: '*' }], {
+      provideNextEdits: () => [{ textDocument: { uri, version: 1 }, range: Range.create(0, 0, 0, 0), newText: 'external' }]
+    }))
+    t.mock.method(workspace, 'jumpTo', async () => {})
+    assert.strictEqual(await nextEdit.trigger(doc.bufnr, { autoTrigger: false }), true)
+    assert.strictEqual(await nextEdit.accept(), false)
+  })
+
+  it('normalizes newlines and executes a command after applying', async t => {
+    let doc = await setup(t)
+    let executed = 0
+    t.mock.method(commands, 'execute', async () => { executed++ })
+    register(doc, version => ({
+      textDocument: { uri: doc.uri, version },
+      range: Range.create(0, 3, 0, 3),
+      newText: '\r\nnext',
+      command: { command: 'nextEdit.test' }
+    }))
+    await nextEdit.trigger(doc.bufnr, { autoTrigger: false })
+    await nextEdit.accept()
+    await nextEdit.accept()
+    assert.strictEqual(executed, 1)
+    assert.ok(doc.textDocument.getText().includes('\nnext'))
+  })
+
+  it('cancels pending requests and refuses stale preview application', async t => {
+    let doc = await setup(t)
+    register(doc, version => ({ textDocument: { uri: doc.uri, version }, range: Range.create(0, 0, 0, 0), newText: 'x' }))
+    let pending = nextEdit.trigger(doc.bufnr, { autoTrigger: false }, 100)
+    nextEdit.cancel()
+    assert.strictEqual(await pending, false)
+    await nextEdit.trigger(doc.bufnr, { autoTrigger: false })
+    await doc.applyEdits([TextEdit.insert(Position.create(0, 0), 'changed')])
+    assert.strictEqual(await nextEdit.accept(), false)
+  })
+
+  it('keeps the accept action with inline completion', async t => {
+    let doc = await setup(t)
+    register(doc, version => ({ textDocument: { uri: doc.uri, version }, range: Range.create(0, 0, 0, 0), newText: 'x' }))
+    let inline = getCurrentPlugin().handler.inlineCompletion
+    inline.session = {} as any
+    assert.strictEqual(await nextEdit.trigger(doc.bufnr, { autoTrigger: false }), true)
+    assert.strictEqual(nextEdit.visible(), false)
+    assert.strictEqual(await nextEdit.accept(), false)
+    inline.session = undefined
+    nextEdit.cancel()
+  })
+
+  it('reports final visibility state and disposes subscriptions', () => {
+    assert.strictEqual(nextEdit.visible(), false)
+    assert.strictEqual(nextEdit.available(), false)
+    nextEdit.dispose()
+  })
+})

--- a/src/__tests__/handler/nextEdit.test.ts
+++ b/src/__tests__/handler/nextEdit.test.ts
@@ -10,6 +10,7 @@ import workspace from '../../workspace'
 
 let nextEdit: NextEdit
 let disposables: Disposable[] = []
+let vtextCalls: any[][] = []
 
 before(() => {
   nextEdit = getCurrentPlugin().handler.nextEdit
@@ -20,6 +21,7 @@ afterEach(async t => {
   nextEdit.cancel()
   disposables.forEach(d => d.dispose())
   disposables = []
+  vtextCalls = []
 })
 
 async function setup(t: any, lines = ['one', 'two']): Promise<any> {
@@ -30,7 +32,10 @@ async function setup(t: any, lines = ['one', 'two']): Promise<any> {
   await workspace.nvim.call('cursor', [1, 1])
   let originalCall = workspace.nvim.call
   t.mock.method(workspace.nvim, 'call', ((method: string, ...args: any[]) => {
-    if (method === 'coc#vtext#add') return Promise.resolve(1)
+    if (method === 'coc#vtext#add') {
+      vtextCalls.push(args)
+      return Promise.resolve(1)
+    }
     return originalCall.apply(workspace.nvim, [method, ...args] as any)
   }) as any)
   return doc
@@ -70,6 +75,34 @@ describe('NextEdit handler', () => {
     assert.notStrictEqual(doc.textDocument.getText(), before)
     assert.strictEqual(doc.getline(0), 'Xone')
     assert.strictEqual(await nextEdit.accept(), false)
+  })
+
+  it('renders the preview at a 1 based byte column of the edit start', async t => {
+    let doc = await setup(t, ['中文one', 'two'])
+    // Byte column 7 is the character index 2 position (after 中文).
+    await workspace.nvim.call('cursor', [1, 7])
+    register(doc, version => ({
+      textDocument: { uri: doc.uri, version },
+      range: Range.create(0, 2, 0, 2),
+      newText: 'X'
+    }))
+    assert.strictEqual(await nextEdit.trigger(doc.bufnr, { autoTrigger: false }), true)
+    assert.strictEqual(nextEdit.visible(), true)
+    assert.strictEqual(vtextCalls.length, 1)
+    // byteIndex('中文one', 2) is 6; the virtual text column must be 7.
+    assert.strictEqual(vtextCalls[0][0][4].col, 7)
+  })
+
+  it('uses column 1 for an insertion at the start of a line', async t => {
+    let doc = await setup(t)
+    register(doc, version => ({
+      textDocument: { uri: doc.uri, version },
+      range: Range.create(0, 0, 0, 0),
+      newText: 'X'
+    }))
+    assert.strictEqual(await nextEdit.trigger(doc.bufnr, { autoTrigger: false }), true)
+    assert.strictEqual(nextEdit.visible(), true)
+    assert.strictEqual(vtextCalls[0][0][4].col, 1)
   })
 
   it('jumps before previewing an off-cursor candidate, then applies a deletion', async t => {
@@ -162,6 +195,51 @@ describe('NextEdit handler', () => {
     await nextEdit.trigger(doc.bufnr, { autoTrigger: false })
     await doc.applyEdits([TextEdit.insert(Position.create(0, 0), 'changed')])
     assert.strictEqual(await nextEdit.accept(), false)
+  })
+
+  it('invalidates a preview when the document changes with autoTrigger disabled', async t => {
+    let doc = await setup(t)
+    register(doc, version => ({ textDocument: { uri: doc.uri, version }, range: Range.create(0, 0, 0, 0), newText: 'x' }))
+    assert.strictEqual(await nextEdit.trigger(doc.bufnr, { autoTrigger: false }), true)
+    assert.strictEqual(nextEdit.visible(), true)
+    await doc.applyEdits([TextEdit.insert(Position.create(0, 0), 'changed')])
+    assert.strictEqual(nextEdit.available(), false)
+    assert.strictEqual(nextEdit.visible(), false)
+  })
+
+  it('aborts when the active buffer changed during the request', async t => {
+    let doc = await setup(t)
+    register(doc, version => ({ textDocument: { uri: doc.uri, version }, range: Range.create(0, 0, 0, 0), newText: 'x' }))
+    let originalEval = workspace.nvim.eval
+    t.mock.method(workspace.nvim, 'eval', ((expr: string) => {
+      if (typeof expr === 'string' && expr.includes('coc#cursor#position')) {
+        return Promise.resolve([doc.bufnr + 1, [0, 0]])
+      }
+      return originalEval.apply(workspace.nvim, [expr] as any)
+    }) as any)
+    assert.strictEqual(await nextEdit.trigger(doc.bufnr, { autoTrigger: false }), false)
+    assert.strictEqual(nextEdit.available(), false)
+  })
+
+  it('drops a render that finishes after cancel without orphan state', async t => {
+    let doc = await setup(t)
+    register(doc, version => ({ textDocument: { uri: doc.uri, version }, range: Range.create(0, 0, 0, 0), newText: 'x' }))
+    let originalCall = workspace.nvim.call
+    let resolveAdd: (value?: unknown) => void
+    t.mock.method(workspace.nvim, 'call', ((method: string, ...args: any[]) => {
+      if (method === 'coc#vtext#add') {
+        return new Promise(resolve => { resolveAdd = resolve })
+      }
+      return originalCall.apply(workspace.nvim, [method, ...args] as any)
+    }) as any)
+    let pending = nextEdit.trigger(doc.bufnr, { autoTrigger: false })
+    await shared.waitValue(() => resolveAdd != null, true)
+    nextEdit.cancel()
+    resolveAdd(1)
+    assert.strictEqual(await pending, true)
+    assert.strictEqual(nextEdit.available(), false)
+    assert.strictEqual((nextEdit as any).state, 'idle')
+    assert.strictEqual((nextEdit as any).renderedBufnrs.size, 0)
   })
 
   it('keeps the accept action with inline completion', async t => {

--- a/src/__tests__/unit/nextEditManager.test.ts
+++ b/src/__tests__/unit/nextEditManager.test.ts
@@ -1,0 +1,104 @@
+import { CancellationToken, CancellationTokenSource, InlineCompletionTriggerKind, Position, Range } from 'vscode-languageserver-protocol'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import '../../workspace'
+import NextEditManager from '../../provider/nextEditManager'
+
+const document = TextDocument.create('file:///tmp/next-edit.ts', 'typescript', 3, 'const value = 1\n')
+const context = { triggerKind: InlineCompletionTriggerKind.Automatic }
+const item = (newText: string, line = 0) => ({
+  textDocument: { uri: document.uri, version: document.version },
+  range: Range.create(line, 0, line, 0),
+  newText
+})
+
+describe('NextEditManager', () => {
+  it('reports provider availability and empty results', async () => {
+    let manager = new NextEditManager()
+    assert.strictEqual(manager.isEmpty, true)
+    let disposable = manager.register([{ language: '*' }], { provideNextEdits: () => undefined })
+    assert.strictEqual(manager.isEmpty, false)
+    assert.deepStrictEqual(await manager.provideNextEdits(document, Position.create(0, 0), context, CancellationToken.None), [])
+    disposable.dispose()
+    assert.strictEqual(manager.isEmpty, true)
+  })
+
+  it('returns empty for an unknown provider filter and ignores malformed items', async () => {
+    let manager = new NextEditManager()
+    manager.register([{ language: '*' }], {
+      provideNextEdits: () => [null as any, 1 as any, item('valid')]
+    })
+    assert.deepStrictEqual(await manager.provideNextEdits(document, Position.create(0, 0), { ...context, provider: 'missing' }, CancellationToken.None), [])
+    let result = await manager.provideNextEdits(document, Position.create(0, 0), context, CancellationToken.None)
+    assert.deepStrictEqual(result.map(o => o.newText), ['valid'])
+  })
+
+  it('normalizes results in registration order and deduplicates candidates', async () => {
+    let manager = new NextEditManager()
+    let first = item('first')
+    let second = item('second', 1)
+    let p1 = { provideNextEdits: async () => {
+      await new Promise(resolve => setTimeout(resolve, 20))
+      return { items: [first, second] }
+    } }
+    let p2 = { provideNextEdits: () => [second, item('third', 2)] }
+    manager.register([{ language: '*' }], p1)
+    manager.register([{ language: '*' }], p2)
+    let result = await manager.provideNextEdits(document, Position.create(0, 0), context, CancellationToken.None)
+    assert.deepStrictEqual(result.map(o => o.newText), ['first', 'second', 'third'])
+  })
+
+  it('returns no late results after cancellation', async () => {
+    let manager = new NextEditManager()
+    let resolve: (value: any) => void
+    manager.register([{ language: '*' }], {
+      provideNextEdits: () => new Promise(r => { resolve = r })
+    })
+    let source = new CancellationTokenSource()
+    let promise = manager.provideNextEdits(document, Position.create(0, 0), context, source.token)
+    source.cancel()
+    resolve([item('late')])
+    assert.deepStrictEqual(await promise, [])
+  })
+
+  it('does not call providers for an already cancelled token', async () => {
+    let manager = new NextEditManager()
+    let called = 0
+    manager.register([{ language: '*' }], { provideNextEdits: () => { called++; return [] } })
+    let source = new CancellationTokenSource()
+    source.cancel()
+    assert.deepStrictEqual(await manager.provideNextEdits(document, Position.create(0, 0), context, source.token), [])
+    assert.strictEqual(called, 0)
+  })
+
+  it('contains provider and shown callback errors', async () => {
+    let manager = new NextEditManager()
+    let fail = true
+    let provider = {
+      provideNextEdits: () => fail ? Promise.reject(new Error('provider failure')) : [item('owned')],
+      handleDidShowNextEdit: () => Promise.reject(new Error('callback failure'))
+    }
+    Object.defineProperty(provider, '__extensionName', { value: 'errors' })
+    manager.register([{ language: '*' }], provider)
+    let result = await manager.provideNextEdits(document, Position.create(0, 0), context, CancellationToken.None)
+    assert.deepStrictEqual(result, [])
+    manager.handleDidShow({} as any)
+    fail = false
+    let selected = await manager.provideNextEdits(document, Position.create(0, 0), { ...context, provider: 'errors' }, CancellationToken.None)
+    manager.handleDidShow(selected[0])
+    await new Promise(resolve => setImmediate(resolve))
+  })
+
+  it('filters providers and routes shown callbacks to the owner', async () => {
+    let manager = new NextEditManager()
+    let shown = 0
+    let provider = { provideNextEdits: () => [item('owned')], handleDidShowNextEdit: () => { shown++ } }
+    Object.defineProperty(provider, '__extensionName', { value: 'selected' })
+    manager.register([{ language: '*' }], provider)
+    manager.register([{ language: '*' }], { provideNextEdits: () => [item('other')] })
+    let result = await manager.provideNextEdits(document, Position.create(0, 0), { ...context, provider: 'selected' }, CancellationToken.None)
+    assert.deepStrictEqual(result.map(o => o.newText), ['owned'])
+    manager.handleDidShow(result[0])
+    await new Promise(resolve => setImmediate(resolve))
+    assert.strictEqual(shown, 1)
+  })
+})

--- a/src/__tests__/unit/nextEditManager.test.ts
+++ b/src/__tests__/unit/nextEditManager.test.ts
@@ -90,6 +90,32 @@ describe('NextEditManager', () => {
     assert.deepStrictEqual(await promise, [])
   })
 
+  it('returns promptly when a provider ignores cancellation', async () => {
+    let manager = new NextEditManager()
+    manager.register([{ language: '*' }], { provideNextEdits: () => new Promise(() => {}) })
+    let source = new CancellationTokenSource()
+    let promise = manager.provideNextEdits(document, Position.create(0, 0), context, source.token)
+    source.cancel()
+    assert.deepStrictEqual(await Promise.race([
+      promise,
+      new Promise(resolve => setTimeout(() => resolve('timed out'), 50))
+    ]), [])
+  })
+
+  it('does not invoke a named provider outside its document selector', async () => {
+    let manager = new NextEditManager()
+    let called = 0
+    let wrong = { provideNextEdits: () => { called++; return [item('wrong language')] } }
+    let matching = { provideNextEdits: () => [item('matching language')] }
+    Object.defineProperty(wrong, '__extensionName', { value: 'selected' })
+    Object.defineProperty(matching, '__extensionName', { value: 'selected' })
+    manager.register([{ language: 'javascript' }], wrong)
+    manager.register([{ language: 'typescript' }], matching)
+    let result = await manager.provideNextEdits(document, Position.create(0, 0), { ...context, provider: 'selected' }, CancellationToken.None)
+    assert.deepStrictEqual(result.map(o => o.newText), ['matching language'])
+    assert.strictEqual(called, 0)
+  })
+
   it('does not call providers for an already cancelled token', async () => {
     let manager = new NextEditManager()
     let called = 0

--- a/src/__tests__/unit/nextEditManager.test.ts
+++ b/src/__tests__/unit/nextEditManager.test.ts
@@ -1,5 +1,6 @@
 import { CancellationToken, CancellationTokenSource, InlineCompletionTriggerKind, Position, Range } from 'vscode-languageserver-protocol'
 import { TextDocument } from 'vscode-languageserver-textdocument'
+import { CancellationError } from '../../util/errors'
 import '../../workspace'
 import NextEditManager from '../../provider/nextEditManager'
 
@@ -30,6 +31,35 @@ describe('NextEditManager', () => {
     assert.deepStrictEqual(await manager.provideNextEdits(document, Position.create(0, 0), { ...context, provider: 'missing' }, CancellationToken.None), [])
     let result = await manager.provideNextEdits(document, Position.create(0, 0), context, CancellationToken.None)
     assert.deepStrictEqual(result.map(o => o.newText), ['valid'])
+  })
+
+  it('skips items without a textDocument instead of failing the request', async () => {
+    let manager = new NextEditManager()
+    manager.register([{ language: '*' }], {
+      provideNextEdits: () => [{ newText: 'missing' } as any, { textDocument: null, range: Range.create(0, 0, 0, 0), newText: 'null' } as any, item('valid')]
+    })
+    let result = await manager.provideNextEdits(document, Position.create(0, 0), context, CancellationToken.None)
+    assert.deepStrictEqual(result.map(o => o.newText), ['valid'])
+  })
+
+  it('keeps other provider results when one provider fails with a cancellation error', async () => {
+    let manager = new NextEditManager()
+    manager.register([{ language: '*' }], {
+      provideNextEdits: () => { throw new CancellationError() }
+    })
+    manager.register([{ language: '*' }], { provideNextEdits: () => [item('survivor')] })
+    let result = await manager.provideNextEdits(document, Position.create(0, 0), context, CancellationToken.None)
+    assert.deepStrictEqual(result.map(o => o.newText), ['survivor'])
+  })
+
+  it('contains synchronous handleDidShowNextEdit exceptions', async () => {
+    let manager = new NextEditManager()
+    manager.register([{ language: '*' }], {
+      provideNextEdits: () => [item('owned')],
+      handleDidShowNextEdit: () => { throw new Error('sync failure') }
+    })
+    let result = await manager.provideNextEdits(document, Position.create(0, 0), context, CancellationToken.None)
+    assert.doesNotThrow(() => manager.handleDidShow(result[0]))
   })
 
   it('normalizes results in registration order and deduplicates candidates', async () => {

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -28,6 +28,7 @@ import Highlights from './highlights'
 import HoverHandler from './hover'
 import InlayHintHandler from './inlayHint/index'
 import InlineCompletion, { InlineSuggestOption } from './inline'
+import NextEdit from './nextEdit'
 import LinkedEditingHandler from './linkedEditing'
 import Links from './links'
 import Locations from './locations'
@@ -70,6 +71,7 @@ export default class Handler implements HandlerDelegate {
   public readonly callHierarchy: CallHierarchy
   public readonly typeHierarchy: TypeHierarchy
   public readonly inlineCompletion: InlineCompletion
+  public readonly nextEdit: NextEdit
   public readonly semanticHighlighter: SemanticTokens
   public readonly workspace: WorkspaceHandler
   public readonly linkedEditingHandler: LinkedEditingHandler
@@ -108,6 +110,7 @@ export default class Handler implements HandlerDelegate {
     this.linkedEditingHandler = new LinkedEditingHandler(nvim, this)
     this.inlayHintHandler = new InlayHintHandler(nvim, this)
     this.inlineCompletion = new InlineCompletion(nvim, this)
+    this.nextEdit = new NextEdit(nvim, this, this.inlineCompletion)
     this.disposables.push({
       dispose: () => {
         this.callHierarchy.dispose()
@@ -122,6 +125,7 @@ export default class Handler implements HandlerDelegate {
         this.documentHighlighter.dispose()
         this.semanticHighlighter.dispose()
         this.inlineCompletion.dispose()
+        this.nextEdit.dispose()
       }
     })
     this.registerCommands()
@@ -182,6 +186,10 @@ export default class Handler implements HandlerDelegate {
     this.register('editor.action.triggerInlineCompletion', async (option?: InlineSuggestOption) => {
       let bufnr = await this.nvim.eval('bufnr("%")') as number
       return await this.inlineCompletion.trigger(bufnr, option)
+    })
+    this.register('editor.action.triggerNextEdit', async (option?: { provider?: string; autoTrigger?: boolean }) => {
+      let bufnr = await this.nvim.eval('bufnr("%")') as number
+      return this.nextEdit.trigger(bufnr, { ...option, autoTrigger: false })
     })
   }
 

--- a/src/handler/inline.ts
+++ b/src/handler/inline.ts
@@ -12,7 +12,7 @@ import { SnippetParser } from '../snippets/parser'
 import { defaultValue, disposeAll, waitWithToken } from '../util'
 import { onUnexpectedError } from '../util/errors'
 import { comparePosition, emptyRange, getEnd, positionInRange } from '../util/position'
-import { CancellationTokenSource, Disposable, InlineCompletionItem } from '../util/protocol'
+import { CancellationTokenSource, Disposable, Emitter, Event, InlineCompletionItem } from '../util/protocol'
 import { byteIndex, toText } from '../util/string'
 import window from '../window'
 import workspace from '../workspace'
@@ -140,6 +140,8 @@ export class InlineSession {
 
 export default class InlineCompletion {
   public session: InlineSession | undefined
+  private readonly _onDidChangeVisibility = new Emitter<boolean>()
+  public readonly onDidChangeVisibility: Event<boolean> = this._onDidChangeVisibility.event
   private bufnr: number
   private tokenSource: CancellationTokenSource
   private disposables: Disposable[] = []
@@ -295,6 +297,7 @@ export default class InlineCompletion {
       return false
     }
     this.session = new InlineSession(bufnr, cursor, items)
+    this._onDidChangeVisibility.fire(true)
     await this.insertVtext(items[0])
     return true
   }
@@ -398,6 +401,7 @@ export default class InlineCompletion {
     } else {
       this.session.clearNamespace()
       this.session = undefined
+      this._onDidChangeVisibility.fire(false)
     }
   }
 
@@ -410,11 +414,13 @@ export default class InlineCompletion {
     if (this.session) {
       this.session.clearNamespace()
       this.session = undefined
+      this._onDidChangeVisibility.fire(false)
     }
     this.bufnr = undefined
   }
 
   public dispose(): void {
+    this._onDidChangeVisibility.dispose()
     disposeAll(this.disposables)
   }
 }

--- a/src/handler/nextEdit.ts
+++ b/src/handler/nextEdit.ts
@@ -15,7 +15,7 @@ import Document from '../model/document'
 import { HandlerDelegate } from './types'
 
 const logger = createLogger('handler-next-edit')
-const NAMESPACE = 'nextEdit'
+const NAMESPACE = 'coc-nextEdit'
 
 export type NextEditState = 'idle' | 'waiting' | 'requesting' | 'ready' | 'preview' | 'applying'
 interface SourceSnapshot { uri: string; version: number; position: Position; bufnr: number }
@@ -53,6 +53,7 @@ export default class NextEdit {
   constructor(private nvim: Neovim, private handler: HandlerDelegate, private inline: { session: unknown; onDidChangeVisibility: (cb: (visible: boolean) => void) => Disposable }) {
     this.loadConfiguration()
     workspace.onDidChangeConfiguration(this.loadConfiguration, this, this.disposables)
+    window.onDidChangeActiveTextEditor(this.loadConfiguration, this, this.disposables)
     workspace.onDidChangeTextDocument(e => {
       // Invalidate the current session on document changes even when auto
       // triggering is disabled, so stale previews are not kept around.
@@ -88,7 +89,8 @@ export default class NextEdit {
     await this.clearRender()
     let session = this.session
     if (!session || this.inline.session) return
-    let item = session.items[session.index]
+    let index = session.index
+    let item = session.items[index]
     let target = workspace.getDocument(item.textDocument.uri)
     if (!target || target.bufnr !== window.activeTextEditor?.bufnr || !this.preview) {
       this.state = 'ready'
@@ -108,11 +110,11 @@ export default class NextEdit {
     // while the request is in flight still clears this virtual text.
     this.renderedBufnrs.add(target.bufnr)
     await this.nvim.call('coc#vtext#add', [target.bufnr, this.namespace, line, [[text, item.newText ? 'CocNextEditInsert' : 'CocNextEditDelete']], { col }])
-    if (this.session !== session) return
+    if (this.session !== session || session.index !== index) return
     workspace.nvim.createBuffer(target.bufnr).setVar('coc_next_edit_state', 2, true)
     this.state = 'preview'
-    if (!session.shownIndexes.has(session.index)) {
-      session.shownIndexes.add(session.index)
+    if (!session.shownIndexes.has(index)) {
+      session.shownIndexes.add(index)
       languages.nextEditManager.handleDidShow(item)
     }
   }

--- a/src/handler/nextEdit.ts
+++ b/src/handler/nextEdit.ts
@@ -2,11 +2,10 @@
 import { Neovim } from '@chemzqm/neovim'
 import { InlineCompletionTriggerKind, Position, Range, TextEdit } from 'vscode-languageserver-types'
 import commands from '../commands'
-import events from '../events'
 import languages, { ProviderName } from '../languages'
 import { createLogger } from '../logger'
 import { CancellationTokenSource, Disposable } from '../util/protocol'
-import { waitWithToken } from '../util'
+import { wait, waitWithToken } from '../util'
 import { byteIndex } from '../util/string'
 import { comparePosition, getEnd, positionInRange } from '../util/position'
 import window from '../window'
@@ -21,7 +20,7 @@ const NAMESPACE = 'nextEdit'
 export type NextEditState = 'idle' | 'waiting' | 'requesting' | 'ready' | 'preview' | 'applying'
 interface SourceSnapshot { uri: string; version: number; position: Position; bufnr: number }
 interface PreviewSnapshot { uri: string; version: number; range: Range; originalText: string }
-interface Session { source: SourceSnapshot; items: NextEditItem[]; index: number; shownIndexes: Set<number>; originWinid: number; originUri: string; originPosition: Position }
+interface Session { source: SourceSnapshot; items: NextEditItem[]; index: number; shownIndexes: Set<number> }
 
 function validPosition(doc: Document, pos: Position): boolean {
   return Number.isInteger(pos.line) && Number.isInteger(pos.character) && pos.line >= 0 && pos.line < doc.textDocument.lineCount
@@ -55,6 +54,9 @@ export default class NextEdit {
     this.loadConfiguration()
     workspace.onDidChangeConfiguration(this.loadConfiguration, this, this.disposables)
     workspace.onDidChangeTextDocument(e => {
+      // Invalidate the current session on document changes even when auto
+      // triggering is disabled, so stale previews are not kept around.
+      if (!this.applying && this.session && e.bufnr === this.session.source.bufnr) this.cancel()
       if (this.applying || !this.config.autoTrigger || e.bufnr !== window.activeTextEditor?.bufnr) return
       let doc = workspace.getDocument(e.bufnr)
       if (doc?.attached && languages.hasProvider(ProviderName.NextEdit, doc.textDocument)) this.trigger(e.bufnr, { autoTrigger: true }, this.config.triggerWait).catch(logger.error)
@@ -84,25 +86,33 @@ export default class NextEdit {
 
   private async render(): Promise<void> {
     await this.clearRender()
-    if (!this.session || this.inline.session) return
-    let item = this.session.items[this.session.index]
+    let session = this.session
+    if (!session || this.inline.session) return
+    let item = session.items[session.index]
     let target = workspace.getDocument(item.textDocument.uri)
     if (!target || target.bufnr !== window.activeTextEditor?.bufnr || !this.preview) {
       this.state = 'ready'
-      this.renderedBufnrs.add(this.session.source.bufnr)
-      workspace.nvim.createBuffer(this.session.source.bufnr).setVar('coc_next_edit_state', 1, true)
+      this.renderedBufnrs.add(session.source.bufnr)
+      workspace.nvim.createBuffer(session.source.bufnr).setVar('coc_next_edit_state', 1, true)
       return
     }
-    if (this.namespace == null) this.namespace = await this.nvim.createNamespace(NAMESPACE) as number
+    if (this.namespace == null) {
+      this.namespace = await this.nvim.createNamespace(NAMESPACE) as number
+      if (this.session !== session) return
+    }
     let text = item.newText.length ? `Next edit: ${item.newText.replace(/\n/g, ' ↵ ')}` : 'Next edit: delete'
     let line = item.range.start.line
-    let col = byteIndex(target.getline(line), item.range.start.character)
-    await this.nvim.call('coc#vtext#add', [target.bufnr, this.namespace, line, [[text, item.newText ? 'CocNextEditInsert' : 'CocNextEditDelete']], { col }])
+    // coc#vtext#add expects a 1 based byte column, same as inline completion.
+    let col = byteIndex(target.getline(line), item.range.start.character) + 1
+    // Track the buffer before the RPC round trip so a cancel that happens
+    // while the request is in flight still clears this virtual text.
     this.renderedBufnrs.add(target.bufnr)
+    await this.nvim.call('coc#vtext#add', [target.bufnr, this.namespace, line, [[text, item.newText ? 'CocNextEditInsert' : 'CocNextEditDelete']], { col }])
+    if (this.session !== session) return
     workspace.nvim.createBuffer(target.bufnr).setVar('coc_next_edit_state', 2, true)
     this.state = 'preview'
-    if (!this.session.shownIndexes.has(this.session.index)) {
-      this.session.shownIndexes.add(this.session.index)
+    if (!session.shownIndexes.has(session.index)) {
+      session.shownIndexes.add(session.index)
       languages.nextEditManager.handleDidShow(item)
     }
   }
@@ -143,14 +153,18 @@ export default class NextEdit {
     if (delay) await waitWithToken(delay, source.token)
     if (source.token.isCancellationRequested || this.source !== requestId) return false
     await doc.synchronize()
-    let [pos, winid] = await this.nvim.eval('[coc#cursor#position(),win_getid()]') as [[number, number], number]
+    let [nr, pos] = await this.nvim.eval('[bufnr("%"),coc#cursor#position()]') as [number, [number, number]]
+    if (nr !== bufnr) {
+      this.cancel()
+      return false
+    }
     let position = Position.create(pos[0], pos[1])
     let items = await languages.provideNextEdits(doc.textDocument, position, { provider: option.provider, triggerKind: option.autoTrigger ? InlineCompletionTriggerKind.Automatic : InlineCompletionTriggerKind.Invoked }, source.token)
     if (source.token.isCancellationRequested || this.source !== requestId) return false
     this.source = undefined
     let valid = items.filter(item => this.validCandidate(item))
     if (!valid.length) { this.cancel(); return false }
-    this.session = { source: { uri: doc.uri, version: doc.version, position, bufnr }, items: valid, index: 0, shownIndexes: new Set(), originWinid: winid, originUri: doc.uri, originPosition: position }
+    this.session = { source: { uri: doc.uri, version: doc.version, position, bufnr }, items: valid, index: 0, shownIndexes: new Set() }
     this.state = 'ready'
     let selected = valid[0]
     let target = workspace.getDocument(selected.textDocument.uri)
@@ -164,11 +178,13 @@ export default class NextEdit {
 
   public async accept(): Promise<boolean> {
     if (this.inline.session || !this.session || (this.state !== 'ready' && this.state !== 'preview')) return false
-    let item = this.session.items[this.session.index]
+    let session = this.session
+    let item = session.items[session.index]
     if (this.state === 'ready') {
       await workspace.jumpTo(item.textDocument.uri, item.range.start)
-      let checked = this.validate(item)
-      if (!checked) { this.cancel(); return false }
+      if (this.session !== session) { this.cancel(); return false }
+      let checked = await this.waitForValidate(item)
+      if (!checked || this.session !== session) { this.cancel(); return false }
       this.preview = { uri: checked.doc.uri, version: checked.doc.version, range: item.range, originalText: checked.originalText }
       await this.render()
       return true
@@ -188,6 +204,20 @@ export default class NextEdit {
     }
     this.cancel()
     return true
+  }
+
+  /**
+   * Validate a candidate, waiting briefly for the target document to attach
+   * after it was opened by workspace.jumpTo.
+   */
+  private async waitForValidate(item: NextEditItem): Promise<{ doc: Document; originalText: string } | undefined> {
+    let deadline = Date.now() + 300
+    let checked = this.validate(item)
+    while (!checked && Date.now() < deadline) {
+      await wait(20)
+      checked = this.validate(item)
+    }
+    return checked
   }
 
   public cancel(): void {

--- a/src/handler/nextEdit.ts
+++ b/src/handler/nextEdit.ts
@@ -1,0 +1,217 @@
+'use strict'
+import { Neovim } from '@chemzqm/neovim'
+import { InlineCompletionTriggerKind, Position, Range, TextEdit } from 'vscode-languageserver-types'
+import commands from '../commands'
+import events from '../events'
+import languages, { ProviderName } from '../languages'
+import { createLogger } from '../logger'
+import { CancellationTokenSource, Disposable } from '../util/protocol'
+import { waitWithToken } from '../util'
+import { byteIndex } from '../util/string'
+import { comparePosition, getEnd, positionInRange } from '../util/position'
+import window from '../window'
+import workspace from '../workspace'
+import { NextEditContext, NextEditItem } from '../provider'
+import Document from '../model/document'
+import { HandlerDelegate } from './types'
+
+const logger = createLogger('handler-next-edit')
+const NAMESPACE = 'nextEdit'
+
+export type NextEditState = 'idle' | 'waiting' | 'requesting' | 'ready' | 'preview' | 'applying'
+interface SourceSnapshot { uri: string; version: number; position: Position; bufnr: number }
+interface PreviewSnapshot { uri: string; version: number; range: Range; originalText: string }
+interface Session { source: SourceSnapshot; items: NextEditItem[]; index: number; shownIndexes: Set<number>; originWinid: number; originUri: string; originPosition: Position }
+
+function validPosition(doc: Document, pos: Position): boolean {
+  return Number.isInteger(pos.line) && Number.isInteger(pos.character) && pos.line >= 0 && pos.line < doc.textDocument.lineCount
+    && pos.character >= 0 && pos.character <= doc.textDocument.lineAt(pos.line).text.length
+}
+
+function validRange(doc: Document, range: Range): boolean {
+  return !!range && validPosition(doc, range.start) && validPosition(doc, range.end)
+    && (range.start.line < range.end.line || (range.start.line === range.end.line && range.start.character <= range.end.character))
+}
+
+function validRangeShape(range: Range): boolean {
+  return !!range && Number.isInteger(range.start?.line) && Number.isInteger(range.start?.character)
+    && Number.isInteger(range.end?.line) && Number.isInteger(range.end?.character)
+    && range.start.line >= 0 && range.start.character >= 0 && range.end.line >= 0 && range.end.character >= 0
+    && (range.start.line < range.end.line || (range.start.line === range.end.line && range.start.character <= range.end.character))
+}
+
+export default class NextEdit {
+  private state: NextEditState = 'idle'
+  private session: Session | undefined
+  private preview: PreviewSnapshot | undefined
+  private source: CancellationTokenSource | undefined
+  private namespace: number | undefined
+  private renderedBufnrs = new Set<number>()
+  private applying = false
+  private disposables: Disposable[] = []
+  private config = { autoTrigger: true, triggerWait: 150 }
+
+  constructor(private nvim: Neovim, private handler: HandlerDelegate, private inline: { session: unknown; onDidChangeVisibility: (cb: (visible: boolean) => void) => Disposable }) {
+    this.loadConfiguration()
+    workspace.onDidChangeConfiguration(this.loadConfiguration, this, this.disposables)
+    workspace.onDidChangeTextDocument(e => {
+      if (this.applying || !this.config.autoTrigger || e.bufnr !== window.activeTextEditor?.bufnr) return
+      let doc = workspace.getDocument(e.bufnr)
+      if (doc?.attached && languages.hasProvider(ProviderName.NextEdit, doc.textDocument)) this.trigger(e.bufnr, { autoTrigger: true }, this.config.triggerWait).catch(logger.error)
+    }, null, this.disposables)
+    workspace.onDidCloseTextDocument(e => {
+      if (e.bufnr === this.session?.source.bufnr) this.cancel()
+    }, null, this.disposables)
+    this.disposables.push(this.inline.onDidChangeVisibility(() => { this.render().catch(logger.error) }))
+  }
+
+  private loadConfiguration(): void {
+    let config = workspace.getConfiguration('nextEdit', window.activeTextEditor?.document)
+    this.config.autoTrigger = config.get('autoTrigger', true)
+    this.config.triggerWait = config.get('triggerWait', 150)
+  }
+
+  private async clearRender(): Promise<void> {
+    if (this.namespace != null) {
+      for (let bufnr of this.renderedBufnrs) {
+        workspace.nvim.createBuffer(bufnr).clearNamespace(this.namespace)
+        workspace.nvim.createBuffer(bufnr).setVar('coc_next_edit_state', 0, true)
+      }
+    }
+    this.renderedBufnrs.clear()
+    if (this.session) workspace.nvim.createBuffer(this.session.source.bufnr).setVar('coc_next_edit_state', 0, true)
+  }
+
+  private async render(): Promise<void> {
+    await this.clearRender()
+    if (!this.session || this.inline.session) return
+    let item = this.session.items[this.session.index]
+    let target = workspace.getDocument(item.textDocument.uri)
+    if (!target || target.bufnr !== window.activeTextEditor?.bufnr || !this.preview) {
+      this.state = 'ready'
+      this.renderedBufnrs.add(this.session.source.bufnr)
+      workspace.nvim.createBuffer(this.session.source.bufnr).setVar('coc_next_edit_state', 1, true)
+      return
+    }
+    if (this.namespace == null) this.namespace = await this.nvim.createNamespace(NAMESPACE) as number
+    let text = item.newText.length ? `Next edit: ${item.newText.replace(/\n/g, ' ↵ ')}` : 'Next edit: delete'
+    let line = item.range.start.line
+    let col = byteIndex(target.getline(line), item.range.start.character)
+    await this.nvim.call('coc#vtext#add', [target.bufnr, this.namespace, line, [[text, item.newText ? 'CocNextEditInsert' : 'CocNextEditDelete']], { col }])
+    this.renderedBufnrs.add(target.bufnr)
+    workspace.nvim.createBuffer(target.bufnr).setVar('coc_next_edit_state', 2, true)
+    this.state = 'preview'
+    if (!this.session.shownIndexes.has(this.session.index)) {
+      this.session.shownIndexes.add(this.session.index)
+      languages.nextEditManager.handleDidShow(item)
+    }
+  }
+
+  private validate(item: NextEditItem): { doc: Document; originalText: string } | undefined {
+    if (!item?.textDocument || !Number.isInteger(item.textDocument.version) || typeof item.newText !== 'string') return
+    let doc = workspace.getDocument(item.textDocument.uri)
+    if (!doc?.attached || doc.version !== item.textDocument.version || !validRange(doc, item.range)) return
+    let originalText = doc.textDocument.getText(item.range)
+    let newText = item.newText.replace(/\r\n?/g, '\n')
+    if (originalText === newText) return
+    item.newText = newText
+    return { doc, originalText }
+  }
+
+  private validCandidate(item: NextEditItem): boolean {
+    if (!item?.textDocument || !Number.isInteger(item.textDocument.version) || typeof item.newText !== 'string' || !validRangeShape(item.range)) return false
+    let doc = workspace.getDocument(item.textDocument.uri)
+    if (!doc || !doc.attached) {
+      item.newText = item.newText.replace(/\r\n?/g, '\n')
+      return true
+    }
+    return !!this.validate(item)
+  }
+
+  public async trigger(bufnr: number, option: { provider?: string; autoTrigger?: boolean } = {}, delay = 0): Promise<boolean> {
+    this.cancel()
+    let doc = workspace.getDocument(bufnr)
+    if (!doc?.attached || !languages.hasProvider(ProviderName.NextEdit, doc.textDocument)) return false
+    this.state = delay ? 'waiting' : 'requesting'
+    let source = this.source = new CancellationTokenSource()
+    let requestId = source
+    let disable = await this.nvim.createBuffer(bufnr).getVar('coc_next_edit_disable') as number
+    if (disable === 1) {
+      this.cancel()
+      return false
+    }
+    if (delay) await waitWithToken(delay, source.token)
+    if (source.token.isCancellationRequested || this.source !== requestId) return false
+    await doc.synchronize()
+    let [pos, winid] = await this.nvim.eval('[coc#cursor#position(),win_getid()]') as [[number, number], number]
+    let position = Position.create(pos[0], pos[1])
+    let items = await languages.provideNextEdits(doc.textDocument, position, { provider: option.provider, triggerKind: option.autoTrigger ? InlineCompletionTriggerKind.Automatic : InlineCompletionTriggerKind.Invoked }, source.token)
+    if (source.token.isCancellationRequested || this.source !== requestId) return false
+    this.source = undefined
+    let valid = items.filter(item => this.validCandidate(item))
+    if (!valid.length) { this.cancel(); return false }
+    this.session = { source: { uri: doc.uri, version: doc.version, position, bufnr }, items: valid, index: 0, shownIndexes: new Set(), originWinid: winid, originUri: doc.uri, originPosition: position }
+    this.state = 'ready'
+    let selected = valid[0]
+    let target = workspace.getDocument(selected.textDocument.uri)
+    if (target?.bufnr === bufnr && validPosition(target, selected.range.start) && (positionInRange(position, selected.range) === 0 || comparePosition(position, selected.range.start) === 0)) {
+      let checked = this.validate(selected)
+      if (checked) this.preview = { uri: target.uri, version: target.version, range: selected.range, originalText: checked.originalText }
+    }
+    await this.render()
+    return true
+  }
+
+  public async accept(): Promise<boolean> {
+    if (this.inline.session || !this.session || (this.state !== 'ready' && this.state !== 'preview')) return false
+    let item = this.session.items[this.session.index]
+    if (this.state === 'ready') {
+      await workspace.jumpTo(item.textDocument.uri, item.range.start)
+      let checked = this.validate(item)
+      if (!checked) { this.cancel(); return false }
+      this.preview = { uri: checked.doc.uri, version: checked.doc.version, range: item.range, originalText: checked.originalText }
+      await this.render()
+      return true
+    }
+    this.state = 'applying'
+    let checked = this.validate(item)
+    if (!checked || !this.preview || this.preview.uri !== checked.doc.uri || this.preview.version !== checked.doc.version || this.preview.originalText !== checked.originalText) { this.cancel(); return false }
+    this.applying = true
+    try {
+      await checked.doc.applyEdits([TextEdit.replace(item.range, item.newText)], false, false)
+      await window.moveTo(getEnd(item.range.start, item.newText))
+    } finally {
+      this.applying = false
+    }
+    if (item.command) {
+      try { await commands.execute(item.command) } catch (err) { logger.error(`Error on execute command "${item.command.command}"`, err) }
+    }
+    this.cancel()
+    return true
+  }
+
+  public cancel(): void {
+    if (this.source) { this.source.cancel(); this.source.dispose(); this.source = undefined }
+    void this.clearRender()
+    this.session = undefined
+    this.preview = undefined
+    this.state = 'idle'
+  }
+  public async next(): Promise<void> { await this.switchCandidate(1) }
+  public async prev(): Promise<void> { await this.switchCandidate(-1) }
+  private async switchCandidate(delta: number): Promise<void> {
+    if (!this.session || this.session.items.length < 2) return
+    this.session.index = (this.session.index + delta + this.session.items.length) % this.session.items.length
+    this.preview = undefined
+    let item = this.session.items[this.session.index]
+    let target = workspace.getDocument(item.textDocument.uri)
+    if (target?.bufnr === this.session.source.bufnr && (positionInRange(this.session.source.position, item.range) === 0 || comparePosition(this.session.source.position, item.range.start) === 0)) {
+      let checked = this.validate(item)
+      if (checked) this.preview = { uri: checked.doc.uri, version: checked.doc.version, range: item.range, originalText: checked.originalText }
+    }
+    await this.render()
+  }
+  public available(): boolean { return this.state === 'ready' || this.state === 'preview' }
+  public visible(): boolean { return this.state === 'preview' }
+  public dispose(): void { this.cancel(); for (let d of this.disposables) d.dispose() }
+}

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -5,7 +5,7 @@ import { CallHierarchyIncomingCall, CallHierarchyItem, CallHierarchyOutgoingCall
 import type { Sources } from './completion/sources'
 import DiagnosticCollection from './diagnostic/collection'
 import diagnosticManager from './diagnostic/manager'
-import { CallHierarchyProvider, CodeActionProvider, CodeLensProvider, CompletionItemProvider, DeclarationProvider, DefinitionProvider, DocumentColorProvider, DocumentFormattingEditProvider, DocumentHighlightProvider, DocumentLinkProvider, DocumentRangeFormattingEditProvider, DocumentRangeSemanticTokensProvider, DocumentSelector, DocumentSemanticTokensProvider, DocumentSymbolProvider, DocumentSymbolProviderMetadata, FoldingContext, FoldingRangeProvider, HoverProvider, ImplementationProvider, InlayHintsProvider, InlineCompletionItemProvider, InlineValuesProvider, LinkedEditingRangeProvider, OnTypeFormattingEditProvider, ReferenceContext, ReferenceProvider, RenameProvider, SelectionRangeProvider, SignatureHelpProvider, TypeDefinitionProvider, TypeHierarchyProvider, WorkspaceSymbolProvider } from './provider'
+import { CallHierarchyProvider, CodeActionProvider, CodeLensProvider, CompletionItemProvider, DeclarationProvider, DefinitionProvider, DocumentColorProvider, DocumentFormattingEditProvider, DocumentHighlightProvider, DocumentLinkProvider, DocumentRangeFormattingEditProvider, DocumentRangeSemanticTokensProvider, DocumentSelector, DocumentSemanticTokensProvider, DocumentSymbolProvider, DocumentSymbolProviderMetadata, FoldingContext, FoldingRangeProvider, HoverProvider, ImplementationProvider, InlayHintsProvider, InlineCompletionItemProvider, InlineValuesProvider, LinkedEditingRangeProvider, NextEditContext, NextEditItem, NextEditProvider, OnTypeFormattingEditProvider, ReferenceContext, ReferenceProvider, RenameProvider, SelectionRangeProvider, SignatureHelpProvider, TypeDefinitionProvider, TypeHierarchyProvider, WorkspaceSymbolProvider } from './provider'
 import CallHierarchyManager from './provider/callHierarchyManager'
 import CodeActionManager from './provider/codeActionManager'
 import CodeLensManager from './provider/codeLensManager'
@@ -22,6 +22,7 @@ import HoverManager from './provider/hoverManager'
 import ImplementationManager from './provider/implementationManager'
 import InlayHintManger, { InlayHintWithProvider } from './provider/inlayHintManager'
 import InlineCompletionItemManager, { ExtendedInlineContext } from './provider/inlineCompletionItemManager'
+import NextEditManager from './provider/nextEditManager'
 import InlineValueManager from './provider/inlineValueManager'
 import LinkedEditingRangeManager from './provider/linkedEditingRangeManager'
 import OnTypeFormatManager from './provider/onTypeFormatManager'
@@ -79,6 +80,7 @@ export enum ProviderName {
   InlayHint = 'inlayHint',
   InlineValue = 'inlineValue',
   InlineCompletion = 'inlineCompletion',
+  NextEdit = 'nextEdit',
   TypeHierarchy = 'typeHierarchy'
 }
 
@@ -143,6 +145,8 @@ class Languages {
    * @internal
    */
   public inlineCompletionItemManager = new InlineCompletionItemManager()
+  /** @internal */
+  public nextEditManager = new NextEditManager()
   private inlineValueManager = new InlineValueManager()
   /**
    * @internal
@@ -206,6 +210,10 @@ class Languages {
 
   public registerInlineCompletionItemProvider(selector: DocumentSelector, provider: InlineCompletionItemProvider): Disposable {
     return this.inlineCompletionItemManager.register(selector, provider)
+  }
+
+  public registerNextEditProvider(selector: DocumentSelector, provider: NextEditProvider): Disposable {
+    return this.nextEditManager.register(selector, provider)
   }
 
   public registerCodeActionProvider(selector: DocumentSelector, provider: CodeActionProvider, clientId: string | undefined, codeActionKinds?: CodeActionKind[]): Disposable {
@@ -542,6 +550,11 @@ class Languages {
   public async provideInlineCompletionItems(document: TextDocument, position: Position, context: ExtendedInlineContext, token: CancellationToken): Promise<InlineCompletionItem[]> {
     return this.inlineCompletionItemManager.provideInlineCompletionItems(document, position, context, token)
   }
+
+  /** @internal */
+  public async provideNextEdits(document: TextDocument, position: Position, context: NextEditContext & { provider?: string }, token: CancellationToken): Promise<NextEditItem[]> {
+    return this.nextEditManager.provideNextEdits(document, position, context, token)
+  }
   /**
    * @internal
    */
@@ -777,6 +790,8 @@ class Languages {
         return this.inlayHintManager.hasProvider(document)
       case ProviderName.InlineCompletion:
         return this.inlineCompletionItemManager.hasProvider(document)
+      case ProviderName.NextEdit:
+        return this.nextEditManager.hasProvider(document)
       case ProviderName.InlineValue:
         return this.inlineValueManager.hasProvider(document)
       case ProviderName.TypeHierarchy:

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -189,6 +189,15 @@ export default class Plugin {
     this.addAction('inlineAccept', (bufnr: number, kind?: AcceptKind) => this.handler.inlineCompletion.accept(bufnr, kind))
     this.addAction('inlineNext', (bufnr: number) => this.handler.inlineCompletion.next(bufnr))
     this.addAction('inlinePrev', (bufnr: number) => this.handler.inlineCompletion.prev(bufnr))
+    this.addAction('nextEditTrigger', async (option?: { provider?: string; autoTrigger?: boolean }) => {
+      let bufnr = await this.nvim.eval('bufnr("%")') as number
+      return this.handler.nextEdit.trigger(bufnr, { ...option, autoTrigger: false })
+    })
+    this.addAction('nextEditAccept', () => this.handler.nextEdit.accept())
+    this.addAction('nextEditCancel', () => this.handler.nextEdit.cancel())
+    this.addAction('nextEditNext', () => this.handler.nextEdit.next())
+    this.addAction('nextEditPrev', () => this.handler.nextEdit.prev())
+    this.addAction('nextEditAvailable', () => this.handler.nextEdit.available())
     this.addAction('notificationHistory', () => window.notifications.history)
   }
 

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -1,5 +1,6 @@
 'use strict'
 import type { CallHierarchyIncomingCall, DocumentFilter, CallHierarchyItem, CallHierarchyOutgoingCall, CancellationToken, CodeAction, CodeActionContext, CodeActionKind, CodeLens, Color, ColorInformation, ColorPresentation, Command, CompletionContext, CompletionItem, CompletionList, Definition, DefinitionLink, DocumentDiagnosticReport, DocumentHighlight, DocumentLink, DocumentSymbol, Event, FoldingRange, FormattingOptions, Hover, InlayHint, InlineValue, InlineValueContext, LinkedEditingRanges, Location, Position, PreviousResultId, Range, SelectionRange, SemanticTokens, SemanticTokensDelta, SignatureHelp, SignatureHelpContext, SymbolInformation, TextEdit, TypeHierarchyItem, WorkspaceDiagnosticReport, WorkspaceDiagnosticReportPartialResult, WorkspaceEdit, WorkspaceSymbol, InlineCompletionContext, InlineCompletionItem, InlineCompletionList } from 'vscode-languageserver-protocol'
+import type { InlineCompletionTriggerKind, VersionedTextDocumentIdentifier } from 'vscode-languageserver-types'
 import type { TextDocument } from 'vscode-languageserver-textdocument'
 import type { URI } from 'vscode-uri'
 
@@ -113,6 +114,26 @@ export interface InlineCompletionItemProvider {
     context: InlineCompletionContext,
     token: CancellationToken
   ): ProviderResult<InlineCompletionItem[] | InlineCompletionList>
+}
+
+export interface NextEditItem {
+  textDocument: VersionedTextDocumentIdentifier
+  range: Range
+  newText: string
+  command?: Command
+}
+
+export interface NextEditList {
+  items: NextEditItem[]
+}
+
+export interface NextEditContext {
+  triggerKind: InlineCompletionTriggerKind
+}
+
+export interface NextEditProvider {
+  provideNextEdits(document: TextDocument, position: Position, context: NextEditContext, token: CancellationToken): ProviderResult<NextEditItem[] | NextEditList>
+  handleDidShowNextEdit?(item: NextEditItem): void | Thenable<void>
 }
 
 /**

--- a/src/provider/nextEditManager.ts
+++ b/src/provider/nextEditManager.ts
@@ -1,0 +1,81 @@
+'use strict'
+import { Position } from 'vscode-languageserver-types'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import { toArray } from '../util/array'
+import { onUnexpectedError } from '../util/errors'
+import { createLogger } from '../logger'
+import { CancellationToken, Disposable } from '../util/protocol'
+import { DocumentSelector, NextEditContext, NextEditItem, NextEditList, NextEditProvider } from './index'
+import Manager, { ProviderItem } from './manager'
+const logger = createLogger('provider-next-edit')
+
+function itemKey(item: NextEditItem): string {
+  let { textDocument, range, newText } = item
+  return JSON.stringify([textDocument.uri, textDocument.version, range, newText])
+}
+
+export default class NextEditManager extends Manager<NextEditProvider> {
+  private owners = new WeakMap<object, NextEditProvider>()
+
+  public register(selector: DocumentSelector, provider: NextEditProvider): Disposable {
+    return this.addProvider({ id: crypto.randomUUID(), selector, provider })
+  }
+
+  public get isEmpty(): boolean {
+    return this.providers.size === 0
+  }
+
+  public async provideNextEdits(
+    document: TextDocument,
+    position: Position,
+    context: NextEditContext & { provider?: string },
+    token: CancellationToken
+  ): Promise<NextEditItem[]> {
+    let providers: ProviderItem<NextEditProvider>[]
+    if (context.provider) {
+      let item = this.getProvideByExtension(document, context.provider)
+      providers = item ? [item] : []
+    } else {
+      providers = this.getProviders(document)
+    }
+    if (providers.length === 0 || token.isCancellationRequested) return []
+    let results = await Promise.all(providers.map(async item => {
+      try {
+        let result = await item.provider.provideNextEdits(document, position, {
+          triggerKind: context.triggerKind
+        }, token)
+        return Array.isArray(result) ? result : toArray((result as NextEditList | null | undefined)?.items)
+      } catch (err) {
+        this.handleResults([{ status: 'rejected', reason: err }], 'provideNextEdits', [item], token)
+        return []
+      }
+    }))
+    if (token.isCancellationRequested) return []
+    let items: NextEditItem[] = []
+    let seen = new Set<string>()
+    for (let i = 0; i < results.length; i++) {
+      for (let item of results[i]) {
+        if (!item || typeof item !== 'object') continue
+        let candidate = item as NextEditItem
+        let key = itemKey(candidate)
+        if (seen.has(key)) continue
+        seen.add(key)
+        this.owners.set(candidate, providers[i].provider)
+        items.push(candidate)
+      }
+    }
+    return items
+  }
+
+  public handleDidShow(item: NextEditItem): void {
+    let provider = this.owners.get(item)
+    if (!provider?.handleDidShowNextEdit) return
+    Promise.resolve(provider.handleDidShowNextEdit(item)).catch(err => {
+      try {
+        onUnexpectedError(err)
+      } catch (error) {
+        logger.error('Error on handleDidShowNextEdit', error)
+      }
+    })
+  }
+}

--- a/src/provider/nextEditManager.ts
+++ b/src/provider/nextEditManager.ts
@@ -2,7 +2,7 @@
 import { Position } from 'vscode-languageserver-types'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { toArray } from '../util/array'
-import { onUnexpectedError } from '../util/errors'
+import { shouldIgnore } from '../util/errors'
 import { createLogger } from '../logger'
 import { CancellationToken, Disposable } from '../util/protocol'
 import { DocumentSelector, NextEditContext, NextEditItem, NextEditList, NextEditProvider } from './index'
@@ -46,7 +46,13 @@ export default class NextEditManager extends Manager<NextEditProvider> {
         }, token)
         return Array.isArray(result) ? result : toArray((result as NextEditList | null | undefined)?.items)
       } catch (err) {
-        this.handleResults([{ status: 'rejected', reason: err }], 'provideNextEdits', [item], token)
+        try {
+          this.handleResults([{ status: 'rejected', reason: err }], 'provideNextEdits', [item], token)
+        } catch (error) {
+          // A cancellation surfaced by one provider must not fail the whole
+          // request: other providers may still produce candidates.
+          void error
+        }
         return []
       }
     }))
@@ -57,6 +63,7 @@ export default class NextEditManager extends Manager<NextEditProvider> {
       for (let item of results[i]) {
         if (!item || typeof item !== 'object') continue
         let candidate = item as NextEditItem
+        if (!candidate.textDocument) continue
         let key = itemKey(candidate)
         if (seen.has(key)) continue
         seen.add(key)
@@ -70,12 +77,19 @@ export default class NextEditManager extends Manager<NextEditProvider> {
   public handleDidShow(item: NextEditItem): void {
     let provider = this.owners.get(item)
     if (!provider?.handleDidShowNextEdit) return
-    Promise.resolve(provider.handleDidShowNextEdit(item)).catch(err => {
-      try {
-        onUnexpectedError(err)
-      } catch (error) {
-        logger.error('Error on handleDidShowNextEdit', error)
-      }
-    })
+    let result: void | Thenable<void>
+    try {
+      result = provider.handleDidShowNextEdit(item)
+    } catch (err) {
+      this.handleDidShowError(err)
+      return
+    }
+    Promise.resolve(result).catch(err => this.handleDidShowError(err))
+  }
+
+  private handleDidShowError(err: any): void {
+    if (!shouldIgnore(err)) {
+      logger.error('Error on handleDidShowNextEdit', err)
+    }
   }
 }

--- a/src/provider/nextEditManager.ts
+++ b/src/provider/nextEditManager.ts
@@ -33,13 +33,13 @@ export default class NextEditManager extends Manager<NextEditProvider> {
   ): Promise<NextEditItem[]> {
     let providers: ProviderItem<NextEditProvider>[]
     if (context.provider) {
-      let item = this.getProvideByExtension(document, context.provider)
+      let item = this.getProviders(document).find(item => item.provider['__extensionName'] === context.provider)
       providers = item ? [item] : []
     } else {
       providers = this.getProviders(document)
     }
     if (providers.length === 0 || token.isCancellationRequested) return []
-    let results = await Promise.all(providers.map(async item => {
+    let aggregate = Promise.all(providers.map(async item => {
       try {
         let result = await item.provider.provideNextEdits(document, position, {
           triggerKind: context.triggerKind
@@ -56,6 +56,12 @@ export default class NextEditManager extends Manager<NextEditProvider> {
         return []
       }
     }))
+    let disposable: Disposable | undefined
+    let results = await Promise.race([aggregate, new Promise<undefined>(resolve => {
+      disposable = token.onCancellationRequested(() => resolve(undefined))
+    })])
+    disposable?.dispose()
+    if (!results) return []
     if (token.isCancellationRequested) return []
     let items: NextEditItem[] = []
     let seen = new Set<string>()

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -6119,6 +6119,7 @@ declare module 'coc.nvim' {
     InlayHint = 'inlayHint',
     InlineValue = 'inlineValue',
     InlineCompletion = 'inlineCompletion',
+    NextEdit = 'nextEdit',
     TypeHierarchy = 'typeHierarchy'
   }
 
@@ -7054,6 +7055,27 @@ declare module 'coc.nvim' {
       context: InlineCompletionContext,
       token: CancellationToken
     ): ProviderResult<InlineCompletionItem[] | InlineCompletionList>
+  }
+
+  export interface NextEditItem {
+    /** Target document and the exact version used to compute this edit. */
+    textDocument: VersionedTextDocumentIdentifier
+    range: Range
+    newText: string
+    command?: Command
+  }
+
+  export interface NextEditList {
+    items: NextEditItem[]
+  }
+
+  export interface NextEditContext {
+    triggerKind: InlineCompletionTriggerKind
+  }
+
+  export interface NextEditProvider {
+    provideNextEdits(document: TextDocument, position: Position, context: NextEditContext, token: CancellationToken): ProviderResult<NextEditItem[] | NextEditList>
+    handleDidShowNextEdit?(item: NextEditItem): void | Thenable<void>
   }
   // }}
 
@@ -8046,6 +8068,9 @@ declare module 'coc.nvim' {
      * Trigger inline completion
      */
     export function executeCommand(command: 'editor.action.triggerInlineCompletion', option?: InlineCompletionOption): Promise<void>
+
+    /** Trigger coc.nvim's generic next edit provider. */
+    export function executeCommand(command: 'editor.action.triggerNextEdit', option?: { provider?: string; autoTrigger?: boolean }): Promise<boolean>
   }
   // }}
 
@@ -8828,6 +8853,9 @@ declare module 'coc.nvim' {
      * @return A {@link Disposable} that unregisters this provider when being disposed.
      */
     export function registerInlineCompletionItemProvider(selector: DocumentSelector, provider: InlineCompletionItemProvider): Disposable
+
+    /** Register a provider of generic, versioned next edits. */
+    export function registerNextEditProvider(selector: DocumentSelector, provider: NextEditProvider): Disposable
   }
   // }}
 


### PR DESCRIPTION
## Summary

Adds a provider-neutral Next Edit API to coc.nvim, letting extensions register versioned insertion, replacement, or deletion candidates and letting users preview, navigate, and accept them without changing the buffer.

## What's included

- New `languages.registerNextEditProvider()` API with `NextEditItem`, `NextEditList`, `NextEditContext`, and `NextEditProvider` types.
- Handler with preview, candidate navigation (next/prev with wrapping), two-step acceptance for off-cursor or cross-file candidates, and stale-version rejection.
- `handleDidShowNextEdit` extension callback, invoked once per shown candidate.
- Vim/Neovim actions (`coc#nextedit#*`) and the `editor.action.triggerNextEdit` command.
- Configuration: `nextEdit.autoTrigger` (default `true`) and `nextEdit.triggerWait` (default `150`).
- Documentation in coc.txt and coc-config.txt, plus unit and handler tests.

## Hardening included in this branch

- Preview virtual text uses the correct 1-based byte column, matching inline completion and the `coc#vtext#add` contract.
- Session state is re-checked after async rendering, so cancelling during a render leaves no orphan preview or stale state.
- Triggering aborts when the active buffer changes during the request.
- Sessions are invalidated on document changes even with `autoTrigger` disabled.
- Cross-file acceptance waits briefly for the target document to attach.
- Provider items without a `textDocument` are skipped, and a single failing provider cannot fail the whole request.
- `handleDidShowNextEdit` errors are logged through `shouldIgnore` instead of an `onUnexpectedError` throw/catch.

## Tests

- `src/__tests__/unit/nextEditManager.test.ts`: provider filtering, deduplication, cancellation, malformed items, and error containment.
- `src/__tests__/handler/nextEdit.test.ts`: preview and apply, off-cursor jumps, candidate switching, stale rejection, cancellation races, buffer switches, and preview column placement.

All 25 tests in the two new files pass, along with the full unit lane (1105 tests), `tsc --noEmit`, and oxlint.