### PR TITLE
fix(provider): race aggregation against cancellation

### DIFF
--- a/src/__tests__/handler/basic.test.ts
+++ b/src/__tests__/handler/basic.test.ts
@@ -60,28 +60,17 @@ describe('InlineCompletion', () => {
     assert.strictEqual(res.length, 2)
   })
 
-  it('should return empty when token cancelled', async t => {
+  it('should return immediately when a provider ignores cancellation', async t => {
     let doc = await workspace.document
     let pos = await window.getCursorPosition()
     let context: InlineCompletionContext = { triggerKind: InlineCompletionTriggerKind.Automatic }
-    let cancelled = false
     disposables.push(languages.registerInlineCompletionItemProvider(['*'], {
-      provideInlineCompletionItems: (_doc, _pos, _context, token) => {
-        return new Promise(resolve => {
-          let timer = setTimeout(() => resolve([]), 500)
-          token.onCancellationRequested(() => {
-            cancelled = true
-            clearTimeout(timer)
-            resolve(undefined)
-          })
-        })
-      }
+      provideInlineCompletionItems: () => new Promise(() => {})
     }))
     let tokenSource = new CancellationTokenSource()
     let p = languages.provideInlineCompletionItems(doc.textDocument, pos, context, tokenSource.token)
     tokenSource.cancel()
     let res = await p
-    assert.strictEqual(cancelled, true)
     assert.deepStrictEqual(res, [])
   })
 

--- a/src/provider/inlineCompletionItemManager.ts
+++ b/src/provider/inlineCompletionItemManager.ts
@@ -2,7 +2,6 @@
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { InlineCompletionContext, InlineCompletionItem, Position } from 'vscode-languageserver-types'
 import { toArray } from '../util/array'
-import { onUnexpectedError } from '../util/errors'
 import { omit } from '../util/lodash'
 import { CancellationToken, Disposable } from '../util/protocol'
 import { DocumentSelector, InlineCompletionItemProvider } from './index'
@@ -57,15 +56,8 @@ export default class InlineCompletionItemManager extends Manager<InlineCompletio
         }
       })
     }))
-    let disposable: Disposable
-    await Promise.race([new Promise(resolve => {
-      disposable = token.onCancellationRequested(() => {
-        resolve(undefined)
-      })
-    }), promise.then(results => {
-      if (!token.isCancellationRequested) this.handleResults(results, 'provideInlineCompletionItems', providers)
-    })]).catch(onUnexpectedError)
-    if (disposable) disposable.dispose()
+    const results = await this.raceCancellation(promise, token)
+    if (results) this.handleResults(results, 'provideInlineCompletionItems', providers)
     return items
   }
 }

--- a/src/provider/manager.ts
+++ b/src/provider/manager.ts
@@ -65,6 +65,25 @@ export default class Manager<T extends object, P = object> {
     if (serverCancelError) throw serverCancelError
   }
 
+  /**
+   * Wait for provider aggregation without letting a provider that ignores its
+   * cancellation token keep the request alive.
+   */
+  protected async raceCancellation<R>(promise: Promise<R>, token: CancellationToken): Promise<R | undefined> {
+    if (token.isCancellationRequested) return undefined
+    let disposable: Disposable
+    try {
+      return await Promise.race([
+        promise,
+        new Promise<undefined>(resolve => {
+          disposable = token.onCancellationRequested(() => resolve(undefined))
+        })
+      ])
+    } finally {
+      disposable?.dispose()
+    }
+  }
+
   protected getProvider(document: TextDocumentMatch): ProviderItem<T, P> {
     let currScore = 0
     let providerItem: ProviderItem<T, P>


### PR DESCRIPTION
### Motivation

- Prevent provider aggregation from being kept alive by providers that ignore their cancellation token so cancelled requests can return immediately.

### Description

- Add `raceCancellation` to `Manager` to race provider aggregation against a `CancellationToken` and dispose the listener after resolution (`src/provider/manager.ts`).
- Use `raceCancellation` in `InlineCompletionItemManager.provideInlineCompletionItems` to avoid waiting on unresponsive providers (`src/provider/inlineCompletionItemManager.ts`).
- Update the inline completion test to cover a provider that never settles and assert the API returns immediately after cancellation (`src/__tests__/handler/basic.test.ts`).
- Remove an unused `onUnexpectedError` import as part of the cleanup.

### Testing

- Ran TypeScript typecheck with `tsc -p tsconfig.json --noEmit` which succeeded. 
- Ran linter checks with `oxlint` on the modified files which succeeded. 
- Ran the repository test runner for the updated test with `node scripts/test/cli.mjs src/__tests__/handler/basic.test.ts -t 'provider ignores cancellation'` which passed. 
- Attempted `npx jest` but it could not run in this environment due to network/npm registry restrictions (failed to download dependencies).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a86a78427648325b54be1d76bd3ffc5)