### PR TITLE
feat(textdocument): upstream vscode textdocument

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
         "tslib": "^2.8.1",
         "unidecode": "^1.1.0",
         "vscode-languageserver-protocol": "^3.18.2",
-        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-textdocument": "^1.0.14",
         "vscode-languageserver-types": "^3.18.0",
-        "vscode-uri": "^3.1.0",
+        "vscode-uri": "^3.2.0",
         "which": "^7.0.0",
         "yauzl": "^3.4.0"
       },
@@ -1618,9 +1618,9 @@
       }
     },
     "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.14.tgz",
+      "integrity": "sha512-EQyqJMi552E4ZTf46izQ4Fj6XquqxCySR3J5ZSD1SisMf6RfpeOWHxGBE8Gr6V0/3GHIGdAzDn8F8+1nTGCnoQ==",
       "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
@@ -1630,9 +1630,9 @@
       "license": "MIT"
     },
     "node_modules/vscode-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
-      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.2.0.tgz",
+      "integrity": "sha512-m2gXo3bn0G1kT9InzMf07fTbqMbGtyckj3bH5ktLO+1Ssv+yiATZ4dhwaQv9UZWxJh6E9IFGnQyjgWVDWVBDrg==",
       "license": "MIT"
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -72,9 +72,9 @@
     "tslib": "^2.8.1",
     "unidecode": "^1.1.0",
     "vscode-languageserver-protocol": "^3.18.2",
-    "vscode-languageserver-textdocument": "^1.0.12",
+    "vscode-languageserver-textdocument": "^1.0.14",
     "vscode-languageserver-types": "^3.18.0",
-    "vscode-uri": "^3.1.0",
+    "vscode-uri": "^3.2.0",
     "which": "^7.0.0",
     "yauzl": "^3.4.0"
   },

--- a/src/__tests__/modules/document.test.ts
+++ b/src/__tests__/modules/document.test.ts
@@ -116,6 +116,34 @@ describe('LinesTextDocument', () => {
     assert.strictEqual(doc.offsetAt({ line: -1, character: -1 }), 0)
   })
 
+  it('should get line ranges and EOL characters', t => {
+    let cases: Array<[string[], boolean, number[], string[]]> = [
+      [['Hello World'], false, [11], ['']],
+      [[''], false, [0], ['']],
+      [['ABCDE', 'FGHIJ', 'KLMNO'], false, [5, 5, 5], ['\n', '\n', '']],
+      [['ABCDE', 'FGHIJ'], true, [5, 5, 0], ['\n', '\n', '']],
+      [['ABCDE', '', 'FGHIJ'], false, [5, 0, 5], ['\n', '\n', '']],
+      [['', 'ABCDE'], false, [0, 5], ['\n', '']]
+    ]
+    for (let [lines, eol, lineLengths, eolCharacters] of cases) {
+      let doc = createTextDocument(lines, eol)
+      assert.strictEqual(doc.lineCount, lineLengths.length)
+      let reconstructed = ''
+      for (let line = 0; line < doc.lineCount; line++) {
+        let range = Range.create(line, 0, line, lineLengths[line])
+        assert.deepStrictEqual(doc.getLineRange(line), range)
+        assert.strictEqual(doc.getEOLCharacters(line), eolCharacters[line])
+        reconstructed += doc.getText(range) + doc.getEOLCharacters(line)
+      }
+      assert.strictEqual(reconstructed, lines.join('\n') + (eol ? '\n' : ''))
+      assert.deepStrictEqual(doc.getLineRange(-1), Range.create(0, 0, 0, 0))
+      assert.strictEqual(doc.getEOLCharacters(-1), '')
+      let lastLine = doc.lineCount - 1
+      assert.deepStrictEqual(doc.getLineRange(doc.lineCount + 2), Range.create(lastLine, 0, lastLine, lineLengths[lastLine]))
+      assert.strictEqual(doc.getEOLCharacters(doc.lineCount + 2), '')
+    }
+  })
+
   it('should work when eol enabled', t => {
     let doc = createTextDocument(['foo', 'bar'])
     assert.strictEqual(doc.lineCount, 3)

--- a/src/model/textdocument.ts
+++ b/src/model/textdocument.ts
@@ -144,6 +144,16 @@ export class LinesTextDocument implements TextDocument {
     return Math.max(Math.min(lineOffset + position.character, nextLineOffset), lineOffset)
   }
 
+  public getLineRange(line: number): Range {
+    if (line < 0 || this.lineCount === 0) return Range.create(0, 0, 0, 0)
+    let target = Math.min(line, this.lineCount - 1)
+    return Range.create(target, 0, target, this.lines[target]?.length ?? 0)
+  }
+
+  public getEOLCharacters(line: number): string {
+    return line >= 0 && line < this.lineCount - 1 ? '\n' : ''
+  }
+
   private getLineOffsets(): number[] {
     if (this._lineOffsets === undefined) {
       this._lineOffsets = computeLinesOffsets(this.lines, this.eol)


### PR DESCRIPTION
Update vscode-languageserver-textdocument to 1.0.14 and vscode-uri to 3.2.0. Implement the new line range and EOL methods in LinesTextDocument, with coverage for LF documents and boundary cases.
