### PR TITLE
fix(extension): escape installer buffer name

### DIFF
--- a/src/__tests__/modules/extensionModules.test.ts
+++ b/src/__tests__/modules/extensionModules.test.ts
@@ -393,6 +393,22 @@ describe('InstallBuffer', () => {
     global.__TEST__ = true
   })
 
+  it('should escape extension buffer name', async t => {
+    let cwd = await nvim.call('getcwd') as string
+    let folder = createFolder()
+    fs.mkdirSync(path.join(folder, 'c'))
+    await nvim.setDirectory(folder)
+    try {
+      let buf = new InstallBuffer({ isUpdate: true, updateUIInTab: false })
+      disposables.push(buf)
+      await buf.start(['coc-json'])
+      assert.strictEqual(await nvim.call('bufname', ['%']), '[Coc Extensions]')
+    } finally {
+      await nvim.command('silent! bwipeout!')
+      await nvim.setDirectory(cwd)
+    }
+  })
+
   it('should draw buffer with stats', async t => {
     let buf = new InstallBuffer({ isUpdate: true, updateUIInTab: true })
     disposables.push(buf)

--- a/src/extension/ui.ts
+++ b/src/extension/ui.ts
@@ -215,13 +215,8 @@ export class InstallBuffer implements InstallUI {
     // `[scratch]`; reusing the named buffer also avoids leaking a new buffer
     // on every show (#5061)
     let name = '[Coc Extensions]'
-    if (isSync) {
-      nvim.command(`edit ${name}`, true)
-    } else if (this.settings.updateUIInTab) {
-      nvim.command(`tabnew ${name}`, true)
-    } else {
-      nvim.command(`vs ${name}`, true)
-    }
+    let command = isSync ? 'edit' : this.settings.updateUIInTab ? 'tabnew' : 'vs'
+    nvim.command(`execute '${command} '.fnameescape('${name}')`, true)
     nvim.call('bufnr', ['%'], true)
     nvim.command('setl buftype=nofile bufhidden=wipe noswapfile nobuflisted wrap undolevels=-1', true)
     if (!isSync) nvim.command('nnoremap <silent><nowait><buffer> q :q<CR>', true)


### PR DESCRIPTION
The extension installer passed [Coc Extensions] directly to edit, tabnew, or vs. Vim and Neovim treated the brackets as a filename pattern, so a one-character directory such as c could match and open instead of the scratch buffer.

Choose the window command separately and escape the buffer name with fnameescape() before executing it. Add a regression test that runs from a directory containing c and verifies that the named extension buffer opens.

Verification: node scripts/test/cli.mjs src/__tests__/modules/extensionModules.test.ts passed. npm run build passed.

Co-authored-by: Codex <noreply@openai.com>
