### PR TITLE
feat(hover): add Neovim OSC 8 hyperlinks

### DIFF
--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -1524,6 +1524,9 @@ endfunction
 function! s:add_highlights(winid, config, create) abort
   let codes = get(a:config, 'codes', [])
   let highlights = get(a:config, 'highlights', [])
+  if !s:is_vim && has('nvim-0.12')
+    call v:lua.require('coc.float').add_hyperlinks(a:winid, get(a:config, 'links', []))
+  endif
   if empty(codes) && empty(highlights) && a:create
     return
   endif

--- a/history.md
+++ b/history.md
@@ -2,6 +2,13 @@
 
 Notable changes of coc.nvim:
 
+## 2026-08-21
+
+- Support neovim OSC 8 hyperlinks.  Hold Command on macOS or Ctrl on
+  Linux/Windows to open the link. In mouse-capturing TUI applications, also hold
+  Shift.
+
+
 ## 2026-08-19
 
 - Add a provider-neutral Next Edit API with versioned candidates, cancellation,

--- a/lua/coc/float.lua
+++ b/lua/coc/float.lua
@@ -1,0 +1,21 @@
+local api = vim.api
+local M = {}
+
+local hyperlink_ns
+
+function M.add_hyperlinks(winid, links)
+  if hyperlink_ns == nil and #links == 0 then
+    return
+  end
+  hyperlink_ns = hyperlink_ns or api.nvim_create_namespace('coc-hyperlinks')
+  local bufnr = api.nvim_win_get_buf(winid)
+  api.nvim_buf_clear_namespace(bufnr, hyperlink_ns, 0, -1)
+  for _, link in ipairs(links) do
+    api.nvim_buf_set_extmark(bufnr, hyperlink_ns, link.lnum, link.colStart, {
+      end_col = link.colEnd,
+      url = link.url,
+    })
+  end
+end
+
+return M

--- a/lua/coc/float.lua
+++ b/lua/coc/float.lua
@@ -11,7 +11,7 @@ function M.add_hyperlinks(winid, links)
   local bufnr = api.nvim_win_get_buf(winid)
   api.nvim_buf_clear_namespace(bufnr, hyperlink_ns, 0, -1)
   for _, link in ipairs(links) do
-    api.nvim_buf_set_extmark(bufnr, hyperlink_ns, link.lnum, link.colStart, {
+    pcall(api.nvim_buf_set_extmark, bufnr, hyperlink_ns, link.lnum, link.colStart, {
       end_col = link.colEnd,
       url = link.url,
     })

--- a/src/__tests__/handler/hover.test.ts
+++ b/src/__tests__/handler/hover.test.ts
@@ -169,6 +169,12 @@ describe('Hover', () => {
       assert.strictEqual(marks[0][3].end_col, 3)
       assert.strictEqual(marks[0][3].url, 'https://github.com/neoclide/coc.nvim')
     })
+
+    it('should ignore rejected Neovim hyperlink extmarks', async t => {
+      if (workspace.isVim || !workspace.has('nvim-0.12.0')) return
+      let winid = await nvim.call('win_getid') as number
+      await nvim.call('luaeval', ["require('coc.float').add_hyperlinks(_A[1], _A[2])", [winid, [{ lnum: -1, colStart: 0, colEnd: 1, url: 'https://example.com' }]]])
+    })
   })
 
   describe('getHover', () => {

--- a/src/__tests__/handler/hover.test.ts
+++ b/src/__tests__/handler/hover.test.ts
@@ -155,6 +155,20 @@ describe('Hover', () => {
       let lines = await nvim.eval(`getbufline(winbufnr(${win.id}),1,'$')`)
       assert.deepStrictEqual(lines, ['const foo:number'])
     })
+
+    it('should add OSC 8 hyperlinks to Neovim hover floats', async t => {
+      hoverResult = { contents: { kind: 'markdown', value: '[Coc](https://github.com/neoclide/coc.nvim)' } }
+      await hover.onHover('float')
+      if (workspace.isVim || !workspace.has('nvim-0.12.0')) return
+      let win = await shared.getFloat()
+      let namespaces = await nvim.call('nvim_get_namespaces') as Record<string, number>
+      let bufnr = await nvim.call('winbufnr', [win.id]) as number
+      let marks = await nvim.call('luaeval', ['vim.api.nvim_buf_get_extmarks(_A[1], _A[2], 0, -1, {details = true})', [bufnr, namespaces['coc-hyperlinks']]]) as any[]
+      assert.strictEqual(marks.length, 1)
+      assert.deepStrictEqual(marks[0].slice(1, 3), [0, 0])
+      assert.strictEqual(marks[0][3].end_col, 3)
+      assert.strictEqual(marks[0][3].url, 'https://github.com/neoclide/coc.nvim')
+    })
   })
 
   describe('getHover', () => {

--- a/src/__tests__/unit/index.test.ts
+++ b/src/__tests__/unit/index.test.ts
@@ -145,10 +145,18 @@ bar
   })
 
   it('should preserve named-link highlights after removing markers', () => {
-    let res = parseMarkdown('[Coc](https://example.com)', {})
+    let res = parseMarkdown('[0123456789](https://example.com)', {})
     assert.deepStrictEqual(res.highlights[0], {
-      hlGroup: 'CocMarkdownLink', lnum: 0, colStart: 0, colEnd: 3
+      hlGroup: 'CocMarkdownLink', lnum: 0, colStart: 0, colEnd: 10
     })
+  })
+
+  it('should preserve emphasis around named links', () => {
+    let res = parseMarkdown('**[Coc](https://example.com)**', {})
+    assert.deepStrictEqual(res.highlights.slice(0, 2), [
+      { hlGroup: 'CocMarkdownLink', lnum: 0, colStart: 0, colEnd: 3 },
+      { hlGroup: 'CocBold', lnum: 0, colStart: 0, colEnd: 3 }
+    ])
   })
 
   it('should retain markdown links across line boundaries', () => {
@@ -205,6 +213,13 @@ bar
     ].join('\n')
     let res = parseMarkdown(content, {})
     assert.ok(res.lines.includes('│ Type │ size_of::<Type>() │'))
+  })
+
+  it('should not include hyperlink markers in table widths', () => {
+    let res = parseMarkdown('| Link | Value |\n| --- | --- |\n| [Coc](https://x) | xx |', {})
+    assert.ok(res.lines.includes('│ Coc  │ xx    │'))
+    let tableLines = res.lines.filter(line => /^[┌├└│]/.test(line))
+    assert.ok(tableLines.every(line => line.length == tableLines[0].length))
   })
 
   it('should render html', () => {

--- a/src/__tests__/unit/index.test.ts
+++ b/src/__tests__/unit/index.test.ts
@@ -168,6 +168,12 @@ bar
     ])
   })
 
+  it('should render titled images without hyperlink ranges', () => {
+    let res = parseMarkdown('![logo](https://example.com/logo.png "Logo")', { breaks: false })
+    assert.deepStrictEqual(res.lines, ['![logo](https://example.com/logo.png "Logo")'])
+    assert.deepStrictEqual(res.links, [])
+  })
+
   it('should exclude images by option', () => {
     let content = 'head\n![img](img)\ncontent ![img](img) ![img](img)'
     let res = parseMarkdown(content, { excludeImages: false })
@@ -345,6 +351,23 @@ describe('parseDocuments', () => {
     assert.deepStrictEqual(res.codes, [
       { filetype: 'typescript', startLine: 0, endLine: 1 }
     ])
+  })
+
+  it('should adjust markdown link lines across documents', () => {
+    let docs = [{
+      filetype: 'typescript',
+      content: 'const workspace'
+    }, {
+      filetype: 'markdown',
+      content: '[Coc](https://github.com/neoclide/coc.nvim)'
+    }]
+    let res = parseDocuments(docs)
+    assert.deepStrictEqual(res.links, [{
+      lnum: 2,
+      colStart: 0,
+      colEnd: 3,
+      url: 'https://github.com/neoclide/coc.nvim'
+    }])
   })
 
   it('should parse document with highlights', () => {

--- a/src/__tests__/unit/index.test.ts
+++ b/src/__tests__/unit/index.test.ts
@@ -144,6 +144,22 @@ bar
     ])
   })
 
+  it('should preserve named-link highlights after removing markers', () => {
+    let res = parseMarkdown('[Coc](https://example.com)', {})
+    assert.deepStrictEqual(res.highlights[0], {
+      hlGroup: 'CocMarkdownLink', lnum: 0, colStart: 0, colEnd: 3
+    })
+  })
+
+  it('should retain markdown links across line boundaries', () => {
+    let res = parseMarkdown('[first\nsecond](https://example.com)', {})
+    assert.deepStrictEqual(res.lines.slice(0, 2), ['first', 'second'])
+    assert.deepStrictEqual(res.links, [
+      { lnum: 0, colStart: 0, colEnd: 5, url: 'https://example.com' },
+      { lnum: 1, colStart: 0, colEnd: 6, url: 'https://example.com' }
+    ])
+  })
+
   it('should exclude images by option', () => {
     let content = 'head\n![img](img)\ncontent ![img](img) ![img](img)'
     let res = parseMarkdown(content, { excludeImages: false })

--- a/src/__tests__/unit/index.test.ts
+++ b/src/__tests__/unit/index.test.ts
@@ -135,6 +135,15 @@ bar
     ])
   })
 
+  it('should retain markdown links for Neovim hyperlink extmarks', () => {
+    let res = parseMarkdown('[Coc](https://github.com/neoclide/coc.nvim) and https://neovim.io', {})
+    assert.deepStrictEqual(res.lines, ['Coc and https://neovim.io', '', 'Coc: https://github.com/neoclide/coc.nvim'])
+    assert.deepStrictEqual(res.links, [
+      { lnum: 0, colStart: 0, colEnd: 3, url: 'https://github.com/neoclide/coc.nvim' },
+      { lnum: 0, colStart: 8, colEnd: 25, url: 'https://neovim.io' }
+    ])
+  })
+
   it('should exclude images by option', () => {
     let content = 'head\n![img](img)\ncontent ![img](img) ![img](img)'
     let res = parseMarkdown(content, { excludeImages: false })

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -5,7 +5,7 @@ import { parseAnsiHighlights } from '../util/ansiparse'
 import * as Is from '../util/is'
 import { stripAnsi } from '../util/node'
 import { byteIndex, byteLength } from '../util/string'
-import Renderer from './renderer'
+import Renderer, { MarkdownLink } from './renderer'
 
 export interface MarkdownParseOptions {
   breaks?: boolean
@@ -26,6 +26,14 @@ export interface DocumentInfo {
   lines: string[]
   highlights: HighlightItem[]
   codes: CodeBlock[]
+  links: MarkdownLinkItem[]
+}
+
+export interface MarkdownLinkItem {
+  lnum: number
+  colStart: number
+  colEnd: number
+  url: string
 }
 
 enum FiletypeHighlights {
@@ -59,6 +67,7 @@ export function parseDocuments(docs: Documentation[], opts: MarkdownParseOptions
   let lines: string[] = []
   let highlights: HighlightItem[] = []
   let codes: CodeBlock[] = []
+  let linkItems: MarkdownLinkItem[] = []
   let idx = 0
   for (let doc of docs) {
     let currline = lines.length
@@ -75,6 +84,7 @@ export function parseDocuments(docs: Documentation[], opts: MarkdownParseOptions
         o.lnum = o.lnum + currline
         return o
       }))
+      linkItems.push(...info.links.map(o => ({ ...o, lnum: o.lnum + currline })))
       lines.push(...info.lines)
     } else {
       let parts = content.trim().split(/\r?\n/)
@@ -106,7 +116,7 @@ export function parseDocuments(docs: Documentation[], opts: MarkdownParseOptions
     }
     idx = idx + 1
   }
-  return { lines, highlights, codes }
+  return { lines, highlights, codes, links: linkItems }
 }
 
 /**
@@ -154,8 +164,9 @@ export function getHighlightItems(content: string, currline: number, active: [nu
  * Parse markdown for lines, highlights & codes
  */
 export function parseMarkdown(content: string, opts: MarkdownParseOptions): DocumentInfo {
+  let renderer = new Renderer()
   marked.setOptions({
-    renderer: new Renderer() as MarkedRenderer,
+    renderer: renderer as MarkedRenderer,
     gfm: true,
     breaks: Is.boolean(opts.breaks) ? opts.breaks : true,
     hooks: Renderer.hooks,
@@ -163,15 +174,16 @@ export function parseMarkdown(content: string, opts: MarkdownParseOptions): Docu
   let lines: string[] = []
   let highlights: HighlightItem[] = []
   let codes: CodeBlock[] = []
+  let linkItems: MarkdownLinkItem[] = []
   let currline = 0
   let inCodeBlock = false
   let filetype: string
   let startLnum = 0
   let parsed = marked(content)
-  let links = Renderer.getLinks()
+  let linkReferences = Renderer.getLinks()
   parsed = parsed.replace(/\s*$/, '')
-  if (links.length) {
-    parsed = parsed + '\n\n' + links.join('\n')
+  if (linkReferences.length) {
+    parsed = parsed + '\n\n' + linkReferences.join('\n')
   }
   let parsedLines = parsed.split(/\n/)
   for (let i = 0; i < parsedLines.length; i++) {
@@ -219,6 +231,9 @@ export function parseMarkdown(content: string, opts: MarkdownParseOptions): Docu
       continue
     }
     let res = parseAnsiHighlights(line, true)
+    let linkResult = extractLinks(res.line, renderer.getLinkMarkers(), currline)
+    res.line = linkResult.line
+    linkItems.push(...linkResult.links)
     if (line === DIVIDE_LINE) {
       highlights.push({
         hlGroup: DIVIDING_LINE_HI_GROUP,
@@ -232,13 +247,48 @@ export function parseMarkdown(content: string, opts: MarkdownParseOptions): Docu
         highlights.push({
           hlGroup,
           lnum: currline,
-          colStart: span[0],
-          colEnd: span[1]
+          colStart: adjustLinkMarkerColumn(span[0], linkResult.markerOffsets, true),
+          colEnd: adjustLinkMarkerColumn(span[1], linkResult.markerOffsets, false)
         })
       }
     }
     lines.push(res.line)
     currline++
   }
-  return { lines, highlights, codes }
+  return { lines, highlights, codes, links: linkItems }
+}
+
+function extractLinks(line: string, markers: readonly MarkdownLink[], lnum: number): { line: string, links: MarkdownLinkItem[], markerOffsets: number[] } {
+  let links: MarkdownLinkItem[] = []
+  let markerOffsets: number[] = []
+  let starts = new Map<number, number>()
+  let result = ''
+  let offset = 0
+  let match: RegExpExecArray | null
+  const marker = String.fromCharCode(0)
+  const regexp = new RegExp(`${marker}(\\d+)${marker}`, 'g')
+  while ((match = regexp.exec(line)) != null) {
+    result += line.slice(offset, match.index)
+    markerOffsets.push(byteLength(line.slice(0, match.index)))
+    let marker = Number(match[1])
+    let start = starts.get(marker)
+    if (start == null) {
+      starts.set(marker, byteLength(result))
+    } else {
+      let url = markers[marker]?.url
+      let end = byteLength(result)
+      if (url && end > start) links.push({ lnum, colStart: start, colEnd: end, url })
+      starts.delete(marker)
+    }
+    offset = match.index + match[0].length
+  }
+  return { line: result + line.slice(offset), links, markerOffsets }
+}
+
+function adjustLinkMarkerColumn(column: number, markerOffsets: readonly number[], includeEqual: boolean): number {
+  let original = column
+  for (let offset of markerOffsets) {
+    if (offset < original || (includeEqual && offset === original)) column -= 2 + offset.toString().length
+  }
+  return column
 }

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -231,9 +231,8 @@ export function parseMarkdown(content: string, opts: MarkdownParseOptions): Docu
       currline++
       continue
     }
-    let res = parseAnsiHighlights(line, true)
-    let linkResult = extractLinks(res.line, renderer.getLinkMarkers(), linkStarts, currline)
-    res.line = linkResult.line
+    let linkResult = extractLinks(line, renderer.getLinkMarkers(), linkStarts, currline)
+    let res = parseAnsiHighlights(linkResult.line, true)
     linkItems.push(...linkResult.links)
     if (line === DIVIDE_LINE) {
       highlights.push({
@@ -248,8 +247,8 @@ export function parseMarkdown(content: string, opts: MarkdownParseOptions): Docu
         highlights.push({
           hlGroup,
           lnum: currline,
-          colStart: adjustLinkMarkerColumn(span[0], linkResult.markerOffsets),
-          colEnd: adjustLinkMarkerColumn(span[1], linkResult.markerOffsets)
+          colStart: span[0],
+          colEnd: span[1]
         })
       }
     }
@@ -259,24 +258,21 @@ export function parseMarkdown(content: string, opts: MarkdownParseOptions): Docu
   return { lines, highlights, codes, links: linkItems }
 }
 
-function extractLinks(line: string, markers: readonly MarkdownLink[], starts: Map<number, number>, lnum: number): { line: string, links: MarkdownLinkItem[], markerOffsets: number[] } {
+function extractLinks(line: string, markers: readonly MarkdownLink[], starts: Map<number, number>, lnum: number): { line: string, links: MarkdownLinkItem[] } {
   let links: MarkdownLinkItem[] = []
-  let markerOffsets: number[] = []
   let result = ''
   let offset = 0
   let match: RegExpExecArray | null
-  const marker = String.fromCharCode(0)
-  const regexp = new RegExp(`${marker}(\\d+)${marker}`, 'g')
+  const regexp = new RegExp(`${String.fromCharCode(27)}\\[1000;(\\d+)m`, 'g')
   while ((match = regexp.exec(line)) != null) {
     result += line.slice(offset, match.index)
-    markerOffsets.push(byteLength(line.slice(0, match.index)))
     let marker = Number(match[1])
     let start = starts.get(marker)
     if (start == null) {
-      starts.set(marker, byteLength(result))
+      starts.set(marker, byteLength(stripAnsi(result)))
     } else {
       let url = markers[marker]?.url
-      let end = byteLength(result)
+      let end = byteLength(stripAnsi(result))
       if (url && end > start) links.push({ lnum, colStart: start, colEnd: end, url })
       starts.delete(marker)
     }
@@ -285,17 +281,9 @@ function extractLinks(line: string, markers: readonly MarkdownLink[], starts: Ma
   result += line.slice(offset)
   for (let [marker, start] of starts) {
     let url = markers[marker]?.url
-    let end = byteLength(result)
+    let end = byteLength(stripAnsi(result))
     if (url && end > start) links.push({ lnum, colStart: start, colEnd: end, url })
     starts.set(marker, 0)
   }
-  return { line: result, links, markerOffsets }
-}
-
-function adjustLinkMarkerColumn(column: number, markerOffsets: readonly number[]): number {
-  let original = column
-  for (let offset of markerOffsets) {
-    if (offset < original) column -= 2 + offset.toString().length
-  }
-  return column
+  return { line: result, links }
 }

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -175,6 +175,7 @@ export function parseMarkdown(content: string, opts: MarkdownParseOptions): Docu
   let highlights: HighlightItem[] = []
   let codes: CodeBlock[] = []
   let linkItems: MarkdownLinkItem[] = []
+  let linkStarts = new Map<number, number>()
   let currline = 0
   let inCodeBlock = false
   let filetype: string
@@ -231,7 +232,7 @@ export function parseMarkdown(content: string, opts: MarkdownParseOptions): Docu
       continue
     }
     let res = parseAnsiHighlights(line, true)
-    let linkResult = extractLinks(res.line, renderer.getLinkMarkers(), currline)
+    let linkResult = extractLinks(res.line, renderer.getLinkMarkers(), linkStarts, currline)
     res.line = linkResult.line
     linkItems.push(...linkResult.links)
     if (line === DIVIDE_LINE) {
@@ -247,8 +248,8 @@ export function parseMarkdown(content: string, opts: MarkdownParseOptions): Docu
         highlights.push({
           hlGroup,
           lnum: currline,
-          colStart: adjustLinkMarkerColumn(span[0], linkResult.markerOffsets, true),
-          colEnd: adjustLinkMarkerColumn(span[1], linkResult.markerOffsets, false)
+          colStart: adjustLinkMarkerColumn(span[0], linkResult.markerOffsets),
+          colEnd: adjustLinkMarkerColumn(span[1], linkResult.markerOffsets)
         })
       }
     }
@@ -258,10 +259,9 @@ export function parseMarkdown(content: string, opts: MarkdownParseOptions): Docu
   return { lines, highlights, codes, links: linkItems }
 }
 
-function extractLinks(line: string, markers: readonly MarkdownLink[], lnum: number): { line: string, links: MarkdownLinkItem[], markerOffsets: number[] } {
+function extractLinks(line: string, markers: readonly MarkdownLink[], starts: Map<number, number>, lnum: number): { line: string, links: MarkdownLinkItem[], markerOffsets: number[] } {
   let links: MarkdownLinkItem[] = []
   let markerOffsets: number[] = []
-  let starts = new Map<number, number>()
   let result = ''
   let offset = 0
   let match: RegExpExecArray | null
@@ -282,13 +282,20 @@ function extractLinks(line: string, markers: readonly MarkdownLink[], lnum: numb
     }
     offset = match.index + match[0].length
   }
-  return { line: result + line.slice(offset), links, markerOffsets }
+  result += line.slice(offset)
+  for (let [marker, start] of starts) {
+    let url = markers[marker]?.url
+    let end = byteLength(result)
+    if (url && end > start) links.push({ lnum, colStart: start, colEnd: end, url })
+    starts.set(marker, 0)
+  }
+  return { line: result, links, markerOffsets }
 }
 
-function adjustLinkMarkerColumn(column: number, markerOffsets: readonly number[], includeEqual: boolean): number {
+function adjustLinkMarkerColumn(column: number, markerOffsets: readonly number[]): number {
   let original = column
   for (let offset of markerOffsets) {
-    if (offset < original || (includeEqual && offset === original)) column -= 2 + offset.toString().length
+    if (offset < original) column -= 2 + offset.toString().length
   }
   return column
 }

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -164,7 +164,7 @@ export function getHighlightItems(content: string, currline: number, active: [nu
  * Parse markdown for lines, highlights & codes
  */
 export function parseMarkdown(content: string, opts: MarkdownParseOptions): DocumentInfo {
-  let renderer = new Renderer()
+  let renderer = new Renderer({ linkMarkers: true })
   marked.setOptions({
     renderer: renderer as MarkedRenderer,
     gfm: true,

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -49,7 +49,6 @@ const filetyepsMap = {
   bash: 'sh'
 }
 const ACTIVE_HL_GROUP = 'CocFloatActive'
-const HEADER_PREFIX = '\x1b[35m'
 const DIVIDING_LINE_HI_GROUP = 'CocFloatDividingLine'
 const MARKDOWN = 'markdown'
 const DOTS = '```'
@@ -260,19 +259,21 @@ export function parseMarkdown(content: string, opts: MarkdownParseOptions): Docu
 
 function extractLinks(line: string, markers: readonly MarkdownLink[], starts: Map<number, number>, lnum: number): { line: string, links: MarkdownLinkItem[] } {
   let links: MarkdownLinkItem[] = []
+  if (markers.length == 0) return { line, links }
   let result = ''
   let offset = 0
   let match: RegExpExecArray | null
   const regexp = new RegExp(`${String.fromCharCode(27)}\\[1000;(\\d+)m`, 'g')
   while ((match = regexp.exec(line)) != null) {
-    result += line.slice(offset, match.index)
+    let part = line.slice(offset, match.index)
+    result += part
     let marker = Number(match[1])
     let start = starts.get(marker)
     if (start == null) {
       starts.set(marker, byteLength(stripAnsi(result)))
     } else {
       let url = markers[marker]?.url
-      let end = byteLength(stripAnsi(result))
+      let end = start + byteLength(stripAnsi(part))
       if (url && end > start) links.push({ lnum, colStart: start, colEnd: end, url })
       starts.delete(marker)
     }

--- a/src/markdown/renderer.ts
+++ b/src/markdown/renderer.ts
@@ -204,6 +204,7 @@ export interface MarkdownLink {
 
 export interface RendererOptions {
   sanitize?: boolean
+  linkMarkers?: boolean
 }
 
 class Renderer {
@@ -348,9 +349,12 @@ class Renderer {
     if (text && href && text != href) {
       links.set(text, href)
     }
-    let marker = `\0${this.linkMarkers.length}\0`
-    this.linkMarkers.push({ marker: this.linkMarkers.length, url: href })
-    if (text && text != href) return styles.blue(marker + text + marker)
+    let marker = ''
+    if (this.o.linkMarkers) {
+      marker = `\0${this.linkMarkers.length}\0`
+      this.linkMarkers.push({ marker: this.linkMarkers.length, url: href })
+    }
+    if (text && text != href) return marker + styles.blue(text) + marker
     let out = this.o.href(href)
     return marker + this.o.link(out) + marker
   }

--- a/src/markdown/renderer.ts
+++ b/src/markdown/renderer.ts
@@ -351,7 +351,9 @@ class Renderer {
     }
     let marker = ''
     if (this.o.linkMarkers) {
-      marker = `\0${this.linkMarkers.length}\0`
+      // Use an ANSI-shaped marker so terminal table renderers treat the
+      // hyperlink metadata as zero-width when calculating column sizes.
+      marker = `\x1b[1000;${this.linkMarkers.length}m`
       this.linkMarkers.push({ marker: this.linkMarkers.length, url: href })
     }
     if (text && text != href) return marker + styles.blue(text) + marker

--- a/src/markdown/renderer.ts
+++ b/src/markdown/renderer.ts
@@ -197,11 +197,17 @@ function unescapeEntities(html: string): string {
 
 const links: Map<string, string> = new Map()
 
+export interface MarkdownLink {
+  marker: number
+  url: string
+}
+
 export interface RendererOptions {
   sanitize?: boolean
 }
 
 class Renderer {
+  private linkMarkers: MarkdownLink[] = []
   private o: any
   private tab: any
   private tableSettings: any
@@ -342,9 +348,15 @@ class Renderer {
     if (text && href && text != href) {
       links.set(text, href)
     }
-    if (text && text != href) return styles.blue(text)
+    let marker = `\0${this.linkMarkers.length}\0`
+    this.linkMarkers.push({ marker: this.linkMarkers.length, url: href })
+    if (text && text != href) return styles.blue(marker + text + marker)
     let out = this.o.href(href)
-    return this.o.link(out)
+    return marker + this.o.link(out) + marker
+  }
+
+  public getLinkMarkers(): readonly MarkdownLink[] {
+    return this.linkMarkers
   }
 
   public image(href: string, title: string | null, text: string): string {

--- a/src/model/floatFactory.ts
+++ b/src/model/floatFactory.ts
@@ -140,10 +140,11 @@ export default class FloatFactoryImpl implements Disposable {
 
   private async createPopup(docs: Documentation[], opts: FloatWinConfig, token: number): Promise<void> {
     docs = docs.filter(o => o.content.trim().length > 0)
-    let { lines, codes, highlights } = parseDocuments(docs, { excludeImages: opts.excludeImages, breaks: opts.breaks })
+    let { lines, codes, highlights, links } = parseDocuments(docs, { excludeImages: opts.excludeImages, breaks: opts.breaks })
     let config: any = {
       codes,
       highlights,
+      links,
       pumAlignTop: events.pumAlignTop,
       preferTop: typeof opts.preferTop === 'boolean' ? opts.preferTop : false,
       offsetX: opts.offsetX || 0,


### PR DESCRIPTION
## Summary

- retain Markdown link ranges and targets during float rendering
- add Neovim 0.12+ URL extmarks through the Lua float helper
- cover Markdown extraction and hover float extmarks

## Testing

- `npx -y node@24.12.0 scripts/test/cli.mjs src/__tests__/unit/index.test.ts src/__tests__/handler/hover.test.ts`
- `npx -y node@24.12.0 ./node_modules/.bin/tsc -p tsconfig.json`
- `npm run lint`