### PR TITLE
Enforce response/download size limits, secure archive extraction, and validate extension names

### DIFF
--- a/src/__tests__/mcp/workspace-tools.test.ts
+++ b/src/__tests__/mcp/workspace-tools.test.ts
@@ -245,6 +245,7 @@ describe('mcp workspace tools', () => {
     let limited = await searchWithJs('hello', {}, tmpdir, 1)
     assert.strictEqual(limited.length, 1)
     await assert.rejects(searchWithJs('[', { regex: true }, tmpdir, 10), new RegExp('Invalid regex'))
+    await assert.rejects(searchWithJs('(a+)+$', { regex: true }, tmpdir, 10), /too complex/)
   })
 
   it('validates required arguments for workspace tools', async t => {

--- a/src/__tests__/modules/fetch.test.ts
+++ b/src/__tests__/modules/fetch.test.ts
@@ -473,6 +473,10 @@ describe('fetch', () => {
     }
     await assert.rejects(fn(), Error)
   })
+
+  it('should reject oversized responses', async () => {
+    await assert.rejects(fetch(`http://127.0.0.1:${port}/binary`, { maxResponseSize: 10 }), /maximum size/)
+  })
 })
 
 describe('download', () => {
@@ -555,6 +559,13 @@ describe('download', () => {
     assert.strictEqual(called, true)
     let exists = fs.existsSync(res)
     assert.strictEqual(exists, true)
+  })
+
+  it('should reject oversized downloads', async () => {
+    await assert.rejects(download(`http://127.0.0.1:${port}/binary`, {
+      dest: tempdir,
+      maxDownloadSize: 10
+    }), /maximum size/)
   })
 
   it('should throw when etag check failed', async t => {

--- a/src/__tests__/modules/fetch.test.ts
+++ b/src/__tests__/modules/fetch.test.ts
@@ -399,13 +399,18 @@ describe('fetch', () => {
   })
 
   it('should catch proxy error', async t => {
+    let noProxy = process.env.no_proxy
     delete process.env.NO_PROXY
+    delete process.env.no_proxy
     process.env.HTTP_PROXY = `http://127.0.0.1`
-    let fn = async () => {
-      await fetch(`http://127.0.0.1:${port}/json`)
+    try {
+      await assert.rejects(() => fetch(`http://127.0.0.1:${port}/json`))
+    } finally {
+      delete process.env.HTTP_PROXY
+      if (noProxy == null) delete process.env.no_proxy
+      else process.env.no_proxy = noProxy
+      process.env.NO_PROXY = '*'
     }
-    await assert.rejects(fn(), )
-    delete process.env.HTTP_PROXY
   })
 
   it('should throw for ECONNRESET error', async t => {
@@ -475,7 +480,7 @@ describe('fetch', () => {
   })
 
   it('should reject oversized responses', async () => {
-    await assert.rejects(fetch(`http://127.0.0.1:${port}/binary`, { maxResponseSize: 10 }), /maximum size/)
+    await assert.rejects(fetch(`http://127.0.0.1:${port}/text`, { maxResponseSize: 1 }), /maximum size/)
   })
 })
 
@@ -651,15 +656,19 @@ describe('download', () => {
   })
 
   it('should throw on agent error', async t => {
+    let noProxy = process.env.no_proxy
     delete process.env.NO_PROXY
+    delete process.env.no_proxy
     process.env.HTTP_PROXY = `http://127.0.0.1`
-    let fn = async () => {
-      await download(`http://127.0.0.1:${port}/json`, { dest: tempdir })
+    try {
+      await assert.rejects(() => download(`http://127.0.0.1:${port}/json`, { dest: tempdir }), /using proxy/)
+    } finally {
+      delete process.env.HTTP_PROXY
+      if (noProxy == null) delete process.env.no_proxy
+      else process.env.no_proxy = noProxy
+      process.env.NO_PROXY = '*'
     }
-    await assert.rejects(fn(), /using proxy/)
-    delete process.env.HTTP_PROXY
-    process.env.NO_PROXY = '*'
-    fn = async () => {
+    let fn = async () => {
       let agent = new http.Agent({ keepAlive: true })
       let p = download(`http://127.0.0.1:${port}/slow`, { dest: tempdir, timeout: 50, agent })
       await p

--- a/src/__tests__/modules/fetch.test.ts
+++ b/src/__tests__/modules/fetch.test.ts
@@ -644,6 +644,15 @@ describe('download', () => {
     assert.notStrictEqual(res, undefined)
   })
 
+  it('should reject tgz extraction limits without an uncaught exception', async () => {
+    await assert.rejects(download(`http://127.0.0.1:${port}/tgz`, {
+      dest: tempdir,
+      extract: 'untar',
+      strip: 0,
+      maxExtractSize: 1
+    }), /exceeds extraction limits/)
+  })
+
   it('should cancel download by CancellationToken', async t => {
     let fn = async () => {
       let tokenSource = new CancellationTokenSource()

--- a/src/__tests__/modules/fetch.test.ts
+++ b/src/__tests__/modules/fetch.test.ts
@@ -605,6 +605,17 @@ describe('download', () => {
     assert.strictEqual(exists, true)
   })
 
+  it('should extract zip to a normalized destination', async () => {
+    let normalized = path.join(tempdir, 'normalized')
+    let dest = path.join(normalized, '..', 'normalized') + path.sep
+    let result = await download(`http://127.0.0.1:${port}/zip`, {
+      dest,
+      extract: true
+    })
+    assert.strictEqual(result, normalized)
+    assert.strictEqual(fs.existsSync(path.join(normalized, 'log.txt')), true)
+  })
+
   it('should not extract zip file outside dest', async t => {
     let dest = path.join(tempdir, 'evil')
     let url = `http://127.0.0.1:${port}/evil_zip`

--- a/src/__tests__/unit/extensionInstaller.test.ts
+++ b/src/__tests__/unit/extensionInstaller.test.ts
@@ -158,6 +158,8 @@ describe('Installer', () => {
         await installer.getInfoFromUri()
       }
       await assert.rejects(fn(), /not supported/)
+      let deceptive = new Installer(import.meta.dirname, 'npm', 'https://github.com.example.com/owner/repo')
+      await assert.rejects(() => deceptive.getInfoFromUri(), /not supported/)
     })
 
     it('should get info from url #1', async t => {
@@ -181,6 +183,13 @@ describe('Installer', () => {
   })
 
   describe('update()', () => {
+    it('should reject extension names outside the extension root', async () => {
+      let installer = new Installer(os.tmpdir(), 'npm', 'foo')
+      await assert.rejects(() => installer.doInstall({ name: '../outside' }), /Invalid extension name/)
+      await assert.rejects(() => installer.doInstall({ name: '..\\outside' }), /Invalid extension name/)
+      await assert.rejects(() => installer.doInstall({ name: '/outside' }), /Invalid extension name/)
+    })
+
     it('should skip install & update for symbolic folder', async t => {
       tmpfolder = path.join(os.tmpdir(), 'foo')
       fs.rmSync(tmpfolder, { recursive: true, force: true })

--- a/src/extension/installer.ts
+++ b/src/extension/installer.ts
@@ -10,6 +10,22 @@ import workspace from '../workspace'
 const logger = createLogger('extension-installer')
 const local_dependencies = ['coc.nvim', 'esbuild', 'webpack', '@types/node']
 
+function extensionPath(root: string, name: string | undefined): string {
+  // npm package names contain either one path component, or two for a scoped
+  // package.  Reject path syntax before using registry-controlled metadata in
+  // destructive filesystem operations.
+  if (typeof name !== 'string' || !/^(?:@[^/\\]+\/)?[^/\\]+$/.test(name) || name.includes('\0') || name.split('/').some(part => part === '.' || part === '..')) {
+    throw new Error(`Invalid extension name: ${name}`)
+  }
+  let resolvedRoot = path.resolve(root)
+  let target = path.resolve(resolvedRoot, name)
+  let relative = path.relative(resolvedRoot, target)
+  if (!relative || relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(`Invalid extension name: ${name}`)
+  }
+  return target
+}
+
 export interface Info {
   'dist.tarball'?: string
   'engines.coc'?: string
@@ -119,6 +135,7 @@ export class Installer extends EventEmitter implements IInstaller {
     if (!obj) throw new Error(`${this.def} doesn't exists in ${registry}.`)
     let requiredVersion = obj['engines'] && obj['engines']['coc']
     if (!requiredVersion) throw new Error(`${this.def} is not a valid coc extension, "engines" field with coc property required.`)
+    extensionPath(this.root, res.name)
     return {
       'dist.tarball': obj['dist']['tarball'],
       'engines.coc': requiredVersion,
@@ -129,7 +146,13 @@ export class Installer extends EventEmitter implements IInstaller {
 
   public async getInfoFromUri(): Promise<Info> {
     let { url } = this
-    if (!url.startsWith('https://github.com')) {
+    let repository: URL
+    try {
+      repository = new URL(url)
+    } catch (_e) {
+      throw new Error(`"${url}" is not supported, coc.nvim support github.com only`)
+    }
+    if (repository.protocol !== 'https:' || repository.hostname !== 'github.com') {
       throw new Error(`"${url}" is not supported, coc.nvim support github.com only`)
     }
     url = url.replace(/\/$/, '')
@@ -144,6 +167,7 @@ export class Installer extends EventEmitter implements IInstaller {
     this.log(`Get info from ${fileUrl}`)
     let content = await this.fetch(fileUrl, { timeout: 10000 })
     let obj = typeof content == 'string' ? JSON.parse(content) : content
+    extensionPath(this.root, obj.name)
     this.name = obj.name
     return {
       'dist.tarball': `${url}/archive/${branch}.tar.gz`,
@@ -167,14 +191,14 @@ export class Installer extends EventEmitter implements IInstaller {
       throw new Error(`${name} ${info.version} requires coc.nvim >= ${required}, please update coc.nvim.`)
     }
     let updated = await this.doInstall(info, new Set())
-    return { name, updated, version, url: this.url, folder: path.join(this.root, info.name) }
+    return { name, updated, version, url: this.url, folder: extensionPath(this.root, info.name) }
   }
 
   public async update(url?: string): Promise<string | undefined> {
     if (url) this.url = url
     let version: string | undefined
     if (this.name) {
-      let folder = path.join(this.root, this.name)
+      let folder = extensionPath(this.root, this.name)
       if (isSymbolicLink(folder)) {
         this.log(`Skipped update for symbol link`)
         return
@@ -262,7 +286,7 @@ export class Installer extends EventEmitter implements IInstaller {
   }
 
   public async doInstall(info: Info, installing: Set<string> = new Set()): Promise<boolean> {
-    let dest = path.join(this.root, info.name)
+    let dest = extensionPath(this.root, info.name)
     if (isSymbolicLink(dest)) return false
     if (installing.has(info.name)) {
       this.log(`Skipping dependency: ${info.name} (already installed or in progress)`)
@@ -270,8 +294,7 @@ export class Installer extends EventEmitter implements IInstaller {
     }
     installing.add(info.name)
 
-    let key = info.name.replace(/\//g, '_')
-    let downloadFolder = path.join(this.root, `${key}-${crypto.randomUUID()}`)
+    let downloadFolder = path.join(path.resolve(this.root), `.coc-download-${crypto.randomUUID()}`)
     let url = info['dist.tarball']
     this.log(`Downloading from ${url}`)
     let etagAlgorithm = url.startsWith('https://registry.npmjs.org') ? 'md5' : undefined

--- a/src/mcp/tools/workspace.ts
+++ b/src/mcp/tools/workspace.ts
@@ -103,7 +103,20 @@ export function escapeRegExp(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
+function unsafeFallbackRegex(pattern: string): boolean {
+  // JavaScript RegExp has no execution timeout. Keep the no-ripgrep fallback
+  // to expressions without the constructs most commonly responsible for
+  // catastrophic backtracking; ripgrep remains the unrestricted regex path.
+  return pattern.length > 1000
+    || /\\[1-9]/.test(pattern)
+    || /\(\?[=!<]/.test(pattern)
+    || /\([^)]*[+*{][^)]*\)\s*(?:[+*?]|\{)/.test(pattern)
+}
+
 export async function searchWithJs(pattern: string, args: any, root: string, maxResults: number): Promise<SearchMatch[]> {
+  if (args.regex === true && unsafeFallbackRegex(pattern)) {
+    throw new Error('Regex is too complex for the JavaScript search fallback; install ripgrep to use it safely')
+  }
   let include = new RelativePatternImpl(URI.file(root), typeof args.include === 'string' && args.include ? args.include : '**/*')
   let uris = await workspace.findFiles(include, args.exclude || null, 500)
   // One (first) match per line, searched from the start of every line: the

--- a/src/model/download.ts
+++ b/src/model/download.ts
@@ -9,6 +9,9 @@ import { crypto, fs, path } from '../util/node'
 import { CancellationToken } from '../util/protocol'
 import { FetchOptions, getRequestModule, resolveRequestOptions, timeout, toURL } from './fetch'
 const logger = createLogger('model-download')
+const DEFAULT_MAX_DOWNLOAD_SIZE = 512 * 1024 * 1024
+const DEFAULT_MAX_EXTRACT_SIZE = 1024 * 1024 * 1024
+const DEFAULT_MAX_ARCHIVE_ENTRIES = 100000
 
 export interface DownloadOptions extends Omit<FetchOptions, 'buffer'> {
   /**
@@ -29,6 +32,12 @@ export interface DownloadOptions extends Omit<FetchOptions, 'buffer'> {
   extract?: boolean | 'untar' | 'unzip'
   onProgress?: (percent: string) => void
   agent?: http.Agent
+  /** Maximum number of compressed bytes accepted from the network. */
+  maxDownloadSize?: number
+  /** Maximum total uncompressed ZIP size. */
+  maxExtractSize?: number
+  /** Maximum number of ZIP entries. */
+  maxArchiveEntries?: number
 }
 
 export function getEtag(headers: IncomingHttpHeaders): string | undefined {
@@ -80,10 +89,12 @@ function openZipEntry(zipfile: ZipFile, entry: Entry): Promise<NodeJS.ReadableSt
   })
 }
 
-async function unzipFile(filepath: string, dest: string): Promise<void> {
+async function unzipFile(filepath: string, dest: string, maxExtractSize: number, maxArchiveEntries: number): Promise<void> {
   let zipfile = await openZip(filepath)
   return await new Promise<void>((resolve, reject) => {
     let settled = false
+    let entries = 0
+    let extractedSize = 0
     const fail = (error: Error): void => {
       if (settled) return
       settled = true
@@ -97,6 +108,12 @@ async function unzipFile(filepath: string, dest: string): Promise<void> {
       resolve()
     })
     zipfile.on('entry', (entry: Entry) => {
+      entries++
+      extractedSize += entry.uncompressedSize
+      if (entries > maxArchiveEntries || extractedSize > maxExtractSize) {
+        fail(new Error('Zip archive exceeds extraction limits'))
+        return
+      }
       let entryPath = getFileNameLowLevel(entry.generalPurposeBitFlag, entry.fileNameRaw, entry.extraFields, false)
       // Preserve unzip-stream's behavior: neutralize parent segments instead
       // of allowing them to escape dest or rejecting the whole archive.
@@ -107,10 +124,12 @@ async function unzipFile(filepath: string, dest: string): Promise<void> {
       }
       let target = path.join(dest, entryPath)
       let isDirectory = entryPath.endsWith('/')
-      void fs.promises.mkdir(isDirectory ? target : path.dirname(target), { recursive: true }).then(async () => {
+      let parent = isDirectory ? target : path.dirname(target)
+      void ensureNoSymlink(dest, parent).then(() => fs.promises.mkdir(parent, { recursive: true })).then(async () => {
+        await ensureNoSymlink(dest, parent)
         if (!isDirectory) {
           let input = await openZipEntry(zipfile, entry)
-          await pipeline(input, fs.createWriteStream(target))
+          await writeZipEntry(input, target)
         }
         zipfile.readEntry()
       }, fail).catch(fail)
@@ -119,12 +138,38 @@ async function unzipFile(filepath: string, dest: string): Promise<void> {
   })
 }
 
+async function ensureNoSymlink(dest: string, target: string): Promise<void> {
+  let relative = path.relative(dest, target)
+  let current = dest
+  for (let part of relative.split(path.sep).filter(Boolean)) {
+    current = path.join(current, part)
+    try {
+      let stat = await fs.promises.lstat(current)
+      if (stat.isSymbolicLink()) throw new Error(`Refusing to extract through symbolic link: ${current}`)
+      if (!stat.isDirectory()) throw new Error(`Invalid extraction directory: ${current}`)
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e
+    }
+  }
+}
+
+async function writeZipEntry(input: NodeJS.ReadableStream, target: string): Promise<void> {
+  let flags = fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC
+  if (typeof fs.constants.O_NOFOLLOW === 'number') flags |= fs.constants.O_NOFOLLOW
+  let handle = await fs.promises.open(target, flags, 0o666)
+  try {
+    await pipeline(input, handle.createWriteStream())
+  } finally {
+    await handle.close().catch(() => undefined)
+  }
+}
+
 /**
  * Save a zip response to a temporary file and extract entries to dest.
  * yauzl uses random access, so archive data stays off the JS heap while each
  * entry is still decompressed through a stream.
  */
-function extractZip(res: IncomingMessage, dest: string): EventEmitter {
+function extractZip(res: IncomingMessage, dest: string, options: DownloadOptions): EventEmitter {
   let emitter = new EventEmitter()
   let archive = path.join(dest, `.coc-download-${crypto.randomUUID()}.zip`)
   let output = fs.createWriteStream(archive)
@@ -141,7 +186,12 @@ function extractZip(res: IncomingMessage, dest: string): EventEmitter {
   }
   output.on('error', finish)
   output.on('finish', () => {
-    void unzipFile(archive, dest).then(() => finish(), finish)
+    void unzipFile(
+      archive,
+      dest,
+      options.maxExtractSize ?? DEFAULT_MAX_EXTRACT_SIZE,
+      options.maxArchiveEntries ?? DEFAULT_MAX_ARCHIVE_ENTRIES
+    ).then(() => finish(), finish)
   })
   res.on('error', error => {
     output.destroy(error)
@@ -159,6 +209,13 @@ export default function download(urlInput: string | URL, options: DownloadOption
   let url = toURL(urlInput)
   let { etagAlgorithm } = options
   let { dest, onProgress, extract } = options
+  for (let [name, value] of Object.entries({
+    maxDownloadSize: options.maxDownloadSize,
+    maxExtractSize: options.maxExtractSize,
+    maxArchiveEntries: options.maxArchiveEntries
+  })) {
+    if (value !== undefined && (!Number.isFinite(value) || value <= 0)) throw new Error(`${name} must be a positive finite number`)
+  }
   if (!dest || !path.isAbsolute(dest)) {
     throw new Error(`Invalid dest path: ${dest}`)
   }
@@ -175,13 +232,26 @@ export default function download(urlInput: string | URL, options: DownloadOption
   if (!opts.agent && options.agent) opts.agent = options.agent
   let extname = path.extname(url.pathname)
   return new Promise<string>((resolve, reject) => {
-    if (token) {
-      let disposable = token.onCancellationRequested(() => {
-        disposable.dispose()
-        req.destroy(new Error('request aborted'))
-      })
-    }
     let timer: NodeJS.Timeout
+    let settled = false
+    let cancellation: { dispose(): void } | undefined
+    const cleanup = (): void => {
+      cancellation?.dispose()
+      cancellation = undefined
+      if (timer) clearTimeout(timer)
+    }
+    const succeed = (value: string): void => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resolve(value)
+    }
+    const fail = (error: Error): void => {
+      if (settled) return
+      settled = true
+      cleanup()
+      reject(error)
+    }
     const req = mod.request(opts, (res: IncomingMessage) => {
       if ((res.statusCode >= 200 && res.statusCode < 300) || res.statusCode === 1223) {
         let headers = res.headers
@@ -197,7 +267,7 @@ export default function download(urlInput: string | URL, options: DownloadOption
           } else if (extname == '.tgz') {
             extract = 'untar'
           } else {
-            reject(new Error(`Unable to detect extract method for ${url}`))
+            fail(new Error(`Unable to detect extract method for ${url}`))
             return
           }
         }
@@ -205,11 +275,15 @@ export default function download(urlInput: string | URL, options: DownloadOption
         let hasTotal = !isNaN(total)
         let cur = 0
         res.on('error', err => {
-          reject(new Error(`Unable to connect ${url}: ${err.message}`))
+          fail(new Error(`Unable to connect ${url}: ${err.message}`))
         })
         let hash = checkEtag ? crypto.createHash(etagAlgorithm) : undefined
         res.on('data', chunk => {
           cur += chunk.length
+          if (cur > (options.maxDownloadSize ?? DEFAULT_MAX_DOWNLOAD_SIZE)) {
+            res.destroy(new Error(`Download exceeds maximum size of ${options.maxDownloadSize ?? DEFAULT_MAX_DOWNLOAD_SIZE} bytes`))
+            return
+          }
           if (hash) hash.update(chunk)
           if (hasTotal) {
             let percent = (cur / total * 100).toFixed(1)
@@ -228,9 +302,27 @@ export default function download(urlInput: string | URL, options: DownloadOption
         let stream: any
         if (extract === 'untar') {
           const tar = require('tar')
-          stream = res.pipe(tar.x({ strip: options.strip ?? 1, C: dest }))
+          let entries = 0
+          let extractedSize = 0
+          stream = res.pipe(tar.x({
+            strip: options.strip ?? 1,
+            C: dest,
+            preservePaths: false,
+            filter: (_entryPath: string, entry: { size?: number, type?: string }) => {
+              entries++
+              extractedSize += entry.size ?? 0
+              if (entry.type === 'SymbolicLink' || entry.type === 'Link') {
+                throw new Error('Tar archive links are not supported')
+              }
+              if (entries > (options.maxArchiveEntries ?? DEFAULT_MAX_ARCHIVE_ENTRIES)
+                || extractedSize > (options.maxExtractSize ?? DEFAULT_MAX_EXTRACT_SIZE)) {
+                throw new Error('Tar archive exceeds extraction limits')
+              }
+              return true
+            }
+          }))
         } else if (extract === 'unzip') {
-          stream = extractZip(res, dest)
+          stream = extractZip(res, dest, options)
         } else {
           dest = path.join(dest, `${crypto.randomUUID()}${extname}`)
           stream = res.pipe(fs.createWriteStream(dest))
@@ -238,18 +330,19 @@ export default function download(urlInput: string | URL, options: DownloadOption
         stream.on('finish', () => {
           if (hash) {
             if (hash.digest('hex') !== etag) {
-              reject(new Error(`Etag check failed by ${etagAlgorithm}, content not match.`))
+              fail(new Error(`Etag check failed by ${etagAlgorithm}, content not match.`))
               return
             }
           }
           logger.info(`Downloaded ${url} => ${dest}`)
           setTimeout(() => {
-            resolve(dest)
+            succeed(dest)
           }, 100)
         })
-        stream.on('error', reject)
+        stream.on('error', fail)
       } else {
-        reject(new Error(`Invalid response from ${url}: ${res.statusCode}`))
+        res.resume()
+        fail(new Error(`Invalid response from ${url}: ${res.statusCode}`))
       }
     })
     obj.req = req
@@ -257,16 +350,19 @@ export default function download(urlInput: string | URL, options: DownloadOption
       // Possible succeed proxy request with ECONNRESET error on node > 14
       if (e['code'] == 'ECONNRESET') {
         timer = setTimeout(() => {
-          reject(e)
+          fail(e)
         }, timeout)
       } else {
         clearTimeout(timer)
         if (opts.agent && opts.agent.proxy) {
-          reject(new Error(`Request failed using proxy ${opts.agent.proxy.host}: ${e.message}`))
+          fail(new Error(`Request failed using proxy ${opts.agent.proxy.host}: ${e.message}`))
           return
         }
-        reject(e)
+        fail(e)
       }
+    })
+    cancellation = token?.onCancellationRequested(() => {
+      req.destroy(new Error('request aborted'))
     })
     req.on('timeout', () => {
       req.destroy(new Error(`request timeout after ${options.timeout}ms`))

--- a/src/model/download.ts
+++ b/src/model/download.ts
@@ -66,8 +66,8 @@ function isSafeEntryPath(dest: string, entryPath: string): boolean {
   // path.join treats absolute entry paths as relative, keeping the
   // extracted files inside dest.
   let destPath = path.join(dest, entryPath)
-  if (destPath === dest) return false
-  return destPath.startsWith(dest + path.sep)
+  let relative = path.relative(dest, destPath)
+  return relative !== '' && relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative)
 }
 
 function openZip(filepath: string): Promise<ZipFile> {
@@ -220,6 +220,9 @@ export default function download(urlInput: string | URL, options: DownloadOption
   if (!dest || !path.isAbsolute(dest)) {
     throw new Error(`Invalid dest path: ${dest}`)
   }
+  // Use one canonical lexical representation for filesystem operations and
+  // archive-boundary checks. path.resolve also removes a trailing separator.
+  dest = path.resolve(dest)
   if (!fs.existsSync(dest)) {
     fs.mkdirSync(dest, { recursive: true })
   } else {

--- a/src/model/download.ts
+++ b/src/model/download.ts
@@ -14,7 +14,7 @@ const DEFAULT_MAX_DOWNLOAD_SIZE = 512 * 1024 * 1024
 const DEFAULT_MAX_EXTRACT_SIZE = 1024 * 1024 * 1024
 const DEFAULT_MAX_ARCHIVE_ENTRIES = 100000
 
-export interface DownloadOptions extends Omit<FetchOptions, 'buffer'> {
+export interface DownloadOptions extends Omit<FetchOptions, 'buffer' | 'maxResponseSize'> {
   /**
    * Folder that contains downloaded file or extracted files by untar or unzip
    */

--- a/src/model/download.ts
+++ b/src/model/download.ts
@@ -2,6 +2,7 @@
 import { EventEmitter } from 'events'
 import http, { IncomingHttpHeaders, IncomingMessage } from 'http'
 import { pipeline } from 'stream/promises'
+import type { Writable } from 'stream'
 import { getFileNameLowLevel, open } from 'yauzl'
 import type { Entry, ZipFile } from 'yauzl'
 import { createLogger } from '../logger'
@@ -300,11 +301,38 @@ export default function download(urlInput: string | URL, options: DownloadOption
           logger.info('Download completed:', url)
         })
         let stream: any
+        const attachStreamHandlers = (): void => {
+          stream.on('finish', () => {
+            if (hash) {
+              if (hash.digest('hex') !== etag) {
+                fail(new Error(`Etag check failed by ${etagAlgorithm}, content not match.`))
+                return
+              }
+            }
+            logger.info(`Downloaded ${url} => ${dest}`)
+            setTimeout(() => {
+              succeed(dest)
+            }, 100)
+          })
+          stream.on('error', fail)
+        }
         if (extract === 'untar') {
           const tar = require('tar')
           let entries = 0
           let extractedSize = 0
-          stream = res.pipe(tar.x({
+          let rejected = false
+          let extraction: Writable & { abort(error: Error): void }
+          const rejectEntry = (error: Error): false => {
+            if (!rejected) {
+              rejected = true
+              // tar's parser abort path destroys its underlying streams and
+              // emits `error`; unlike throwing from filter, it is caught by
+              // the handler installed below.
+              extraction.abort(error)
+            }
+            return false
+          }
+          extraction = tar.x({
             strip: options.strip ?? 1,
             C: dest,
             preservePaths: false,
@@ -312,34 +340,28 @@ export default function download(urlInput: string | URL, options: DownloadOption
               entries++
               extractedSize += entry.size ?? 0
               if (entry.type === 'SymbolicLink' || entry.type === 'Link') {
-                throw new Error('Tar archive links are not supported')
+                return rejectEntry(new Error('Tar archive links are not supported'))
               }
               if (entries > (options.maxArchiveEntries ?? DEFAULT_MAX_ARCHIVE_ENTRIES)
                 || extractedSize > (options.maxExtractSize ?? DEFAULT_MAX_EXTRACT_SIZE)) {
-                throw new Error('Tar archive exceeds extraction limits')
+                return rejectEntry(new Error('Tar archive exceeds extraction limits'))
               }
               return true
             }
-          }))
+          })
+          stream = extraction
+          // Attach the rejection handler before piping. The tar parser invokes
+          // filter synchronously while consuming a response data event.
+          attachStreamHandlers()
+          res.pipe(stream)
+          return
         } else if (extract === 'unzip') {
           stream = extractZip(res, dest, options)
         } else {
           dest = path.join(dest, `${crypto.randomUUID()}${extname}`)
           stream = res.pipe(fs.createWriteStream(dest))
         }
-        stream.on('finish', () => {
-          if (hash) {
-            if (hash.digest('hex') !== etag) {
-              fail(new Error(`Etag check failed by ${etagAlgorithm}, content not match.`))
-              return
-            }
-          }
-          logger.info(`Downloaded ${url} => ${dest}`)
-          setTimeout(() => {
-            succeed(dest)
-          }, 100)
-        })
-        stream.on('error', fail)
+        attachStreamHandlers()
       } else {
         res.resume()
         fail(new Error(`Invalid response from ${url}: ${res.statusCode}`))

--- a/src/model/fetch.ts
+++ b/src/model/fetch.ts
@@ -15,6 +15,7 @@ import workspace from '../workspace'
 import { Agent } from 'node:http'
 const logger = createLogger('model-fetch')
 export const timeout = getConditionValue(500, 50)
+const DEFAULT_MAX_RESPONSE_SIZE = 128 * 1024 * 1024
 
 export type ResponseResult = string | Buffer | { [name: string]: any }
 
@@ -57,6 +58,8 @@ export interface FetchOptions {
    * Password for http basic auth, should use with user
    */
   password?: string
+  /** Maximum decompressed response size in bytes. Defaults to 128 MiB. */
+  maxResponseSize?: number
 }
 
 export function getRequestModule(url: URL): typeof http | typeof https {
@@ -185,6 +188,9 @@ export function resolveRequestOptions(url: URL, options: FetchOptions): any {
   if (url.username) opts.auth = url.username + ':' + (toText(url.password))
   if (options.timeout) opts.timeout = options.timeout
   if (options.buffer) opts.buffer = true
+  let maxResponseSize = options.maxResponseSize ?? DEFAULT_MAX_RESPONSE_SIZE
+  if (!Number.isFinite(maxResponseSize) || maxResponseSize <= 0) throw new Error('maxResponseSize must be a positive finite number')
+  opts.maxResponseSize = maxResponseSize
   return opts
 }
 
@@ -209,25 +215,45 @@ function parseCharset(contentType: string): BufferEncoding {
 export function request(url: URL, data: any, opts: any, token?: CancellationToken, obj: any = {}): Promise<ResponseResult> {
   let mod = getRequestModule(url)
   return new Promise<ResponseResult>((resolve, reject) => {
-    if (token) {
-      let disposable = token.onCancellationRequested(() => {
-        disposable.dispose()
-        req.destroy(new CancellationError())
-      })
-    }
     let timer: NodeJS.Timeout
-    const req = mod.request(opts, res => {
+    let settled = false
+    let req: any
+    let cancellation: { dispose(): void } | undefined
+    const cleanup = (): void => {
+      cancellation?.dispose()
+      cancellation = undefined
+      if (timer) clearTimeout(timer)
+    }
+    const succeed = (value: ResponseResult): void => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resolve(value)
+    }
+    const fail = (error: Error): void => {
+      if (settled) return
+      settled = true
+      cleanup()
+      reject(error)
+    }
+    req = mod.request(opts, res => {
       let readable: Readable = res
       if ((res.statusCode >= 200 && res.statusCode < 300) || res.statusCode === 1223) {
         let headers = res.headers
         let chunks: Buffer[] = []
+        let size = 0
         let contentType: string = toText(headers['content-type'])
         readable = decompressResponse(res)
         readable.on('data', chunk => {
+          size += chunk.length
+          let maxResponseSize = opts.maxResponseSize ?? DEFAULT_MAX_RESPONSE_SIZE
+          if (size > maxResponseSize) {
+            readable.destroy(new Error(`Response exceeds maximum size of ${maxResponseSize} bytes`))
+            return
+          }
           chunks.push(chunk)
         })
         readable.on('end', () => {
-          clearTimeout(timer)
           let buf = Buffer.concat(chunks)
           if (!opts.buffer && (contentType.startsWith('application/json') || contentType.startsWith('text/'))) {
             // The decode must not escape the event callback: unsupported or
@@ -236,38 +262,42 @@ export function request(url: URL, data: any, opts: any, token?: CancellationToke
               let encoding = parseCharset(contentType)
               let rawData = buf.toString(encoding)
               if (!contentType.includes('application/json')) {
-                resolve(rawData)
+                succeed(rawData)
               } else {
                 try {
                   const parsedData = JSON.parse(rawData)
-                  resolve(parsedData)
+                  succeed(parsedData)
                 } catch (e) {
-                  reject(new Error(`Parse response error: ${e}`))
+                  fail(new Error(`Parse response error: ${e}`))
                 }
               }
             } catch (e) {
-              reject(new Error(`Decode response error: ${e instanceof Error ? e.message : String(e)}`))
+              fail(new Error(`Decode response error: ${e instanceof Error ? e.message : String(e)}`))
             }
           } else {
-            resolve(buf)
+            succeed(buf)
           }
         })
         readable.on('error', err => {
-          reject(new Error(`Connection error to ${url}: ${err.message}`))
+          fail(new Error(`Connection error to ${url}: ${err.message}`))
         })
       } else {
-        reject(new Error(`Bad response from ${url}: ${res.statusCode}`))
+        res.resume()
+        fail(new Error(`Bad response from ${url}: ${res.statusCode}`))
       }
+    })
+    cancellation = token?.onCancellationRequested(() => {
+      req.destroy(new CancellationError())
     })
     obj.req = req
     req.on('error', e => {
       // Possible succeed proxy request with ECONNRESET error on node > 14
       if (e['code'] == 'ECONNRESET') {
         timer = setTimeout(() => {
-          reject(e)
+          fail(e)
         }, timeout)
       } else {
-        reject(e)
+        fail(e)
       }
     })
     req.on('timeout', () => {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -7763,6 +7763,10 @@ declare module 'coc.nvim' {
      * Password for http basic auth, should use with user
      */
     password?: string
+    /**
+     * Maximum decompressed response size in bytes. Defaults to 128 MiB.
+     */
+    maxResponseSize?: number
   }
 
   export interface DownloadOptions extends Omit<FetchOptions, 'buffer'> {
@@ -7786,6 +7790,18 @@ declare module 'coc.nvim' {
      * Callback invoked with the download progress percent.
      */
     onProgress?: (percent: string) => void
+    /**
+     * Maximum number of compressed bytes accepted from the network. Defaults to 512 MiB.
+     */
+    maxDownloadSize?: number
+    /**
+     * Maximum total uncompressed archive size. Defaults to 1 GiB.
+     */
+    maxExtractSize?: number
+    /**
+     * Maximum number of archive entries. Defaults to 100000.
+     */
+    maxArchiveEntries?: number
   }
 
   export type ResponseResult = string | Buffer | {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -7769,7 +7769,7 @@ declare module 'coc.nvim' {
     maxResponseSize?: number
   }
 
-  export interface DownloadOptions extends Omit<FetchOptions, 'buffer'> {
+  export interface DownloadOptions extends Omit<FetchOptions, 'buffer' | 'maxResponseSize'> {
     /**
      * Folder that contains downloaded file or extracted files by untar or unzip
      */


### PR DESCRIPTION
### Motivation
- Prevent resource exhaustion and zip/tar extraction attacks by bounding network and archive sizes and rejecting dangerous inputs.
- Protect the filesystem from path traversal and symlink-based escapes during extension install and archive extraction.
- Avoid catastrophic-regex hangs in the JavaScript fallback search and provide clearer error messages for unsupported inputs.

### Description
- Added strict extension name validation via `extensionPath(root, name)` to prevent installs outside the extension root and used it across `installer.ts` (`getInfo`, `getInfoFromUri`, `install`, `update`, `doInstall`).
- Hardened download and extraction in `src/model/download.ts` by introducing `maxDownloadSize`, `maxExtractSize`, and `maxArchiveEntries` options with defaults, enforcing them during network read, tar filtering and zip extraction, and rejecting archive links or excessive entries/size; added `ensureNoSymlink` and `writeZipEntry` to avoid extracting through symlinks and to use `O_NOFOLLOW` when available.
- Improved `fetch` in `src/model/fetch.ts` to support `maxResponseSize` with enforced decompressed-size checking and more robust cancellation/cleanup logic.
- Added a safety check `unsafeFallbackRegex` in `src/mcp/tools/workspace.ts` to reject overly-complex regexes for the JS search fallback and return an instructive error.
- Various robustness fixes: unified settle/cleanup helpers for async request flows, safer temp download folder naming, stricter URL parsing for GitHub URIs and clearer errors for unsupported/deceptive URLs.
- Updated/added tests to cover complex-regex rejection, oversized fetch/download rejection, and invalid extension name rejections in `src/__tests__/*`.

### Testing
- Ran the repository test suite via `npm test` which includes unit and integration tests, focusing on fetch/download, installer, and workspace search tests; all tests including the newly added cases passed.
- Executed targeted tests for `fetch`/`download` oversized response handling and `extensionInstaller` path validation; assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8a43c865488325a81d09a22e18f6d5)