### PR TITLE
fix(handler): fix refactor range restoration after undo

### DIFF
--- a/src/__tests__/handler/refactor.test.ts
+++ b/src/__tests__/handler/refactor.test.ts
@@ -87,6 +87,14 @@ describe('fixChangeParams', () => {
     let change = e.contentChanges[0]
     assert.deepStrictEqual(change.range, Range.create(0, 0, 0, 0))
     assert.strictEqual(change.text, '\u3000barx\nfoo\n')
+
+    e = createChangeParams(Range.create(1, 0, 1, 0), 'foo\n\u3000bar\n', '', [
+      '\u3000bar',
+      'baz'
+    ])
+    e = fixChangeParams(e)
+    assert.deepStrictEqual(e.contentChanges[0].range, Range.create(0, 0, 0, 0))
+    assert.strictEqual(e.contentChanges[0].text, '\u3000bar\nfoo\n')
   })
 })
 

--- a/src/handler/refactor/buffer.ts
+++ b/src/handler/refactor/buffer.ts
@@ -647,6 +647,17 @@ export function fixChangeParams(e: DidChangeTextDocumentParams): DidChangeTextDo
         changes[0].range = Range.create(start.line, 0, end.line, 0)
       }
     }
+    if (emptyRange(range) && range.start.character == 0) {
+      let lines = text.split(/\r?\n/)
+      let last = lines[lines.length - 1]
+      let nest = lines.length > 1 ? lines[lines.length - 2] : ''
+      let prev = originalLines[range.start.line - 1]
+      if (last == '' && nest.startsWith(SEPARATOR) && prev == nest) {
+        changes[0].text = prev + '\n' + lines.slice(0, -2).join('\n') + '\n'
+        let { start, end } = range
+        changes[0].range = Range.create(start.line - 1, 0, end.line - 1, 0)
+      }
+    }
   } else {
     let lines = original.split(/\r?\n/)
     let last = lines[lines.length - 1]


### PR DESCRIPTION
https://github.com/neovim/neovim/pull/41520

Neovim nightly now restores the original cursor position during undo. This can cause getTextEdit() to produce an equivalent insertion where a duplicated refactor separator appears at the end of the inserted text.

fixChangeParams() did not normalize this insertion form, so the restored range was detected at its shifted line instead of its original line. The range metadata then remained out of sync with the refactor buffer.

This change:

- Normalizes insertions that end with the same separator as the preceding line.
- Restores the original insertion range before range tracking runs.
- Adds regression coverage for the duplicated-separator case.
